### PR TITLE
Add C7 irregular participles and gerunds lesson

### DIFF
--- a/src/seed/c7-participles-gerunds-irregular.json
+++ b/src/seed/c7-participles-gerunds-irregular.json
@@ -1,0 +1,438 @@
+{
+  "lessons": [
+    {
+      "id": "c7-participles-gerunds-irregular",
+      "level": "C1",
+      "title": "C7 — Participles & Gerunds (Irregular)",
+      "slug": "c7-participles-gerunds-irregular",
+      "tags": [
+        "participles",
+        "gerunds",
+        "irregulars",
+        "c1",
+        "verbs",
+        "grammar"
+      ],
+      "markdown": "# 🔧 C7 — Participles & Gerunds (Irregular)\n\n**Goal:** Command high-frequency irregular past participles and gerunds for perfect tenses and progressive structures.\n\n---\n\n## 📘 Irregular Past Participles\n| Verb | Irregular participle | Notes |\n|---|---|---|\n| **abrir** | **abierto** | Used across all perfect tenses\n| **cubrir** | **cubierto** | Includes *descubrir → descubierto*\n| **decir** | **dicho** | Related: *bendecir → bendicho* (formal)\n| **escribir** | **escrito** | Also *describir → descrito*\n| **hacer** | **hecho** | *satisfacer → satisfecho*\n| **morir** | **muerto** | Common with *estar muerto*\n| **poner** | **puesto** | *componer → compuesto, suponer → supuesto*\n| **resolver** | **resuelto** | *envolver → envuelto, devolver → devuelto*\n| **romper** | **roto** | Irregular adjective & participle\n| **ver** | **visto** | *prever → previsto*\n| **volver** | **vuelto** | *revolver → revuelto*\n| **imprimir** | **impreso / imprimido** | **Impreso** preferred as adjective\n| **freír** | **frito / freído** | **Frito** most common adjective\n\n> Memorize the base list — prefixes usually keep the same irregular stem (*componer → compuesto*, *descubrir → descubierto*).\n\n---\n\n## 🧩 Agreement & Usage\n- With **haber** (he, había, habré…) the participle stays **invariable**: *hemos abierto*, *habían vuelto*.\n- With **estar**, **quedar**, **llevar**, **tener**, participles behave like adjectives and **agree** in gender/number: *las puertas están abiertas*, *tengo hechas las tareas*.\n- Double forms appear mostly as adjectives: *documentos impresos* / *he imprimido dos copias* (valid but less frequent).\n\nExamples:\n- *Ya han resuelto el caso.*\n- *Las ventanas quedaron abiertas toda la noche.*\n\n---\n\n## 🔄 Irregular Gerunds\n| Pattern | Examples |\n|---|---|\n| **Spelling change → -yendo** | caer → cayendo, creer → creyendo, leer → leyendo, oír → oyendo, traer → trayendo |\n| **e → i stem change** | decir → diciendo, pedir → pidiendo, servir → sirviendo, sentir → sintiendo, vestir(se) → vistiendo(se) |\n| **o → u stem change** | dormir → durmiendo, morir → muriendo, poder → pudiendo |\n| **Unique forms** | ir → yendo, reír → riendo |\n\n> Gerunds never take plural/gender. Attach pronouns to the end and keep the accent: *vistiéndose*, *trayéndolo*.\n\n---\n\n## 🚀 Key Combinations\n- **estar + gerundio** → ongoing action: *estamos durmiendo*.\n- **seguir / continuar + gerundio** → persistence: *sigue diciendo lo mismo*.\n- **andar + gerundio** → repeated or scattered action: *anda trayendo regalos*.\n- **llevar + participio / gerundio** expresses accumulation: *lleva hechas tres llamadas* / *llevan viviendo aquí diez años*.\n\n> Strategy: Learn the irregular bases once, then extend them to prefixed verbs and matching gerunds.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "c7-part-gerund-ex1",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "conjugate",
+      "promptMd": "Conjugate **abrir** in the **pretérito perfecto compuesto** (yo, tú, él/ella, nosotros, vosotros, ellos).",
+      "answer": [
+        "he abierto",
+        "has abierto",
+        "ha abierto",
+        "hemos abierto",
+        "habéis abierto",
+        "han abierto"
+      ],
+      "feedback": {
+        "correct": "Bien — participio irregular **abierto** stays invariable after *haber*.",
+        "wrong": "Use *haber* in present + **abierto**: he/has/ha/hemos/habéis/han abierto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "abrir-participio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex2",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "conjugate",
+      "promptMd": "Conjugate **poner** in the **pluscuamperfecto** (yo, tú, él/ella, nosotros, vosotros, ellos).",
+      "answer": [
+        "había puesto",
+        "habías puesto",
+        "había puesto",
+        "habíamos puesto",
+        "habíais puesto",
+        "habían puesto"
+      ],
+      "feedback": {
+        "correct": "Perfecto — usa el imperfecto de *haber* + participio irregular **puesto**.",
+        "wrong": "Emplea había/habías/había/habíamos/habíais/habían + **puesto**."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "poner-pluscuamperfecto"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex3",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Complete: *Ya han ___ (escribir) el informe.*",
+      "answer": "escrito",
+      "accepted": [
+        "re:^escrito$"
+      ],
+      "feedback": {
+        "correct": "Correcto — participio irregular **escrito**.",
+        "wrong": "Usa **escrito** con *han*."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "escribir-participio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex4",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Complete: *Todavía no hemos ___ (resolver) el problema.*",
+      "answer": "resuelto",
+      "accepted": [
+        "re:^resuelto$"
+      ],
+      "feedback": {
+        "correct": "Bien — **resuelto** es el participio irregular de *resolver*.",
+        "wrong": "Escribe **resuelto** (no *resolverado*)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "resolver-participio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex5",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Fill in: *¿Ya has ___ (volver) de tus vacaciones?*",
+      "answer": "vuelto",
+      "accepted": [
+        "re:^vuelto$"
+      ],
+      "feedback": {
+        "correct": "Exacto — **vuelto** es el participio irregular de *volver*.",
+        "wrong": "Usa **vuelto** (no *volvido*)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "volver-participio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex6",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "mcq",
+      "promptMd": "Choose the correct agreement: *Las flores ya están ___.* (→ **morir**)",
+      "options": [
+        "muertas",
+        "muerto",
+        "morido"
+      ],
+      "answer": "muertas",
+      "feedback": {
+        "correct": "Exacto — con *estar* el participio funciona como adjetivo: **muertas**.",
+        "wrong": "Elige el participio irregular **muerto** concordado en femenino plural: **muertas**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "participles-agreement"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex7",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Complete: *Los documentos quedaron ___ (imprimir).*",
+      "answer": "impresos",
+      "accepted": [
+        "re:^impresos$"
+      ],
+      "feedback": {
+        "correct": "Correcto — como adjetivo usamos **impresos**.",
+        "wrong": "Prefiere **impresos** (doble forma con *imprimidos*, menos común)."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "imprimir-participio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex8",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "translate",
+      "promptMd": "Translate: *They had already seen the movie.*",
+      "answer": "Ya habían visto la película",
+      "accepted": [
+        "re:^ya habían visto la pel[ií]cula\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien — pluscuamperfecto con participio irregular **visto**.",
+        "wrong": "Di **Ya habían visto la película** (haber + visto)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "ver-pluscuamperfecto"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex9",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Fill in: *Sigue ___ (decir) mentiras.*",
+      "answer": "diciendo",
+      "accepted": [
+        "re:^diciendo$"
+      ],
+      "feedback": {
+        "correct": "Perfecto — gerundio irregular **diciendo**.",
+        "wrong": "Usa **diciendo** (e→i)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "decir-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex10",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Complete: *Estamos ___ (dormir) cuando sonó el teléfono.*",
+      "answer": "durmiendo",
+      "accepted": [
+        "re:^durmiendo$"
+      ],
+      "feedback": {
+        "correct": "Bien — o→u en el gerundio: **durmiendo**.",
+        "wrong": "Es **durmiendo**, no *dormiendo*."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "dormir-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex11",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "mcq",
+      "promptMd": "Choose the correct gerund: *Está ___ el artículo.* (→ **leer**)",
+      "options": [
+        "leyendo",
+        "leiendo",
+        "leando"
+      ],
+      "answer": "leyendo",
+      "feedback": {
+        "correct": "Exacto — cambio ortográfico → **leyendo**.",
+        "wrong": "Usa **leyendo** (i→y)."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "leer-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex12",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Fill in: *Lo vi ___ (caer) al suelo.*",
+      "answer": "cayendo",
+      "accepted": [
+        "re:^cayendo$"
+      ],
+      "feedback": {
+        "correct": "Bien — cambio ortográfico → **cayendo**.",
+        "wrong": "Es **cayendo** (no *caendo*)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "caer-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex13",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Complete: *Continúan ___ (traer) regalos cada semana.*",
+      "answer": "trayendo",
+      "accepted": [
+        "re:^trayendo$"
+      ],
+      "feedback": {
+        "correct": "Correcto — gerundio con y: **trayendo**.",
+        "wrong": "Escribe **trayendo** (i→y)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "traer-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex14",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Fill in: *Sigue ___ (venir) tarde a clase.*",
+      "answer": "viniendo",
+      "accepted": [
+        "re:^viniendo$"
+      ],
+      "feedback": {
+        "correct": "Exacto — e→i en el gerundio: **viniendo**.",
+        "wrong": "Usa **viniendo** (no *veniendo*)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "venir-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex15",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "cloze",
+      "promptMd": "Complete: *Estamos ___ (ir) al médico ahora mismo.*",
+      "answer": "yendo",
+      "accepted": [
+        "re:^yendo$"
+      ],
+      "feedback": {
+        "correct": "Bien — forma única del gerundio de *ir*: **yendo**.",
+        "wrong": "Es **yendo**, no *iendo*."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ir-gerundio"
+      }
+    },
+    {
+      "id": "c7-part-gerund-ex16",
+      "lessonId": "c7-participles-gerunds-irregular",
+      "type": "translate",
+      "promptMd": "Translate: *They keep getting dressed slowly.* (→ **seguir + vestirse**)",
+      "answer": "Siguen vistiéndose despacio",
+      "accepted": [
+        "re:^siguen vist[ií]éndose despacio\\.?$",
+        "re:^siguen vistiendose despacio\\.?$"
+      ],
+      "feedback": {
+        "correct": "Perfecto — *seguir* + gerundio con pronombre: **Siguen vistiéndose despacio**.",
+        "wrong": "Di **Siguen vistiéndose despacio** (seguir + gerundio, pronombre enclítico)."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "gerundio-pronombres"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "c7-part-gerund-fc1",
+      "front": "Irregular past participles (core)",
+      "back": "abrir→abierto, cubrir→cubierto, decir→dicho, escribir→escrito, hacer→hecho, morir→muerto, poner→puesto, resolver→resuelto, romper→roto, ver→visto, volver→vuelto",
+      "tag": "participles",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc2",
+      "front": "Prefixed verbs share irregular stems",
+      "back": "componer→compuesto, suponer→supuesto, devolver→devuelto, descubrir→descubierto, prever→previsto",
+      "tag": "participles",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc3",
+      "front": "Double participle forms",
+      "back": "imprimir→impreso/imprimido, freír→frito/freído, proveer→provisto/proveído; irregular form preferred as adjective",
+      "tag": "participles",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc4",
+      "front": "Agreement of participles",
+      "back": "Con *haber* no hay concordancia (hemos abierto); con estar/quedar/tener actúan como adjetivos: puertas abiertas, tareas hechas",
+      "tag": "agreement",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc5",
+      "front": "Irregular gerunds",
+      "back": "decir→diciendo, pedir→pidiendo, servir→sirviendo, venir→viniendo, morir→muriendo",
+      "tag": "gerunds",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc6",
+      "front": "-yendo spelling change",
+      "back": "caer→cayendo, creer→creyendo, leer→leyendo, oír→oyendo, traer→trayendo",
+      "tag": "gerunds",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc7",
+      "front": "Unique gerunds",
+      "back": "ir→yendo, reír→riendo",
+      "tag": "gerunds",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc8",
+      "front": "Pronouns with gerunds",
+      "back": "Se adjuntan al final: diciéndolo, vistiéndose; añade tilde para conservar el acento",
+      "tag": "pronouns",
+      "deck": "grammar"
+    },
+    {
+      "id": "c7-part-gerund-fc9",
+      "front": "Key periphrases",
+      "back": "estar + gerundio (acción en progreso); seguir/continuar + gerundio (todavía); andar + gerundio (andar haciendo); llevar + participio/gerundio (acumulado)",
+      "tag": "perífrasis",
+      "deck": "grammar"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the C7 lesson on irregular past participles and gerunds with detailed markdown notes
- seed sixteen practice exercises covering participle agreement and irregular gerunds
- add supporting flashcards for core forms, spelling changes, and periphrastic usage

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd821a8bf483248d2c8dd0c8493ef1