### PR TITLE
Add C6 imperative irregulars lesson, exercises, and flashcards

### DIFF
--- a/src/seed/c6-imperative-irregulars-pronouns.json
+++ b/src/seed/c6-imperative-irregulars-pronouns.json
@@ -1,0 +1,378 @@
+{
+  "lessons": [
+    {
+      "id": "c6-imperative-irregulars-pronouns",
+      "level": "C1",
+      "title": "C6 — Imperative Irregulars & Pronouns",
+      "slug": "c6-imperative-irregulars-pronouns",
+      "tags": [
+        "imperative",
+        "commands",
+        "pronouns",
+        "irregulars",
+        "c1",
+        "grammar"
+      ],
+      "markdown": "# ⚡ C6 — Imperative Irregulars & Pronouns\\n\\n**Goal:** Command with high-frequency irregulars and place pronouns correctly in affirmative vs. negative orders.\\n\\n---\\n\\n## 🔁 Key Irregular Affirmatives\\n| Verb | tú | usted | vosotros | ustedes | Pattern note |\\n|---|---|---|---|---|---|\\n| **decir** | **di** | diga | decid | digan | Stem change to **di-**\\n| **hacer** | **haz** | haga | haced | hagan | Drop -cer → **haz**\\n| **ir** | **ve** | vaya | id | vayan | tú form reuses **ve** (from *venir*)\\n| **poner** | **pon** | ponga | poned | pongan | -go verbs → **pon-**\\n| **salir** | **sal** | salga | salid | salgan | -go verbs → **sal-**\\n| **ser** | **sé** | sea | sed | sean | Accented tú: **sé**\\n| **tener** | **ten** | tenga | tened | tengan | -go verbs → **ten-**\\n| **venir** | **ven** | venga | venid | vengan | -go verbs → **ven-**\\n\\n> 📌 Only the **tú** form is highly irregular. Ud./Uds./vosotros use the present subjunctive (vosotros = drop *-r* + *-d*).\\n\\n---\\n\\n## 🚫 Negative Imperatives\\n- Formed with **no + present subjunctive** for every person (including tú).\\n- Same irregular stems as the subjunctive (diga, salgas, vayáis…).\\n\\n| Verb | no tú | no usted | no vosotros | no ustedes |\\n|---|---|---|---|---|\\n| decir | no digas | no diga | no digáis | no digan |\\n| hacer | no hagas | no haga | no hagáis | no hagan |\\n| ir | no vayas | no vaya | no vayáis | no vayan |\\n| poner | no pongas | no ponga | no pongáis | no pongan |\\n| salir | no salgas | no salga | no salgáis | no salgan |\\n| ser | no seas | no sea | no seáis | no sean |\\n| tener | no tengas | no tenga | no tengáis | no tengan |\\n| venir | no vengas | no venga | no vengáis | no vengan |\\n\\n> 🧠 Remember **ir**: affirmative nosotros → *vamos*, negative → *no vayamos*; with pronouns → *vámonos* / *no nos vayamos*.\\n\\n---\\n\\n## 📦 Pronoun Placement Rules\\n- **Affirmative commands:** Attach object/reflexive pronouns to the **end** → *dime*, *háganlo*, *siéntense*. Add an accent to keep the original stress when needed (usually 3+ syllables).\\n- **Negative commands:** Pronouns go **before** the verb, after **no** → *no me digas*, *no se lo pongan*.\\n- **Double pronouns:** Order stays **IOP + DOP** (me/te/le/se + lo/la/los/las). Affirmative → *dímelo*; Negative → *no me lo des*.\\n- **Reflexive vosotros:** drop **-d** + **os** → *levantad* → *levantaos* (accent often unnecessary except with 2 pronouns: *daoslo* → *daóselo*).\\n\\n> ✅ Command strategy: Memorize the 8 irregular tú forms, then fall back on the subjunctive for everything else. Pronoun placement flips with negative commands.\\n",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "c6-imp-irreg-ex1",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **decir** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["di", "diga", "decid", "digan"],
+      "feedback": {
+        "correct": "Perfect — irregular tú **di**; others use present subjunctive stems.",
+        "wrong": "Use: tú **di**, usted diga, vosotros decid, ustedes digan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "decir-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex2",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **decir** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no digas", "no diga", "no digáis", "no digan"],
+      "feedback": {
+        "correct": "Yes — negative uses **no + present subjunctive** forms.",
+        "wrong": "Use **no** + subjunctive: no digas, no diga, no digáis, no digan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "decir-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex3",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **hacer** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["haz", "haga", "haced", "hagan"],
+      "feedback": {
+        "correct": "Great — tú **haz**, others from present subjunctive haga…",
+        "wrong": "Use tú haz, usted haga, vosotros haced, ustedes hagan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "hacer-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex4",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **hacer** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no hagas", "no haga", "no hagáis", "no hagan"],
+      "feedback": {
+        "correct": "Exactly — subjunctive stem **hag-** for all negatives.",
+        "wrong": "Use **no hagas**, no haga, no hagáis, no hagan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "hacer-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex5",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **ir** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["ve", "vaya", "id", "vayan"],
+      "feedback": {
+        "correct": "Nice — tú uses **ve**, vosotros keeps **id**.",
+        "wrong": "Use tú ve, usted vaya, vosotros id, ustedes vayan."
+      },
+      "meta": { "difficulty": "C1", "skills": ["write"], "topic": "ir-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex6",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **ir** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no vayas", "no vaya", "no vayáis", "no vayan"],
+      "feedback": {
+        "correct": "Correct — all from the subjunctive of **ir**.",
+        "wrong": "Use: no vayas, no vaya, no vayáis, no vayan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "ir-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex7",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **poner** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["pon", "ponga", "poned", "pongan"],
+      "feedback": {
+        "correct": "Good — tú **pon**; the rest follow subjunctive ponga…",
+        "wrong": "Use tú pon, usted ponga, vosotros poned, ustedes pongan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "poner-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex8",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **poner** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no pongas", "no ponga", "no pongáis", "no pongan"],
+      "feedback": {
+        "correct": "Exactly — **pong-** with negative + subjunctive endings.",
+        "wrong": "Use: no pongas, no ponga, no pongáis, no pongan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "poner-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex9",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **salir** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["sal", "salga", "salid", "salgan"],
+      "feedback": {
+        "correct": "Great — tú **sal**; others salgan…",
+        "wrong": "Use tú sal, usted salga, vosotros salid, ustedes salgan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "salir-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex10",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **salir** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no salgas", "no salga", "no salgáis", "no salgan"],
+      "feedback": {
+        "correct": "Yes — **no salgas** etc. from subjunctive stem salg-.",
+        "wrong": "Use: no salgas, no salga, no salgáis, no salgan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "salir-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex11",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **ser** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["sé", "sea", "sed", "sean"],
+      "feedback": {
+        "correct": "Correct — note the accent on **sé**.",
+        "wrong": "Use tú sé (accent), usted sea, vosotros sed, ustedes sean."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "ser-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex12",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **ser** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no seas", "no sea", "no seáis", "no sean"],
+      "feedback": {
+        "correct": "Exactly — **no seas** etc. from subjunctive sea…",
+        "wrong": "Use: no seas, no sea, no seáis, no sean."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "ser-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex13",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **tener** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["ten", "tenga", "tened", "tengan"],
+      "feedback": {
+        "correct": "Great — tú **ten**, others subjunctive tenga…",
+        "wrong": "Use tú ten, usted tenga, vosotros tened, ustedes tengan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "tener-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex14",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **tener** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no tengas", "no tenga", "no tengáis", "no tengan"],
+      "feedback": {
+        "correct": "Correct — **no tengas** etc. from subjunctive tenga…",
+        "wrong": "Use: no tengas, no tenga, no tengáis, no tengan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "tener-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex15",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **venir** in the **imperativo afirmativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["ven", "venga", "venid", "vengan"],
+      "feedback": {
+        "correct": "Nice — tú **ven**; rest from subjunctive venga…",
+        "wrong": "Use tú ven, usted venga, vosotros venid, ustedes vengan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "venir-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex16",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "conjugate",
+      "promptMd": "Conjugate **venir** in the **imperativo negativo** (tú, usted, vosotros, ustedes).",
+      "answer": ["no vengas", "no venga", "no vengáis", "no vengan"],
+      "feedback": {
+        "correct": "Yes — **no vengas** etc. follow the subjunctive.",
+        "wrong": "Use: no vengas, no venga, no vengáis, no vengan."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "venir-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex17",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "cloze",
+      "promptMd": "Complete with the correct **affirmative command + pronoun**: *\u2014Se\u00f1or, ___ (decir, usted) la verdad.*",
+      "answer": "d\u00edgamela",
+      "accepted": ["re:^d\u00edgamela$"],
+      "feedback": {
+        "correct": "Perfect — attach IO + DO to affirmative: **d\u00edgamela**.",
+        "wrong": "Use affirmative command diga + me + la attached: **d\u00edgamela** (accent preserves stress)."
+      },
+      "meta": { "difficulty": "C1", "skills": ["write"], "topic": "pronoun-affirmative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex18",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "cloze",
+      "promptMd": "Fill in: *Chicos, ___ (poner, vosotros) el abrigo.* (use pronoun **os**).",
+      "answer": "poneos",
+      "accepted": ["re:^poneos$"],
+      "feedback": {
+        "correct": "Bien — vosotros affirmative drops -d + os → **poneos**.",
+        "wrong": "Use **poneos** (poned + os → drop the d)."
+      },
+      "meta": { "difficulty": "C1", "skills": ["write"], "topic": "vosotros-reflexive" }
+    },
+    {
+      "id": "c6-imp-irreg-ex19",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "cloze",
+      "promptMd": "Negative command with pronouns: *Por favor, ___ (no + dar + me + lo, t\u00fa).*",
+      "answer": "no me lo des",
+      "accepted": ["re:^no me lo des$"],
+      "feedback": {
+        "correct": "Exacto — negative keeps pronouns before: **no me lo des**.",
+        "wrong": "Use **no me lo des** (no + pronouns + subjunctive)."
+      },
+      "meta": { "difficulty": "B2", "skills": ["write"], "topic": "pronoun-negative" }
+    },
+    {
+      "id": "c6-imp-irreg-ex20",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "translate",
+      "promptMd": "Translate: *Let's leave now (referring to ourselves).*",
+      "answer": "V\u00e1monos ahora",
+      "accepted": ["re:^v\u00e1monos ahora\\.?$"],
+      "feedback": {
+        "correct": "Correct — affirmative nosotros of irse attaches **-nos** → vámonos.",
+        "wrong": "Use **Vámonos ahora** (vamos + nos with accent)."
+      },
+      "meta": { "difficulty": "C1", "skills": ["read", "write"], "topic": "nosotros-pronoun" }
+    },
+    {
+      "id": "c6-imp-irreg-ex21",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "mcq",
+      "promptMd": "Choose the correct placement: *___ la tarea ahora mismo.*",
+      "options": ["Hazme", "Me haz", "Haz me"],
+      "answer": "Hazme",
+      "feedback": {
+        "correct": "Yes — affirmative attaches pronoun → **Hazme**.",
+        "wrong": "Affirmative commands attach the pronoun: **Hazme**."
+      },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "pronoun-placement" }
+    },
+    {
+      "id": "c6-imp-irreg-ex22",
+      "lessonId": "c6-imperative-irregulars-pronouns",
+      "type": "mcq",
+      "promptMd": "Which option correctly negates the command with pronouns? *No ___ el secreto.*",
+      "options": ["lo digasme", "me lo digas", "digasme lo"],
+      "answer": "me lo digas",
+      "feedback": {
+        "correct": "Correct — negative places pronouns before the verb: **no me lo digas**.",
+        "wrong": "Use **no me lo digas** (no + pronouns + subjunctive)."
+      },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "pronoun-negative" }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "c6-imp-irreg-fc1",
+      "front": "Irregular tú imperatives",
+      "back": "di, haz, ve, pon, sal, sé, ten, ven",
+      "tag": "imperative",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc2",
+      "front": "decir — imperativo afirmativo",
+      "back": "tú di, Ud. diga, vos. decid, Uds. digan",
+      "tag": "decir",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc3",
+      "front": "hacer — imperativo afirmativo",
+      "back": "tú haz, Ud. haga, vos. haced, Uds. hagan",
+      "tag": "hacer",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc4",
+      "front": "ir — imperativo afirmativo",
+      "back": "tú ve, Ud. vaya, vos. id, Uds. vayan",
+      "tag": "ir",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc5",
+      "front": "poner — imperativo afirmativo",
+      "back": "tú pon, Ud. ponga, vos. poned, Uds. pongan",
+      "tag": "poner",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc6",
+      "front": "salir — imperativo afirmativo",
+      "back": "tú sal, Ud. salga, vos. salid, Uds. salgan",
+      "tag": "salir",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc7",
+      "front": "ser — imperativo afirmativo",
+      "back": "tú sé, Ud. sea, vos. sed, Uds. sean",
+      "tag": "ser",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc8",
+      "front": "tener — imperativo afirmativo",
+      "back": "tú ten, Ud. tenga, vos. tened, Uds. tengan",
+      "tag": "tener",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc9",
+      "front": "venir — imperativo afirmativo",
+      "back": "tú ven, Ud. venga, vos. venid, Uds. vengan",
+      "tag": "venir",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc10",
+      "front": "Negative irregular commands",
+      "back": "no digas, no hagas, no vayas, no pongas, no salgas, no seas, no tengas, no vengas",
+      "tag": "negative",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc11",
+      "front": "Pronoun placement",
+      "back": "Affirmative attaches (dímelo); negative precedes (no me lo digas)",
+      "tag": "pronouns",
+      "deck": "grammar"
+    },
+    {
+      "id": "c6-imp-irreg-fc12",
+      "front": "Vosotros reflexive",
+      "back": "drop -d + os → levantaos, poneos, idos/vámonos",
+      "tag": "vosotros",
+      "deck": "grammar"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a C6 Imperative Irregulars & Pronouns lesson detailing irregular command paradigms and pronoun placement rules
- supply 22 practice activities that contrast affirmative/negative commands and reinforce pronoun attachment
- create 12 supporting flashcards summarizing the irregular forms and placement rules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd808104f083248afb653f2f0ef009