### PR TITLE
Add C1 advanced discourse lessons and resources

### DIFF
--- a/src/seed/a24-articles-deep.json
+++ b/src/seed/a24-articles-deep.json
@@ -1,0 +1,301 @@
+{
+  "lessons": [
+    {
+      "id": "a24-articles-deep",
+      "level": "C1",
+      "title": "A24 — Articles Beyond the Basics",
+      "slug": "a24-articles-deep",
+      "tags": [
+        "articles",
+        "determiners",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 📰 A24 — Articles Beyond the Basics\n\n**Goal:** Command article use for abstraction, emphasis, and discourse-level cohesion.\n\n---\n\n## 1. Article as an abstractor\n- **lo + adjetivo/participio** → sustantiva cualidades: *lo esencial, lo vivido*.\n- **el + infinitivo** → convierte acciones en conceptos: *el viajar forma el carácter*.\n- Usa artículo para resumir capítulos previos: *En el anterior, vimos...*.\n\n## 2. Cuándo omitimos el artículo\n- Professions, religions, nationalities after **ser** if unmodified: *Es médica*. Añadir adjetivo → vuelve el artículo: *Es la médica responsable*.\n- Tras **tener, llevar, buscar** en sentido indeterminado: *tiene experiencia*, *busco piso*.\n- Títulos, cargos, cargos de cortesía pierden artículo en vocativos: *Señora presidenta, tiene la palabra*.\n- Estilo telegráfico (titulares/listas) suprime artículos: *Gobierno aprueba reforma*.\n\n## 3. Dónde es obligatorio\n- Días de la semana y partes del día en hábitos: *los lunes, por la mañana*.\n- Cuerpo y ropa con verbos de sensación/afectación: *Me duele la cabeza; le mancharon el abrigo*.\n- Artículo con apellidos para referirse a familias o figuras públicas: *La Allende, los García Márquez*.\n- Doble determinación en énfasis: *Ese mismo problema*, *la siempre compleja logística*.\n\n## 4. Artículo y registro\n- **lo** permite comentarios metalingüísticos: *Lo interesante del informe...*.\n- Artículo neutro con comparativos/superlativos absolutos: *lo más urgente, lo mejor posible*.\n- Recurso académico: *En el presente capítulo se analiza...* (artículo da solemnidad).\n- Omitir artículo produce estilo conciso o coloquial, según contexto.\n\n---\n\n> 📝 **Resumen:** Domina cuándo el artículo introduce abstracción o solemnidad y cuándo borrarlo mantiene naturalidad. Alternar artículo/ø modifica la perspectiva discursiva.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a24-articles-deep-ex1",
+      "lessonId": "a24-articles-deep",
+      "type": "cloze",
+      "promptMd": "**___ bueno es que termina pronto.** (abstract idea)",
+      "answer": "Lo",
+      "accepted": [
+        "re:^lo$",
+        "re:^Lo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: lo bueno → cualidad sustantivada.",
+        "wrong": "Usa **lo** para convertir adjetivo en idea."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "lo + adjetivo"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex2",
+      "lessonId": "a24-articles-deep",
+      "type": "cloze",
+      "promptMd": "**___ viajar en tren** reduce la huella de carbono.",
+      "answer": "El",
+      "accepted": [
+        "re:^el$",
+        "re:^El$"
+      ],
+      "feedback": {
+        "correct": "Bien: el + infinitivo → acción como concepto.",
+        "wrong": "Necesitas artículo para nominalizar el infinitivo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "el + infinitivo"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex3",
+      "lessonId": "a24-articles-deep",
+      "type": "mcq",
+      "promptMd": "Completa: *Tiene ___ experiencia en mediación.*",
+      "options": [
+        "la",
+        "una",
+        "experiencia",
+        "la una"
+      ],
+      "answer": "experiencia",
+      "feedback": {
+        "correct": "Correcto: tras *tener* en sentido general se omite el artículo.",
+        "wrong": "Tras *tener* indefinido → Ø: *tiene experiencia*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "ø tras tener"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex4",
+      "lessonId": "a24-articles-deep",
+      "type": "translate",
+      "promptMd": "Translate: **Lo inesperado nos asusta.**",
+      "answer": "The unexpected scares us",
+      "accepted": [
+        "re:^the unexpected scares us\\.?$"
+      ],
+      "feedback": {
+        "correct": "Exacto: lo + adjetivo → the + adjective (as noun).",
+        "wrong": "Recuerda: lo inesperado → the unexpected."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "lo abstracto"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex5",
+      "lessonId": "a24-articles-deep",
+      "type": "cloze",
+      "promptMd": "Me duele ___ cabeza.",
+      "answer": "la",
+      "accepted": [
+        "re:^la$"
+      ],
+      "feedback": {
+        "correct": "Correcto: partes del cuerpo llevan artículo, no posesivo.",
+        "wrong": "Usa **la cabeza**, no *mi cabeza* tras verbos de sensación."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "cuerpo"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex6",
+      "lessonId": "a24-articles-deep",
+      "type": "mcq",
+      "promptMd": "En una crónica periodística, tras presentar a Laura Fernández, ¿cómo se la menciona después?",
+      "options": [
+        "Fernández",
+        "la Fernández",
+        "la Laura",
+        "una Fernández"
+      ],
+      "answer": "la Fernández",
+      "feedback": {
+        "correct": "Correcto: apellidos notorios llevan artículo definido.",
+        "wrong": "Se usa **la Fernández** para referirse a la persona ya identificada."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "apellidos"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex7",
+      "lessonId": "a24-articles-deep",
+      "type": "cloze",
+      "promptMd": "___ domingos visitamos a mis abuelos. (hábito)",
+      "answer": "Los",
+      "accepted": [
+        "re:^los$",
+        "re:^Los$"
+      ],
+      "feedback": {
+        "correct": "Bien: los + día → rutina semanal.",
+        "wrong": "Las rutinas semanales usan artículo plural: **los domingos**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "días"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex8",
+      "lessonId": "a24-articles-deep",
+      "type": "translate",
+      "promptMd": "Translate: **Estudiaba por la noche para el examen.**",
+      "answer": "He/She studied at night for the exam",
+      "accepted": [
+        "re:^(he|she) studied at night for the exam\\.?$",
+        "re:^studied at night for the exam\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: por la noche mantiene artículo definido.",
+        "wrong": "Incluye el artículo: *at night* corresponde a **por la noche**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "partes del día"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex9",
+      "lessonId": "a24-articles-deep",
+      "type": "short",
+      "promptMd": "¿Cuándo se omite el artículo con profesiones tras *ser*?",
+      "answer": "Cuando la profesión va sin adjetivos ni especificadores (Es médica).",
+      "accepted": [
+        "re:sin adjetivos",
+        "re:profesi[oó]n va sin modificar"
+      ],
+      "feedback": {
+        "correct": "Exacto: *Es médica*; añades artículo si hay calificativos.",
+        "wrong": "Se omite si la profesión va desnuda, sin calificativos."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "profesiones"
+      }
+    },
+    {
+      "id": "a24-articles-deep-ex10",
+      "lessonId": "a24-articles-deep",
+      "type": "cloze",
+      "promptMd": "Su obsesión por ___ digital le impide desconectar.",
+      "answer": "lo",
+      "accepted": [
+        "re:^lo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: lo digital → campo conceptual.",
+        "wrong": "Usa **lo** para sustantivar el adjetivo digital."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "lo + adjetivo"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a24-articles-deep-fc1",
+      "front": "lo + adjetivo",
+      "back": "Crea sustantivos abstractos: lo esencial, lo urgente",
+      "tag": "abstractor",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc2",
+      "front": "el + infinitivo",
+      "back": "Nominaliza acciones: el viajar, el comer sano",
+      "tag": "infinitivo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc3",
+      "front": "Ø tras tener/buscar",
+      "back": "Sentido inespecífico: tiene experiencia, busca trabajo",
+      "tag": "omisión",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc4",
+      "front": "Cuerpo/ropa",
+      "back": "Usa artículo con verbos de sensación: me duele la espalda",
+      "tag": "cuerpo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc5",
+      "front": "Días y hábitos",
+      "back": "los lunes, las noches de verano",
+      "tag": "tiempo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc6",
+      "front": "Apellidos notorios",
+      "back": "La Mistral, los García → artículo marca notoriedad",
+      "tag": "apellidos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc7",
+      "front": "Registro académico",
+      "back": "El artículo aporta solemnidad: En el presente estudio...",
+      "tag": "registro",
+      "deck": "grammar"
+    },
+    {
+      "id": "a24-articles-deep-fc8",
+      "front": "Lo + superlativo",
+      "back": "lo más urgente, lo mejor posible",
+      "tag": "superlativo",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a25-clitics-se.json
+++ b/src/seed/a25-clitics-se.json
@@ -1,0 +1,343 @@
+{
+  "lessons": [
+    {
+      "id": "a25-clitics-se",
+      "level": "C1",
+      "title": "A25 — Clitics, Doubling & the Many Faces of *se*",
+      "slug": "a25-clitics-se",
+      "tags": [
+        "clitics",
+        "pronouns",
+        "se",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🔁 A25 — Clitics, Doubling & the Many Faces of *se*\n\n**Goal:** Manejar la colocación, duplicación y matices discursivos de los clíticos españoles.\n\n---\n\n## 1. Orden fijo (me/te/se/le + lo/la/los/las)\n- Clítico indirecto va antes del directo: *se lo conté*, *me la entregaron*.\n- *le/les* → **se** cuando comparte verbo con lo/la/los/las.\n- En perífrasis y tiempos compuestos se colocan antes del auxiliar o pospuestos al infinitivo/gerundio.\n\n## 2. Duplicación y foco\n- Duplicar IO obligatorio con pronombres tónicos antepuestos: *A María le di...*.\n- Duplicación enfática: *Le di un abrazo a ella, no a ti*.\n- Con OD animados marcados con **a** se admite duplicación para contraste: *La novela la leí yo*.\n\n## 3. Valores de *se*\n- **Reflexivo/recíproco:** *se miran*, *nos vemos*.\n- **Pronominal léxico:** verbos inherentes (*quejarse, arrepentirse*).\n- **Aspectual/intensificador:** *comerse la tarta*, *irse marchando*.\n- **Accidental/dativo ético:** *Se me cayó el café*, *Se me estudia mejor aquí*.\n\n## 4. *Se* impersonal y pasiva\n- **Impersonal:** *Se vive bien aquí* (3ª sg., verbo intransitivo o sin OD expreso).\n- **Pasiva refleja:** *Se publicaron los resultados* (verbo transitivo + sujeto paciente).\n- Ambiguos → apoya con contexto o pronombre: *Aquí se come rico* (impersonal) vs *Se comieron los postres* (pasiva).\n\n## 5. Matices dialectales\n- **Leísmo** animado masculino admitido en estándar peninsular culto: *le vi ayer*.\n- **Laísmo/loísmo** siguen siendo no normativos fuera de registros muy marcados.\n- Dativo enfático: *Se me enfadó* añade implicación afectiva.\n\n---\n\n> 📝 **Resumen:** La posición clítica es rígida; el valor pragmático depende de duplicar, escoger *se* adecuado y entender si el verbo admite voz media, impersonal o intensificadora.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a25-clitics-se-ex1",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "___ lo dije a Ana en confianza.",
+      "answer": "Se",
+      "accepted": [
+        "re:^se$",
+        "re:^Se$"
+      ],
+      "feedback": {
+        "correct": "Correcto: le + lo → se lo.",
+        "wrong": "Cuando le/les precede a lo/la, cambia a **se**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "se lo"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex2",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "A mis padres ___ compré un recuerdo.",
+      "answer": "les",
+      "accepted": [
+        "re:^les$"
+      ],
+      "feedback": {
+        "correct": "Bien: duplicas IO expreso (a mis padres) con **les**.",
+        "wrong": "Con IO léxico antepuesto debes duplicar con **les**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "duplicación IO"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex3",
+      "lessonId": "a25-clitics-se",
+      "type": "mcq",
+      "promptMd": "Orden correcto de clíticos: *¿Puedes ___ ___ explicar?*",
+      "options": [
+        "la me",
+        "me la",
+        "la te",
+        "te la"
+      ],
+      "answer": "me la",
+      "feedback": {
+        "correct": "Correcto: IO (me) antes del OD (la).",
+        "wrong": "Recuerda: me/te/se/nos/os + lo/la/los/las."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "orden clíticos"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex4",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "Los niños ___ lavan los dientes solos.",
+      "answer": "se",
+      "accepted": [
+        "re:^se$"
+      ],
+      "feedback": {
+        "correct": "Correcto: valor reflexivo (ellos mismos).",
+        "wrong": "Es acción sobre sí mismos → **se** reflexivo."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "reflexivo"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex5",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "Aquí ___ vive muy bien. (impersonal)",
+      "answer": "se",
+      "accepted": [
+        "re:^se$"
+      ],
+      "feedback": {
+        "correct": "Correcto: impersonal → se + verbo 3ª sg.",
+        "wrong": "Sin sujeto explícito → usa **se** impersonal."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "se impersonal"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex6",
+      "lessonId": "a25-clitics-se",
+      "type": "mcq",
+      "promptMd": "Identifica el tipo de *se*: *Se vendieron todas las entradas.*",
+      "options": [
+        "Reflexivo",
+        "Pasiva refleja",
+        "Impersonal",
+        "Dativo ético"
+      ],
+      "answer": "Pasiva refleja",
+      "feedback": {
+        "correct": "Correcto: sujeto paciente (las entradas) + verbo transitivo → pasiva refleja.",
+        "wrong": "Hay sujeto paciente, no es impersonal."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "pasiva refleja"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex7",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "Se les cayó el café → ¿Cómo expresas el accidente? *___ ___ cayó el café.*",
+      "answer": [
+        "Se",
+        "les"
+      ],
+      "feedback": {
+        "correct": "Correcto: se (voz media) + les (dativo afectado).",
+        "wrong": "Necesitas **se** accidental + dativo afectado."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "se accidental"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex8",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "No ___ voy a decir dos veces, ¿vale? (dativo ético)",
+      "answer": "te lo",
+      "accepted": [
+        "re:^te lo$"
+      ],
+      "feedback": {
+        "correct": "Bien: te (dativo ético) + lo (contenido).",
+        "wrong": "Mantén orden IO antes de OD: **te lo**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "dativo ético"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex9",
+      "lessonId": "a25-clitics-se",
+      "type": "translate",
+      "promptMd": "Translate: **Se nos fue el tren.**",
+      "answer": "We missed the train",
+      "accepted": [
+        "re:^we missed the train\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: se + dativo expresa pérdida involuntaria.",
+        "wrong": "Equivale a 'the train left us / we missed the train'."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "se dativo"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex10",
+      "lessonId": "a25-clitics-se",
+      "type": "mcq",
+      "promptMd": "¿Cuál es la opción aceptable según la norma culta?",
+      "options": [
+        "La dije la verdad a Marta",
+        "Le vi ayer en Madrid",
+        "Lo dije a María",
+        "Les vi las caras"
+      ],
+      "answer": "Le vi ayer en Madrid",
+      "feedback": {
+        "correct": "Correcto: leísmo animado masculino admitido; *la/lo dije* son laísmos/loísmos.",
+        "wrong": "Solo *le vi* es aceptado; las otras combinaciones violan norma estándar."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "read"
+        ],
+        "topic": "leísmo"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex11",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "Vamos a decír___ mañana. (adjunta al infinitivo)",
+      "answer": "selo",
+      "accepted": [
+        "re:^selo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: al posponer se mantiene *se* + lo → selo.",
+        "wrong": "Recuerda fusionar: decir + se + lo → decírselo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "posposición"
+      }
+    },
+    {
+      "id": "a25-clitics-se-ex12",
+      "lessonId": "a25-clitics-se",
+      "type": "short",
+      "promptMd": "Explica la diferencia entre *Se vive bien aquí* y *Se vendieron casas*.",
+      "answer": "La primera es impersonal (sin sujeto) y la segunda es pasiva refleja con sujeto paciente (casas).",
+      "accepted": [
+        "re:impersonal",
+        "re:pasiva refleja"
+      ],
+      "feedback": {
+        "correct": "Exacto: un caso no tiene sujeto gramatical; el otro sí (casas).",
+        "wrong": "Aclara: *vive* → impersonal; *vendieron* → pasiva con sujeto paciente."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "impersonal vs pasiva"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a25-clitics-se-fc1",
+      "front": "Orden clítico",
+      "back": "me/te/se/nos/os/le + lo/la/los/las (le→se ante lo)",
+      "tag": "orden",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc2",
+      "front": "Duplicación IO",
+      "back": "A María le di… (obligatoria con IO antepuesto)",
+      "tag": "duplicación",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc3",
+      "front": "Se reflexivo",
+      "back": "Acción sobre el mismo sujeto: se lava",
+      "tag": "reflexivo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc4",
+      "front": "Se impersonal",
+      "back": "Verbo 3ª sg. sin sujeto: se trabaja bien",
+      "tag": "impersonal",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc5",
+      "front": "Pasiva refleja",
+      "back": "Se publicaron los datos (sujeto paciente)",
+      "tag": "pasiva",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc6",
+      "front": "Se accidental",
+      "back": "Se me olvidó, se nos fue el tren",
+      "tag": "accidental",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc7",
+      "front": "Aspecto intensivo",
+      "back": "comerse, tomarse, irse + gerundio intensifican",
+      "tag": "aspecto",
+      "deck": "grammar"
+    },
+    {
+      "id": "a25-clitics-se-fc8",
+      "front": "Leísmo culto",
+      "back": "Le vi (masc. animado) aceptado; evita laísmo/loísmo",
+      "tag": "variante",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a26-verb-timeline.json
+++ b/src/seed/a26-verb-timeline.json
@@ -1,0 +1,319 @@
+{
+  "lessons": [
+    {
+      "id": "a26-verb-timeline",
+      "level": "C1",
+      "title": "A26 — Timeline Mastery: situating actions",
+      "slug": "a26-verb-timeline",
+      "tags": [
+        "timeline",
+        "tenses",
+        "aspect",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🕰️ A26 — Timeline Mastery\n\n**Goal:** Construir cronologías complejas eligiendo el eje temporal adecuado.\n\n---\n\n## 1. Punto de anclaje\n- Identifica el **ahora narrativo**. Conversación cotidiana → presente del emisor; narración retrospectiva → pasado del narrador.\n- Pretérito perfecto sitúa acciones **con vigencia** en el ahora; indefinido las desconecta de él (Península vs América varia).\n- Pluscuamperfecto marca pasado anterior a otro pasado; antepretérito en estilo literario.\n\n## 2. Relatos encadenados\n- Usa imperfecto para fondo y hábitos simultáneos; indefinido para eventos puntuales que avanzan la acción.\n- Para causas previas: *había decidido* antes de *viajó*.\n- Progresivos: *estaba leyendo cuando sonó el teléfono*.\n\n## 3. Proyección futura\n- Futuro simple expresa conjetura o evento posterior al ahora: *Estará en casa*.\n- Futuro perfecto = evento completado antes de un punto futuro: *Para las ocho habré llegado*.\n- Condicional simple/futuro del pasado: *Dijo que llegaría tarde*.\n- Condicional perfecto para hipótesis vencidas: *Dijo que para 2030 habrían reducido emisiones*.\n\n## 4. Duración y continuidad\n- **Llevar + gerundio** sitúa duración acumulada hasta el anclaje: *Llevo diez años trabajando aquí*.\n- **Desde hace / hacía** conectan inicio y continuidad según si el eje está en presente o pasado.\n- **Acabar de + inf.** marca pasado inmediato relativo al anclaje.\n\n## 5. Marcadores temporales\n- *En cuanto, cuando, antes de que* reorganizan la línea: atención al modo/tiempo requerido.\n- *Para entonces, ya, todavía* expresan completitud vs continuidad.\n\n---\n\n> 📝 **Resumen:** Fija el anclaje temporal y decide si la acción está anterior, simultánea o posterior. Escoge tiempo simple o compuesto según conexión con el punto de referencia.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a26-verb-timeline-ex1",
+      "lessonId": "a26-verb-timeline",
+      "type": "mcq",
+      "promptMd": "En España, para una experiencia este mes se prefiere: *Este mes ___ dos informes.*",
+      "options": [
+        "entregué",
+        "he entregado",
+        "entrego",
+        "había entregado"
+      ],
+      "answer": "he entregado",
+      "feedback": {
+        "correct": "Correcto: pretérito perfecto conecta con el presente del mes en curso.",
+        "wrong": "Se usa **he entregado** si el periodo sigue vigente."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "perfecto peninsular"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex2",
+      "lessonId": "a26-verb-timeline",
+      "type": "cloze",
+      "promptMd": "Cuando llegué, ellos ya ___ (salir).",
+      "answer": "habían salido",
+      "accepted": [
+        "re:^habían salido$"
+      ],
+      "feedback": {
+        "correct": "Bien: acción anterior a otro pasado → pluscuamperfecto.",
+        "wrong": "Marca pasado anterior con **habían salido**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "pluscuamperfecto"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex3",
+      "lessonId": "a26-verb-timeline",
+      "type": "cloze",
+      "promptMd": "Mañana a estas horas ya ___ (terminar, yo) el informe.",
+      "answer": "habré terminado",
+      "accepted": [
+        "re:^habré terminado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: futuro perfecto proyecta acción completada antes de un punto futuro.",
+        "wrong": "Usa **habré terminado** para completitud anterior al futuro."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "futuro perfecto"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex4",
+      "lessonId": "a26-verb-timeline",
+      "type": "cloze",
+      "promptMd": "Llevábamos cinco años ___ (vivir) allí cuando nos mudamos.",
+      "answer": "viviendo",
+      "accepted": [
+        "re:^viviendo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: llevar + gerundio para duración acumulada en pasado.",
+        "wrong": "Usa **llevábamos ... viviendo** para duración hasta ese pasado."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "llevar + gerundio"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex5",
+      "lessonId": "a26-verb-timeline",
+      "type": "translate",
+      "promptMd": "Translate: **Para cuando leas esto, me habré ido.**",
+      "answer": "By the time you read this, I will have left",
+      "accepted": [
+        "re:^by the time you read this, i will have left\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: futuro perfecto = will have + participle.",
+        "wrong": "Incluye 'will have left' para futuro perfecto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "futuro perfecto"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex6",
+      "lessonId": "a26-verb-timeline",
+      "type": "mcq",
+      "promptMd": "Escoge la versión coherente: *Dijo que para 2030 ___ la pobreza extrema.*",
+      "options": [
+        "elimina",
+        "eliminará",
+        "habrá eliminado",
+        "habrían eliminado"
+      ],
+      "answer": "habrían eliminado",
+      "feedback": {
+        "correct": "Correcto: futuro visto desde un pasado → condicional perfecto.",
+        "wrong": "Desde el punto de vista de 'dijo' se anticipa → **habrían eliminado**."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "read"
+        ],
+        "topic": "futuro del pasado"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex7",
+      "lessonId": "a26-verb-timeline",
+      "type": "cloze",
+      "promptMd": "Mientras ella investigaba, yo ___ (tomar) notas.",
+      "answer": "tomaba",
+      "accepted": [
+        "re:^tomaba$"
+      ],
+      "feedback": {
+        "correct": "Correcto: simultaneidad de fondo → imperfecto.",
+        "wrong": "Usa **tomaba** para acción en curso simultánea."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "imperfecto simultáneo"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex8",
+      "lessonId": "a26-verb-timeline",
+      "type": "cloze",
+      "promptMd": "Si hubiéramos salido antes, ___ (llegar) a tiempo.",
+      "answer": "habríamos llegado",
+      "accepted": [
+        "re:^habríamos llegado$"
+      ],
+      "feedback": {
+        "correct": "Bien: condicional perfecto para la apódosis irreal del pasado.",
+        "wrong": "La consecuencia hipotética requiere **habríamos llegado**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "condicional perfecto"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex9",
+      "lessonId": "a26-verb-timeline",
+      "type": "translate",
+      "promptMd": "Translate: **Acababa de salir cuando llamaste.**",
+      "answer": "I had just left when you called",
+      "accepted": [
+        "re:^i had just left when you called\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acabar de + inf. en imperfecto = past perfect 'had just'.",
+        "wrong": "'Acababa de' → had just."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "acabar de"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex10",
+      "lessonId": "a26-verb-timeline",
+      "type": "short",
+      "promptMd": "¿Qué cambia si dices *El año pasado he viajado a Perú* en España?",
+      "answer": "Suena extraño porque el periodo está cerrado; se prefiere *viajé* (pretérito indefinido).",
+      "accepted": [
+        "re:extrañ",
+        "re:se prefiere viajé"
+      ],
+      "feedback": {
+        "correct": "Exacto: año pasado es periodo terminado → indefinido.",
+        "wrong": "Indica que el periodo está cerrado → usa indefinido."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "indefinido vs perfecto"
+      }
+    },
+    {
+      "id": "a26-verb-timeline-ex11",
+      "lessonId": "a26-verb-timeline",
+      "type": "cloze",
+      "promptMd": "Desde hacía dos años ___ (no ver, nosotros) a Marta cuando apareció.",
+      "answer": "no veíamos",
+      "accepted": [
+        "re:^no veíamos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: referencia pasada → desde hacía + imperfecto.",
+        "wrong": "Para pasado continuo usa **desde hacía... no veíamos**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "desde hacía"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a26-verb-timeline-fc1",
+      "front": "Anclaje narrativo",
+      "back": "Determina ahora narrativo antes de elegir tiempo",
+      "tag": "anclaje",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc2",
+      "front": "Perfecto vs indefinido",
+      "back": "Perfecto conecta periodo vigente; indefinido lo cierra",
+      "tag": "perfecto",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc3",
+      "front": "Pluscuamperfecto",
+      "back": "Pasado anterior a otro pasado",
+      "tag": "pluscuam",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc4",
+      "front": "Futuro perfecto",
+      "back": "Para cuando + futuro → habré terminado",
+      "tag": "futuro",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc5",
+      "front": "Condicional (futuro del pasado)",
+      "back": "Dijo que llegaría; para 2030 habrían logrado",
+      "tag": "condicional",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc6",
+      "front": "Llevar + gerundio",
+      "back": "Duración acumulada hasta el anclaje",
+      "tag": "duración",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc7",
+      "front": "Desde hace / hacía",
+      "back": "Presente vs pasado como referencia",
+      "tag": "marcadores",
+      "deck": "grammar"
+    },
+    {
+      "id": "a26-verb-timeline-fc8",
+      "front": "Acabar de",
+      "back": "Pasado inmediato relativo al anclaje",
+      "tag": "aspecto",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a27-indicative-contrasts.json
+++ b/src/seed/a27-indicative-contrasts.json
@@ -1,0 +1,321 @@
+{
+  "lessons": [
+    {
+      "id": "a27-indicative-contrasts",
+      "level": "C1",
+      "title": "A27 — Indicative Contrasts & Nuance",
+      "slug": "a27-indicative-contrasts",
+      "tags": [
+        "indicative",
+        "aspect",
+        "nuance",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# ⚖️ A27 — Indicative Contrasts & Nuance\n\n**Goal:** Elegir entre tiempos del indicativo según foco aspectual, vigencia y grado de certeza.\n\n---\n\n## 1. Pretérito indefinido vs imperfecto\n- Indefinido: eventos cerrados, secuencia. *Llegó, vio, venció.*\n- Imperfecto: fondo, hábito, estado, acción en curso. *Cuando llegué, llovía.*\n- Verbos con cambio semántico: *saber* (supé = me enteré; sabía = conocía), *poder* (pude = logré; podía = tenía capacidad).\n\n## 2. Perfecto compuesto vs indefinido\n- Península: perfecto para acciones recientes con vínculo actual; indefinido para pasado terminado.\n- América: perfecto restringido, indefinido cubre la mayoría de pasados.\n- Evita mezclar marcadores cerrados con perfecto (*ayer he ido* suena forzado).\n\n## 3. Presente expandido\n- Presente histórico dramatiza pasado: *En 1810 nace...*.\n- Presente con valor futurizante programado: *Mañana salgo a las ocho*.\n- Perífrasis de inminencia: *Estoy a punto de salir*, *Voy saliendo*.\n\n## 4. Futuro y condicional epistémicos\n- Futuro expresa conjetura sobre presente: *Estará en casa* (= probably).\n- Condicional expresa conjetura sobre pasado: *Serían las cinco*.\n- Cortesía: *¿Querría usted...?*, *¿Podrías abrir?*.\n- Condicional simple vs perfecto en estilo indirecto: *Dijo que vendría / habría venido*.\n\n## 5. Pluscuamperfecto vs indefinido\n- Pluscuamperfecto solo si otra referencia pasada lo exige; si no, usa indefinido: *Había terminado cuando llegaste*.\n- Narra en indefinido, reserva pluscuamperfecto para antecedentes necesarios.\n\n---\n\n> 📝 **Resumen:** Decide si el foco está en la culminación, el transcurso o la evidencia presente. Ajusta el tiempo para transmitir cortesía, hipótesis o contraste narrativo.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a27-indicative-contrasts-ex1",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "mcq",
+      "promptMd": "*Ayer ___ que la reunión se cancelaba.*",
+      "options": [
+        "supe",
+        "sabía",
+        "sé",
+        "sabría"
+      ],
+      "answer": "supe",
+      "feedback": {
+        "correct": "Correcto: supe = me enteré en ese momento puntual.",
+        "wrong": "Uso puntual de pasado → pretérito indefinido **supe**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "saber"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex2",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "cloze",
+      "promptMd": "Cuando era pequeño, ___ (ir) al pueblo cada verano.",
+      "answer": "iba",
+      "accepted": [
+        "re:^iba$"
+      ],
+      "feedback": {
+        "correct": "Correcto: hábito prolongado → imperfecto.",
+        "wrong": "Usa **iba** para hábito en la infancia."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "imperfecto hábito"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex3",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "cloze",
+      "promptMd": "En 2019 ___ (conocer) a Marta y nos hicimos amigos.",
+      "answer": "conocí",
+      "accepted": [
+        "re:^conocí$"
+      ],
+      "feedback": {
+        "correct": "Bien: evento puntual que cambia el estado → indefinido.",
+        "wrong": "La acción puntual usa **conocí**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "indefinido puntual"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex4",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "mcq",
+      "promptMd": "Selecciona la opción peninsular natural: *Este invierno ___ mucha nieve.*",
+      "options": [
+        "ha caído",
+        "cayó",
+        "caía",
+        "había caído"
+      ],
+      "answer": "ha caído",
+      "feedback": {
+        "correct": "Correcto: periodo aún vigente → pretérito perfecto.",
+        "wrong": "Se prefiere **ha caído** si el invierno no ha terminado."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "perfecto vs indefinido"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex5",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "cloze",
+      "promptMd": "Pensábamos que no ___ (poder) entrar, pero al final sí.",
+      "answer": "podíamos",
+      "accepted": [
+        "re:^podíamos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: expresa posibilidad considerada, no resultado logrado.",
+        "wrong": "Para capacidad o intención usa **podíamos**; *pudimos* implicaría éxito."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "poder"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex6",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "cloze",
+      "promptMd": "Mañana ___ (salir, yo) a las siete en punto.",
+      "answer": "salgo",
+      "accepted": [
+        "re:^salgo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: presente con valor programado.",
+        "wrong": "El horario fijo puede expresarse con presente simple: **salgo**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "presente futurizante"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex7",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "mcq",
+      "promptMd": "¿Qué expresa mejor conjetura sobre el presente?:",
+      "options": [
+        "Estará en casa",
+        "Estuvo en casa",
+        "Estaría en casa",
+        "Ha estado en casa"
+      ],
+      "answer": "Estará en casa",
+      "feedback": {
+        "correct": "Correcto: futuro simple con valor de probabilidad presente.",
+        "wrong": "Para conjetura actual usa **estará**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "futuro epistémico"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex8",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "cloze",
+      "promptMd": "Para entonces ya ___ (terminar, ellos) el proyecto, nos dijeron.",
+      "answer": "habrían terminado",
+      "accepted": [
+        "re:^habrían terminado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: futuro perfecto visto desde un pasado → condicional perfecto.",
+        "wrong": "Transmite futuro cumplido desde la perspectiva del pasado: **habrían terminado**."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "condicional perfecto"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex9",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "translate",
+      "promptMd": "Translate: **En 1810 nace Argentina como nación.** (efecto histórico)",
+      "answer": "In 1810 Argentina is born as a nation",
+      "accepted": [
+        "re:^in 1810 argentina is born as a nation\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: presente histórico dramático.",
+        "wrong": "Usa presente en inglés también si quieres efecto histórico."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "presente histórico"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex10",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "cloze",
+      "promptMd": "Para cuando llegaste, nosotros ya ___ (preparar) la cena.",
+      "answer": "habíamos preparado",
+      "accepted": [
+        "re:^habíamos preparado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: pasado anterior a otro pasado.",
+        "wrong": "Necesitas **habíamos preparado** (pluscuamperfecto)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "pluscuam"
+      }
+    },
+    {
+      "id": "a27-indicative-contrasts-ex11",
+      "lessonId": "a27-indicative-contrasts",
+      "type": "short",
+      "promptMd": "Explica el matiz entre *Quería pedirte un favor* y *Quiero pedirte un favor*.",
+      "answer": "El condicional o imperfecto suaviza la petición (cortesía); el presente suena directo/inmediato.",
+      "accepted": [
+        "re:suaviza",
+        "re:cortes[ií]a"
+      ],
+      "feedback": {
+        "correct": "Exacto: usar pasado/condicional mitiga la petición.",
+        "wrong": "Aclara que el pasado expresa cortesía o mitigación."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "cortesía"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a27-indicative-contrasts-fc1",
+      "front": "Indefinido vs imperfecto",
+      "back": "Evento cerrado vs fondo/hábito",
+      "tag": "aspecto",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc2",
+      "front": "Saber supo/sabía",
+      "back": "supe = enterarse; sabía = conocimiento previo",
+      "tag": "verbos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc3",
+      "front": "Perfecto peninsular",
+      "back": "Vínculo con presente: este mes he ido",
+      "tag": "perfecto",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc4",
+      "front": "Presente histórico",
+      "back": "Relata pasado con vividez: en 1492 llega...",
+      "tag": "presente",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc5",
+      "front": "Futuro epistémico",
+      "back": "Probabilidad: Estará en casa",
+      "tag": "futuro",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc6",
+      "front": "Condicional cortesía",
+      "back": "¿Podrías...? suaviza peticiones",
+      "tag": "cortesía",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc7",
+      "front": "Pluscuamperfecto",
+      "back": "Solo si hay pasado posterior que lo requiere",
+      "tag": "pluscuam",
+      "deck": "grammar"
+    },
+    {
+      "id": "a27-indicative-contrasts-fc8",
+      "front": "Poder pude/podía",
+      "back": "pude = logré; podía = tenía capacidad",
+      "tag": "verbos",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a28-subjunctive-sequence.json
+++ b/src/seed/a28-subjunctive-sequence.json
@@ -1,0 +1,335 @@
+{
+  "lessons": [
+    {
+      "id": "a28-subjunctive-sequence",
+      "level": "C1",
+      "title": "A28 — Subjunctive Sequencing & Concord",
+      "slug": "a28-subjunctive-sequence",
+      "tags": [
+        "subjunctive",
+        "sequence",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🌙 A28 — Subjunctive Sequencing & Concord\n\n**Goal:** Coordinar tiempos del subjuntivo con el eje temporal de la oración principal.\n\n---\n\n## 1. Secuencia básica\n- **Presente / futuro** en principal → subordinada en **presente** o **perfecto de subjuntivo** según anterioridad: *Espero que vengas / hayas venido*.\n- **Pasado** en principal → subordinada en **imperfecto** o **pluscuamperfecto de subjuntivo**: *Quería que vinieras / hubieras venido*.\n- Condicional simple suele combinar con imperfecto; condicional compuesto con pluscuam: *Me encantaría que vinieras / hubieras venido*.\n\n## 2. Simultaneidad vs anterioridad\n- Acción simultánea/posterior → presente/imperfecto: *Me alegra que estés aquí / Me alegraba que estuvieras aquí*.\n- Acción anterior → perfecto/pluscuamperfecto: *Lamento que hayas sufrido*; *Lamentaba que hubieras sufrido*.\n\n## 3. Conjunciones temporales\n- *Cuando, en cuanto, hasta que* + subjuntivo si refieren a futuro: *Cuando llegues, avisa*.\n- Si refieren al pasado real → indicativo: *Cuando llegó, avisó*.\n- *Antes de que* siempre subjuntivo; *después de que* depende de referencia temporal.\n\n## 4. Subordinadas adjetivas\n- Antecedente indefinido/negado → subjuntivo: *Busco a alguien que hable mandarín*.\n- Referente concreto → indicativo: *Conozco a la persona que habla mandarín*.\n\n## 5. Estilo indirecto\n- Si el hecho sigue vigente, puedes conservar presente de subj.: *Dijo que espera que llegues a tiempo*.\n- Para concordancia clásica, desplaza: *Dijo que esperaba que llegaras a tiempo*.\n\n---\n\n> 📝 **Resumen:** Identifica la relación temporal (simultánea/anterior) y la vigencia. Selecciona presente/perfecto o imperfecto/pluscuam según la distancia de la acción subordinada respecto al eje principal.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a28-subjunctive-sequence-ex1",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Quiero que tú ___ (venir) temprano.",
+      "answer": "vengas",
+      "accepted": [
+        "re:^vengas$"
+      ],
+      "feedback": {
+        "correct": "Correcto: presente principal → presente de subjuntivo.",
+        "wrong": "Usa **vengas** para simultaneidad."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "presente subj"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex2",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Quería que tú ___ (venir) temprano.",
+      "answer": "vinieras",
+      "accepted": [
+        "re:^vinieras$"
+      ],
+      "feedback": {
+        "correct": "Correcto: principal en pasado → imperfecto de subjuntivo.",
+        "wrong": "Usa **vinieras** en concordancia clásica."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "imperfecto subj"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex3",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Dudo que ellos ___ (haber terminar) el informe.",
+      "answer": "hayan terminado",
+      "accepted": [
+        "re:^hayan terminado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: duda en presente + acción acabada → perfecto de subjuntivo.",
+        "wrong": "Utiliza **hayan terminado** para anterioridad."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "perfecto subj"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex4",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "No creía que ellos ___ (haber terminar) tan rápido.",
+      "answer": "hubieran terminado",
+      "accepted": [
+        "re:^hubieran terminado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: pasado principal + anterioridad → pluscuamperfecto de subjuntivo.",
+        "wrong": "Usa **hubieran terminado**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "pluscuam subj"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex5",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Cuando ___ (llegar) avísame por mensaje.",
+      "answer": "llegues",
+      "accepted": [
+        "re:^llegues$"
+      ],
+      "feedback": {
+        "correct": "Correcto: referencia futura con cuando → subjuntivo.",
+        "wrong": "Usa **llegues** para futuro no realizado."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "cuando futuro"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex6",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "mcq",
+      "promptMd": "Escoge la opción correcta: *Antes de que ___, deja la llave en recepción.*",
+      "options": [
+        "sales",
+        "salgas",
+        "saliste",
+        "saldrás"
+      ],
+      "answer": "salgas",
+      "feedback": {
+        "correct": "Correcto: 'antes de que' siempre exige subjuntivo.",
+        "wrong": "Debe ir en subjuntivo: **salgas**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "antes de que"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex7",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Busco a alguien que ___ (saber) japonés.",
+      "answer": "sepa",
+      "accepted": [
+        "re:^sepa$"
+      ],
+      "feedback": {
+        "correct": "Correcto: antecedente indefinido → subjuntivo.",
+        "wrong": "Usa **sepa** porque la existencia no está asegurada."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "relativa indefinida"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex8",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Encontré a alguien que ___ (hablar) japonés perfectamente.",
+      "answer": "hablaba",
+      "accepted": [
+        "re:^hablaba$"
+      ],
+      "feedback": {
+        "correct": "Correcto: referente real identificado → indicativo imperfecto.",
+        "wrong": "Con antecedente real, usa indicativo: **hablaba**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "relativa definida"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex9",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "translate",
+      "promptMd": "Translate: **Me molesta que se hayan ido tan pronto.**",
+      "answer": "It bothers me that they have left so soon",
+      "accepted": [
+        "re:^it bothers me that they have left so soon\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: have left = se hayan ido (perfecto).",
+        "wrong": "Recuerda usar 'have left' para perfecto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "perfecto"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex10",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Ojalá ___ (llover) mañana.",
+      "answer": "llueva",
+      "accepted": [
+        "re:^llueva$"
+      ],
+      "feedback": {
+        "correct": "Correcto: deseo sobre futuro → presente de subjuntivo.",
+        "wrong": "Usa **llueva** tras ojalá + futuro próximo."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ojalá"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex11",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "Me habría gustado que tú ___ (venir) también.",
+      "answer": "hubieras venido",
+      "accepted": [
+        "re:^hubieras venido$"
+      ],
+      "feedback": {
+        "correct": "Correcto: condicional compuesto + anterioridad → pluscuamperfecto subj.",
+        "wrong": "Usa **hubieras venido**."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "condicional"
+      }
+    },
+    {
+      "id": "a28-subjunctive-sequence-ex12",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "short",
+      "promptMd": "¿Por qué *Cuando vino, avísame* es incorrecto?",
+      "answer": "Porque 'cuando vino' refiere a pasado real, pero la orden es futura; debe ser 'cuando vengas, avísame'.",
+      "accepted": [
+        "re:pasado real",
+        "re:vengas"
+      ],
+      "feedback": {
+        "correct": "Exacto: futuro → subjuntivo, no indefinido.",
+        "wrong": "Se necesita *cuando vengas* para evento futuro."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "cuando"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a28-subjunctive-sequence-fc1",
+      "front": "Presente principal",
+      "back": "→ presente/ perfecto de subjuntivo",
+      "tag": "presente",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc2",
+      "front": "Pasado principal",
+      "back": "→ imperfecto/ pluscuamperfecto de subj.",
+      "tag": "pasado",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc3",
+      "front": "Simultaneidad",
+      "back": "Presente vs imperfecto según eje",
+      "tag": "simultáneo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc4",
+      "front": "Anterioridad",
+      "back": "Perfecto / pluscuamperfecto de subj.",
+      "tag": "anterioridad",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc5",
+      "front": "Cuando + futuro",
+      "back": "Lleva subjuntivo (cuando llegues)",
+      "tag": "conjunciones",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc6",
+      "front": "Antes de que",
+      "back": "Siempre subjuntivo",
+      "tag": "antes",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc7",
+      "front": "Relativa indefinida",
+      "back": "Busco a alguien que + subj.",
+      "tag": "relativa",
+      "deck": "grammar"
+    },
+    {
+      "id": "a28-subjunctive-sequence-fc8",
+      "front": "Ojalá",
+      "back": "Usa subjuntivo (llueva, lloviera)",
+      "tag": "ojalá",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a29-imperatives-etiquette.json
+++ b/src/seed/a29-imperatives-etiquette.json
@@ -1,0 +1,298 @@
+{
+  "lessons": [
+    {
+      "id": "a29-imperatives-etiquette",
+      "level": "C1",
+      "title": "A29 — Imperatives & Etiquette",
+      "slug": "a29-imperatives-etiquette",
+      "tags": [
+        "imperatives",
+        "pragmatics",
+        "register",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🎩 A29 — Imperatives & Etiquette\n\n**Goal:** Modular comandos según relación social, grado de cortesía y registro.\n\n---\n\n## 1. Formas canónicas\n- Afirmativos: *tú haz*, *vosotros haced*, *usted haga*, *ustedes hagan*.\n- Negativos: siempre subjuntivo (*no hagas, no haga, no hagáis, no hagan*).\n- Vosotros reflexivo pierde la -d: *sentaos, idos* (formal *váyanse*).\n\n## 2. Cortesía y atenuación\n- Usa condicional / imperfecto: *Querría que me ayudara*, *¿Podrías cerrar la ventana?*.\n- Estructuras con *si* y presente: *Si puedes, envíame el informe* (invita, no ordena).\n- Añadir mitigadores: *por favor, si es tan amable, cuando pueda*.\n\n## 3. Mandatos indirectos\n- *Que + subjuntivo*: *Que pase el siguiente*, *Que no se mueva nadie*.\n- *Vamos a + infinitivo* (propuesta compartida), *No vamos a discutir* (decisión).  \n- *A + infinitivo* en registros coloquiales: *¡A comer!*.\n\n## 4. Registro institucional\n- Formularios: *Favor de llenar*, *Sírvase completar* (LatAm).\n- Correos formales: usa perífrasis (*Le agradecería que...*, *Ruego que...*).\n- Evita imperativo directo con superiores; opta por modalizaciones.\n\n## 5. Secuenciación y tono\n- Alterna directividad: instrucción clara seguida de justificación: *Complete el formulario para agilizar el proceso*.\n- Añade cierre amable: *Muchas gracias por su colaboración*.\n\n---\n\n> 📝 **Resumen:** Escoge la forma verbal según distancia social. Los recursos modales (condicional, *si*, *que + subj*) permiten ordenar sin sonar brusco.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a29-imperatives-etiquette-ex1",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "cloze",
+      "promptMd": "Por favor, ___ (sentarse, usted) aquí.",
+      "answer": "siéntese",
+      "accepted": [
+        "re:^siéntese$"
+      ],
+      "feedback": {
+        "correct": "Correcto: imperativo formal afirmativo con pronombre pospuesto.",
+        "wrong": "Use **siéntese** para usted."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "imperativo usted"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex2",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "cloze",
+      "promptMd": "No ___ (salir, ustedes) sin casco.",
+      "answer": "salgan",
+      "accepted": [
+        "re:^salgan$"
+      ],
+      "feedback": {
+        "correct": "Correcto: negativo → subjuntivo.",
+        "wrong": "Usa **salgan** en negativos formales."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "negativo"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex3",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "mcq",
+      "promptMd": "Selecciona la opción más cortés para un correo profesional.",
+      "options": [
+        "Envíeme el informe ya.",
+        "Le agradecería que me enviara el informe.",
+        "Mandé el informe, por favor.",
+        "Me envía el informe."
+      ],
+      "answer": "Le agradecería que me enviara el informe.",
+      "feedback": {
+        "correct": "Correcto: perífrasis condicional suaviza la petición.",
+        "wrong": "Escoge la fórmula con condicional + que."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "cortesía"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex4",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "cloze",
+      "promptMd": "Que ___ (pasar) el siguiente, por favor.",
+      "answer": "pase",
+      "accepted": [
+        "re:^pase$"
+      ],
+      "feedback": {
+        "correct": "Correcto: que + subjuntivo para mandato impersonal.",
+        "wrong": "Usa **pase**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "que + subj"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex5",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "translate",
+      "promptMd": "Translate: **No nos pongamos nerviosos.**",
+      "answer": "Let's not get nervous",
+      "accepted": [
+        "re:^let's not get nervous\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: imperativo de primera plural negativo → let's not...",
+        "wrong": "Usa 'let's not' para equivaler a 'no nos pongamos'."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "imperativo nosotros"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex6",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "cloze",
+      "promptMd": "Favor de ___ (llenar) el formulario en mayúsculas.",
+      "answer": "llenar",
+      "accepted": [
+        "re:^llenar$"
+      ],
+      "feedback": {
+        "correct": "Correcto: construcción fija 'favor de + infinitivo'.",
+        "wrong": "Se mantiene el infinitivo: **llenar**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "favor de"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex7",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "cloze",
+      "promptMd": "Si puedes, ___ (enviar, tú) el documento hoy.",
+      "answer": "envía",
+      "accepted": [
+        "re:^envía$"
+      ],
+      "feedback": {
+        "correct": "Correcto: condicional con *si puedes* mantiene imperativo atenuado.",
+        "wrong": "Se usa imperativo directo tras la condicional de cortesía: **envía**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "si + imperativo"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex8",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "mcq",
+      "promptMd": "¿Cuál suena más formal para cerrar una reunión?",
+      "options": [
+        "Váyanse ya.",
+        "Les ruego que se retiren.",
+        "Idos de aquí.",
+        "Fuera."
+      ],
+      "answer": "Les ruego que se retiren.",
+      "feedback": {
+        "correct": "Correcto: ruego + subjuntivo expresa deferencia.",
+        "wrong": "Elige la opción con ruego, no imperativos bruscos."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "registro"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex9",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "cloze",
+      "promptMd": "___ (Ir, nosotros) cerrando el acta.",
+      "answer": "Vamos",
+      "accepted": [
+        "re:^Vamos$",
+        "re:^vamos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: vamos + gerundio indica sugerencia compartida.",
+        "wrong": "Usa **vamos** para propuesta inclusiva."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "vamos + gerundio"
+      }
+    },
+    {
+      "id": "a29-imperatives-etiquette-ex10",
+      "lessonId": "a29-imperatives-etiquette",
+      "type": "short",
+      "promptMd": "¿Qué efecto tiene añadir *cuando pueda* a un mandato?",
+      "answer": "Reduce la imposición; deja libertad temporal y suena más cortés.",
+      "accepted": [
+        "re:reduce",
+        "re:cort[eé]s"
+      ],
+      "feedback": {
+        "correct": "Exacto: mitiga la orden y muestra deferencia.",
+        "wrong": "Explica que suaviza la orden y respeta tiempo del interlocutor."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "mitigadores"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a29-imperatives-etiquette-fc1",
+      "front": "Imperativo formal",
+      "back": "hable, coman, siéntese",
+      "tag": "formas",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc2",
+      "front": "Negativos",
+      "back": "Siempre subjuntivo: no hagas, no hagan",
+      "tag": "negativos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc3",
+      "front": "Condicional cortés",
+      "back": "¿Podría/Podrías...?",
+      "tag": "cortesía",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc4",
+      "front": "Si + presente",
+      "back": "Si puede, confirme mañana (petición suave)",
+      "tag": "mitigadores",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc5",
+      "front": "Que + subj.",
+      "back": "Que pase el siguiente (mandato impersonal)",
+      "tag": "que",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc6",
+      "front": "Favor de + inf.",
+      "back": "Registro administrativo latinoamericano",
+      "tag": "registro",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc7",
+      "front": "Vamos a / vamos + gerundio",
+      "back": "Propuesta inclusiva sin imponer",
+      "tag": "nosotros",
+      "deck": "grammar"
+    },
+    {
+      "id": "a29-imperatives-etiquette-fc8",
+      "front": "Cierre amable",
+      "back": "Gracias por su colaboración → suaviza órdenes",
+      "tag": "cierre",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a30-periphrasis-nuance.json
+++ b/src/seed/a30-periphrasis-nuance.json
@@ -1,0 +1,316 @@
+{
+  "lessons": [
+    {
+      "id": "a30-periphrasis-nuance",
+      "level": "C1",
+      "title": "A30 — Periphrasis & Aspectual Nuance",
+      "slug": "a30-periphrasis-nuance",
+      "tags": [
+        "periphrasis",
+        "aspect",
+        "modality",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🔄 A30 — Periphrasis & Aspectual Nuance\n\n**Goal:** Usar perífrasis verbales para expresar matices de duración, intención, obligación y resultado.\n\n---\n\n## 1. Duración y progresión\n- **Estar + gerundio** = acción en curso puntual.\n- **Llevar + gerundio** = duración acumulada: *Llevo estudiando tres horas*.\n- **Ir/venir/andar + gerundio** aportan progresión, reiteración o dispersión: *Anda diciendo*, *Vamos mejorando*.\n\n## 2. Inminencia y planes\n- **Ir a + inf.** (plan inmediato), **estar a punto de + inf.** (inminencia), **estar por + inf.** (intención pendiente).\n- **Acabar de + inf.** = pasado inmediato; **acabar por + inf.** = desenlace tras resistencia.\n\n## 3. Obligación y probabilidad\n- **Deber + inf.** obligación fuerte; **tener que + inf.** obligación externa.\n- **Deber de + inf.** probabilidad: *Debe de ser tarde*.\n- **Haber de + inf.** registro formal / destino.\n\n## 4. Resultado y hábito\n- **Tener + participio** resalta resultado mantenido: *Tiene escrita la carta*.\n- **Llevar + participio** suma cantidades: *Llevan vendidos 500 ejemplares*.\n- **Soler + inf.** marca hábito consolidado.\n\n## 5. Perífrasis lexicalizadas\n- **Venir a + inf.** ≈ aproximadamente: *Vino a costar 200 €*.\n- **Volver a + inf.** repetición; **terminar + gerundio** resultado progresivo.\n\n---\n\n> 📝 **Resumen:** Escoge perífrasis para situar la acción en el tiempo (duración, hábito), describir intención, valorar obligación o enfatizar resultados.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a30-periphrasis-nuance-ex1",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Llevo dos horas ___ (esperar) la llamada.",
+      "answer": "esperando",
+      "accepted": [
+        "re:^esperando$"
+      ],
+      "feedback": {
+        "correct": "Correcto: llevar + gerundio indica duración acumulada.",
+        "wrong": "Usa **esperando** tras llevar."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "llevar + gerundio"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex2",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Anda ___ (buscar) piso por el centro.",
+      "answer": "buscando",
+      "accepted": [
+        "re:^buscando$"
+      ],
+      "feedback": {
+        "correct": "Correcto: andar + gerundio = acción dispersa/reiterada.",
+        "wrong": "Emplea gerundio: **buscando**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "andar + gerundio"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex3",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Estoy por ___ (llamar) a la policía.",
+      "answer": "llamar",
+      "accepted": [
+        "re:^llamar$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estar por + inf. = intención pendiente.",
+        "wrong": "Mantén infinitivo: **llamar**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar por"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex4",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Acabó por ___ (aceptar) la propuesta.",
+      "answer": "aceptar",
+      "accepted": [
+        "re:^aceptar$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acabar por + inf. marca desenlace tras resistencia.",
+        "wrong": "Usa infinitivo: **aceptar**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "acabar por"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex5",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Debe de ___ (ser) la una.",
+      "answer": "ser",
+      "accepted": [
+        "re:^ser$"
+      ],
+      "feedback": {
+        "correct": "Correcto: deber de + inf. → probabilidad.",
+        "wrong": "Usa **ser** con 'debe de'."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "deber de"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex6",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "mcq",
+      "promptMd": "¿Cuál resalta mejor la mejora progresiva?",
+      "options": [
+        "Estamos mejorando",
+        "Vamos mejorando",
+        "Mejoramos",
+        "Solemos mejorar"
+      ],
+      "answer": "Vamos mejorando",
+      "feedback": {
+        "correct": "Correcto: ir + gerundio enfatiza progresión gradual.",
+        "wrong": "Elige **vamos mejorando** para avance paulatino."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "ir + gerundio"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex7",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "translate",
+      "promptMd": "Translate: **Tiene el informe hecho.**",
+      "answer": "He/She has the report done",
+      "accepted": [
+        "re:^(he|she) has the report done\\.?$",
+        "re:^has the report done\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: tener + participio subraya resultado vigente.",
+        "wrong": "Expresa resultado con 'has ... done'."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "tener + participio"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex8",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Suele ___ (llegar) tarde los lunes.",
+      "answer": "llegar",
+      "accepted": [
+        "re:^llegar$"
+      ],
+      "feedback": {
+        "correct": "Correcto: soler + infinitivo marca hábito.",
+        "wrong": "Emplea infinitivo: **llegar**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "soler"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex9",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Venimos ___ (decir) que el sistema necesita ajustes.",
+      "answer": "diciendo",
+      "accepted": [
+        "re:^diciendo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: venir + gerundio indica insistencia acumulada.",
+        "wrong": "Usa gerundio: **diciendo**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "venir + gerundio"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex10",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "short",
+      "promptMd": "¿Diferencia pragmática entre *debo terminarlo* y *debo de terminarlo*?",
+      "answer": "'Debo terminarlo' expresa obligación; 'debo de terminarlo' expresa suposición/probabilidad.",
+      "accepted": [
+        "re:obligaci[oó]n",
+        "re:probabil"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'de' cambia a matiz de conjetura.",
+        "wrong": "Aclara: sin 'de' = obligación; con 'de' = probabilidad."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "deber"
+      }
+    },
+    {
+      "id": "a30-periphrasis-nuance-ex11",
+      "lessonId": "a30-periphrasis-nuance",
+      "type": "cloze",
+      "promptMd": "Terminó ___ (trabajar) de noche para cumplir el plazo.",
+      "answer": "trabajando",
+      "accepted": [
+        "re:^trabajando$"
+      ],
+      "feedback": {
+        "correct": "Correcto: terminar + gerundio resalta el modo del desenlace.",
+        "wrong": "Usa gerundio: **trabajando**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "terminar + gerundio"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a30-periphrasis-nuance-fc1",
+      "front": "Llevar + gerundio",
+      "back": "Duración acumulada (Llevo estudiando...)",
+      "tag": "duración",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc2",
+      "front": "Andar/Venir + gerundio",
+      "back": "Acción reiterada o insistente",
+      "tag": "progresión",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc3",
+      "front": "Estar por",
+      "back": "Intención pendiente (Estoy por llamar)",
+      "tag": "intención",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc4",
+      "front": "Acabar de / acabar por",
+      "back": "Pasado inmediato vs desenlace tras resistencia",
+      "tag": "acabar",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc5",
+      "front": "Deber vs deber de",
+      "back": "Obligación fuerte vs probabilidad",
+      "tag": "modalidad",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc6",
+      "front": "Tener + participio",
+      "back": "Resultado mantenido (Tiene preparado...)",
+      "tag": "resultado",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc7",
+      "front": "Soler + inf.",
+      "back": "Marca hábito estable",
+      "tag": "hábito",
+      "deck": "grammar"
+    },
+    {
+      "id": "a30-periphrasis-nuance-fc8",
+      "front": "Venir a + inf.",
+      "back": "Valor aproximativo (Vino a costar...)",
+      "tag": "aproximación",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a31-ser-estar-advanced.json
+++ b/src/seed/a31-ser-estar-advanced.json
@@ -1,0 +1,339 @@
+{
+  "lessons": [
+    {
+      "id": "a31-ser-estar-advanced",
+      "level": "C1",
+      "title": "A31 — Ser vs Estar: Advanced Nuance",
+      "slug": "a31-ser-estar-advanced",
+      "tags": [
+        "ser",
+        "estar",
+        "copulas",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🧭 A31 — Ser vs Estar: Advanced Nuance\n\n**Goal:** Elegir la cópula según significado léxico, registro y efecto pragmático.\n\n---\n\n## 1. Adjetivos con doble lectura\n- *ser aburrido* = produce aburrimiento; *estar aburrido* = se aburre.\n- *ser listo* = inteligente; *estar listo* = preparado.\n- *ser atento* = cortés; *estar atento* = prestar atención.\n- *ser bueno* = buena persona/calidad; *estar bueno* = sabroso / atractivo / recuperado.\n\n## 2. Participios\n- **Ser + participio** = voz pasiva (agente opcional): *La carta fue enviada por Ana*.\n- **Estar + participio** = resultado/estado: *La carta está enviada*.\n- Con adjetivos de cambio de estado: *está roto, está abierto*.\n\n## 3. Localización vs eventos\n- *Estar* indica ubicación física: *La cafetera está en la cocina*.\n- *Ser* sitúa eventos: *La boda es en la catedral*.\n- En registros coloquiales se admite *ser* con localización enfática (*Eso es en México*), pero norma prefiere *estar*.\n\n## 4. Expresiones idiomáticas\n- *Estar por + inf.* intención pendiente; *estar para + inf.* disponibilidad/ánimo (*No estoy para bromas*).\n- *Estar de + sustantivo* = función temporal: *Está de camarera*.\n- *Ser de* = pertenencia, origen, material: *Es de Madrid, es de madera*.\n\n## 5. Evaluación subjetiva\n- *Estar + adjetivo* enfatiza percepción personal momentánea: *El café está riquísimo hoy*.\n- *Ser + adjetivo* aporta rasgo definitorio: *El café es amargo* (por naturaleza).\n\n---\n\n> 📝 **Resumen:** Determina si describes esencia, resultado, ubicación o percepción momentánea. Cambiar de *ser* a *estar* altera radicalmente la interpretación.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a31-ser-estar-advanced-ex1",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "La conferencia ___ en el auditorio principal.",
+      "answer": "es",
+      "accepted": [
+        "re:^es$"
+      ],
+      "feedback": {
+        "correct": "Correcto: eventos usan *ser* para ubicar.",
+        "wrong": "Usa **es** para eventos (no *está*)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "eventos"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex2",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "El informe ya ___ enviado; revisa la bandeja.",
+      "answer": "está",
+      "accepted": [
+        "re:^está$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estado resultante → estar + participio.",
+        "wrong": "Se usa **está enviado** para resultado, no *es enviado*."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar participio"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex3",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "mcq",
+      "promptMd": "Completa: *María ___ muy lista; siempre resuelve problemas.*",
+      "options": [
+        "está",
+        "es",
+        "estuvo",
+        "era"
+      ],
+      "answer": "es",
+      "feedback": {
+        "correct": "Correcto: rasgo permanente → ser lista = inteligente.",
+        "wrong": "Se usa **es** para cualidad inherente."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "adjetivos"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex4",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "Hoy Juan ___ aburrido en clase.",
+      "answer": "está",
+      "accepted": [
+        "re:^está$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estado momentáneo → estar aburrido.",
+        "wrong": "Temporalidad requiere **está**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estado"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex5",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "La novela ___ aburrida; no la recomiendo.",
+      "answer": "es",
+      "accepted": [
+        "re:^es$"
+      ],
+      "feedback": {
+        "correct": "Correcto: valoración inherente del texto → ser aburrida.",
+        "wrong": "Usa **es** para característica permanente."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "característica"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex6",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "mcq",
+      "promptMd": "Escoge la combinación correcta:",
+      "options": [
+        "Es atento a la conferencia (presta atención)",
+        "Está atento con los clientes (cortés)",
+        "Es atento con los clientes (cortés)",
+        "Está atento a los clientes (cortés permanente)"
+      ],
+      "answer": "Es atento con los clientes (cortés)",
+      "feedback": {
+        "correct": "Correcto: ser atento = ser cortés; estar atento = prestar atención.",
+        "wrong": "Recuerda: ser atento = amable; estar atento = poner atención."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "adjetivos"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex7",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "translate",
+      "promptMd": "Translate: **La puerta está cerrada.**",
+      "answer": "The door is closed",
+      "accepted": [
+        "re:^the door is closed\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estado resultante.",
+        "wrong": "Usa 'is closed'."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "estar participio"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex8",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "Está de ___ (camarero) este verano en la costa.",
+      "answer": "camarero",
+      "accepted": [
+        "re:^camarero$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estar de + profesión temporal.",
+        "wrong": "Emplea **estar de camarero** para trabajo temporal."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar de"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex9",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "Somos de Valencia y nuestros padres ___ de allí también.",
+      "answer": "son",
+      "accepted": [
+        "re:^son$"
+      ],
+      "feedback": {
+        "correct": "Correcto: origen → ser de.",
+        "wrong": "Usa **son** para origen permanente."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ser de"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex10",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "El museo ___ abierto los domingos por la tarde.",
+      "answer": "está",
+      "accepted": [
+        "re:^está$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estado de apertura (resultado).",
+        "wrong": "Usa **está** para estado operativo."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "estado"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex11",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "short",
+      "promptMd": "¿Cuándo preferimos *ser + participio* frente a *estar + participio*?",
+      "answer": "Cuando queremos voz pasiva con agente (la carta fue enviada por Ana); *estar* describe el resultado sin agente.",
+      "accepted": [
+        "re:voz pasiva",
+        "re:agente"
+      ],
+      "feedback": {
+        "correct": "Exacto: ser + participio forma pasiva con agente expreso/implícito.",
+        "wrong": "Aclara que *ser* construye pasiva con agente."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "pasiva"
+      }
+    },
+    {
+      "id": "a31-ser-estar-advanced-ex12",
+      "lessonId": "a31-ser-estar-advanced",
+      "type": "cloze",
+      "promptMd": "No ___ para bromas después de lo que pasó.",
+      "answer": "estoy",
+      "accepted": [
+        "re:^estoy$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estar para + sustantivo → disposición/ánimo.",
+        "wrong": "Usa **estoy** (estar para)."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar para"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a31-ser-estar-advanced-fc1",
+      "front": "Ser aburrido / estar aburrido",
+      "back": "causa aburrimiento vs sentirse aburrido",
+      "tag": "adjetivos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc2",
+      "front": "Ser listo / estar listo",
+      "back": "inteligente vs preparado",
+      "tag": "adjetivos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc3",
+      "front": "Ser atento / estar atento",
+      "back": "cortés vs prestar atención",
+      "tag": "adjetivos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc4",
+      "front": "Ser + participio",
+      "back": "voz pasiva (fue firmado)",
+      "tag": "pasiva",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc5",
+      "front": "Estar + participio",
+      "back": "estado resultante (está firmado)",
+      "tag": "resultado",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc6",
+      "front": "Ser de / estar en",
+      "back": "origen vs ubicación física",
+      "tag": "localización",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc7",
+      "front": "Estar para / estar por",
+      "back": "ánimo vs intención pendiente",
+      "tag": "perífrasis",
+      "deck": "grammar"
+    },
+    {
+      "id": "a31-ser-estar-advanced-fc8",
+      "front": "Estar de + oficio",
+      "back": "función temporal (está de recepcionista)",
+      "tag": "temporal",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a32-por-para-advanced.json
+++ b/src/seed/a32-por-para-advanced.json
@@ -1,0 +1,340 @@
+{
+  "lessons": [
+    {
+      "id": "a32-por-para-advanced",
+      "level": "C1",
+      "title": "A32 — Por vs Para: Advanced Uses",
+      "slug": "a32-por-para-advanced",
+      "tags": [
+        "por",
+        "para",
+        "prepositions",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🔀 A32 — Por vs Para: Advanced Uses\n\n**Goal:** Elegir *por* o *para* según causa, finalidad, perspectiva y expresiones idiomáticas.\n\n---\n\n## 1. Finalidad vs causa\n- **Para** indica objetivo/destino: *Carta para Marta, estudiar para aprobar*.\n- **Por** marca causa, motivo o agente: *Lo hice por ti, Fue premiado por su labor*.\n\n## 2. Trayecto vs destino\n- **Por** = a través de, alrededor de: *Pasamos por Madrid*.\n- **Para** = hacia un destino final: *Salimos para Madrid*.\n- Duración aproximada → por (*por tres horas*); fecha límite → para (*para el lunes*).\n\n## 3. Sustitución e intercambio\n- **Por** expresa cambio: *Te cambio mi turno por el tuyo*.\n- **Para** asigna beneficiario/empleador: *Trabajo para una ONG*.\n\n## 4. Valoraciones y perspectiva\n- **Para + sujeto** = juicio desde punto de vista: *Para mí, es tarde*.\n- **Para + ser** introduce contraste: *Para ser lunes, hay buen ambiente*.\n- **Por + infinitivo** = causa/razón: *Por llegar tarde, perdió el tren*.\n\n## 5. Locuciones fijas\n- Por si acaso, por lo visto, por poco, por completo.\n- Para entonces, para colmo, para variar, para siempre.\n- *Estar para* (disposición) vs *estar por* (intención pendiente).\n\n---\n\n> 📝 **Resumen:** Pregunta si enfocas el destino/beneficiario (para) o la causa, medio o intercambio (por). Atiende locuciones fijas que fijan la elección.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a32-por-para-advanced-ex1",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Este informe es ___ la dirección general.",
+      "answer": "para",
+      "accepted": [
+        "re:^para$"
+      ],
+      "feedback": {
+        "correct": "Correcto: destinatario → para.",
+        "wrong": "Usa **para** para indicar receptor."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "destinatario"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex2",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Lo hice ___ ti porque estabas enfermo.",
+      "answer": "por",
+      "accepted": [
+        "re:^por$"
+      ],
+      "feedback": {
+        "correct": "Correcto: motivo o causa → por.",
+        "wrong": "Emplea **por** para causa."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "causa"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex3",
+      "lessonId": "a32-por-para-advanced",
+      "type": "mcq",
+      "promptMd": "Elegir la opción correcta: *Cambiamos euros ___ dólares.*",
+      "options": [
+        "para",
+        "por",
+        "a",
+        "en"
+      ],
+      "answer": "por",
+      "feedback": {
+        "correct": "Correcto: intercambio → por.",
+        "wrong": "El intercambio se expresa con **por**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "intercambio"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex4",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Pasaremos ___ Madrid de camino a Zaragoza.",
+      "answer": "por",
+      "accepted": [
+        "re:^por$"
+      ],
+      "feedback": {
+        "correct": "Correcto: trayecto intermedio → por.",
+        "wrong": "Usa **por Madrid** cuando es paso intermedio."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "trayecto"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex5",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Necesito el informe ___ el viernes a más tardar.",
+      "answer": "para",
+      "accepted": [
+        "re:^para$"
+      ],
+      "feedback": {
+        "correct": "Correcto: fecha límite → para.",
+        "wrong": "Usa **para** para plazos."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "plazo"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex6",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Fue escrito ___ Borges en 1944.",
+      "answer": "por",
+      "accepted": [
+        "re:^por$"
+      ],
+      "feedback": {
+        "correct": "Correcto: agente de pasiva → por.",
+        "wrong": "Usa **por** para agente."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "agente"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex7",
+      "lessonId": "a32-por-para-advanced",
+      "type": "translate",
+      "promptMd": "Translate: **Cambiaron euros por dólares.**",
+      "answer": "They exchanged euros for dollars",
+      "accepted": [
+        "re:^they exchanged euros for dollars\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: exchange = for.",
+        "wrong": "Expresa intercambio con 'for'."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "intercambio"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex8",
+      "lessonId": "a32-por-para-advanced",
+      "type": "mcq",
+      "promptMd": "¿Qué locución expresa 'just in case'?",
+      "options": [
+        "para entonces",
+        "por si acaso",
+        "por lo visto",
+        "para colmo"
+      ],
+      "answer": "por si acaso",
+      "feedback": {
+        "correct": "Correcto: por si acaso = just in case.",
+        "wrong": "La locución correcta es **por si acaso**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "locuciones"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex9",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Está ___ salir, así que no lo entretengas.",
+      "answer": "para",
+      "accepted": [
+        "re:^para$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estar para = a punto/dispuesto.",
+        "wrong": "Usa **para** (estar para salir)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar para"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex10",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "Estamos ___ aprobar la propuesta, solo falta la firma.",
+      "answer": "por",
+      "accepted": [
+        "re:^por$"
+      ],
+      "feedback": {
+        "correct": "Correcto: estar por + inf. = intención pendiente.",
+        "wrong": "Usa **por** (estar por hacer)."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar por"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex11",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "___ ser un principiante, toca muy bien el piano.",
+      "answer": "Para",
+      "accepted": [
+        "re:^Para$",
+        "re:^para$"
+      ],
+      "feedback": {
+        "correct": "Correcto: para ser = comparación con expectativa.",
+        "wrong": "Usa **para ser** para contraste."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "para ser"
+      }
+    },
+    {
+      "id": "a32-por-para-advanced-ex12",
+      "lessonId": "a32-por-para-advanced",
+      "type": "short",
+      "promptMd": "¿Diferencia entre *para + infinitivo* y *por + infinitivo*?",
+      "answer": "Para + inf. indica finalidad (para ahorrar); por + inf. indica causa/motivo (por ahorrar, no viajó).",
+      "accepted": [
+        "re:finalidad",
+        "re:causa"
+      ],
+      "feedback": {
+        "correct": "Correcto: para = propósito; por = motivo causa.",
+        "wrong": "Aclara: para + inf. objetivo; por + inf. causa."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "infinitivo"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a32-por-para-advanced-fc1",
+      "front": "Para = destino",
+      "back": "Destinatario, propósito, deadline",
+      "tag": "destino",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc2",
+      "front": "Por = causa",
+      "back": "Motivo, agente, gracias a",
+      "tag": "causa",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc3",
+      "front": "Por = trayecto",
+      "back": "por Madrid, por el parque",
+      "tag": "trayecto",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc4",
+      "front": "Para = punto de vista",
+      "back": "Para mí, para ser...",
+      "tag": "perspectiva",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc5",
+      "front": "Por = intercambio",
+      "back": "Pagué 20€ por el libro",
+      "tag": "intercambio",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc6",
+      "front": "Estar para / estar por",
+      "back": "disposición vs intención pendiente",
+      "tag": "perífrasis",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc7",
+      "front": "Locuciones por",
+      "back": "por si acaso, por lo visto, por poco",
+      "tag": "locuciones",
+      "deck": "grammar"
+    },
+    {
+      "id": "a32-por-para-advanced-fc8",
+      "front": "Locuciones para",
+      "back": "para entonces, para colmo, para variar",
+      "tag": "locuciones",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a33-clauses-advanced.json
+++ b/src/seed/a33-clauses-advanced.json
@@ -1,0 +1,336 @@
+{
+  "lessons": [
+    {
+      "id": "a33-clauses-advanced",
+      "level": "C1",
+      "title": "A33 — Complex Clauses & Subordination",
+      "slug": "a33-clauses-advanced",
+      "tags": [
+        "clauses",
+        "subordination",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🧩 A33 — Complex Clauses & Subordination\n\n**Goal:** Dominar las cláusulas nominales, relativas y adverbiales que estructuran el discurso académico.\n\n---\n\n## 1. Cláusulas nominales\n- Funcionan como sujeto/objeto: *Que vengas me alegra; Dijo que vendría*.\n- Modo depende del verbo matriz (certeza → indicativo; duda/voluntad → subjuntivo).\n- Infinitivo reduce subordinación: *Decidió acudir* vs *Decidió que acudiría*.\n\n## 2. Cláusulas relativas\n- Especificativas sin comas; explicativas con comas.\n- Antecedente indefinido → subjuntivo (*busco a alguien que aporte*).\n- Recursos avanzados: **cuyo/a/os/as** (posesión), **el/la cual**, **quien**, **lo cual** para referencias complejas.\n\n## 3. Cláusulas adverbiales\n- Temporales: *Cuando*, *en cuanto*, *mientras* (indicativo o subj. según proyección).\n- Causales: *porque*, *puesto que*, *dado que*.  \n- Finales: *para que* + subj., *a fin de que*.\n- Concesivas: *aunque, aun cuando, por más que* (modo según realidad).\n- Condicionales: *siempre que*, *a menos que*, *con tal de que* (subjuntivo).\n\n## 4. Encadenar cláusulas\n- Usa conectores para jerarquizar ideas: *mientras que* (contraste), *de modo que* (consecuencia), *sin que* (excluye).\n- Evita ambigüedades con pronombres claros (*lo cual* retoma toda la oración previa).\n- Alterna infinitivos/gerundios para evitar exceso de *que*.\n\n---\n\n> 📝 **Resumen:** Decide la función de la subordinada (sujeto, adjetivo, adverbio) y aplica el modo/conector apropiado para expresar contraste, condición o finalidad con precisión.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a33-clauses-advanced-ex1",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Busco un equipo que ___ (saber) reaccionar bajo presión.",
+      "answer": "sepa",
+      "accepted": [
+        "re:^sepa$"
+      ],
+      "feedback": {
+        "correct": "Correcto: antecedente indefinido → subjuntivo.",
+        "wrong": "Usa **sepa** al no conocer al equipo aún."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "relativa subj"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex2",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Los resultados, ___ publicación se retrasó, generaron debate.",
+      "answer": "cuya",
+      "accepted": [
+        "re:^cuya$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'cuyo/a' indica posesión (publicación de los resultados).",
+        "wrong": "Usa **cuya** con el sustantivo 'publicación'."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "cuyo"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex3",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "El informe, ___ mencionaste ayer, está listo.",
+      "answer": "que",
+      "accepted": [
+        "re:^que$",
+        "re:^el que$"
+      ],
+      "feedback": {
+        "correct": "Correcto: pronombre relativo en cláusula explicativa.",
+        "wrong": "Puedes usar **que** (o 'el que' en registros formales)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "relativa explicativa"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex4",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Aunque ___ (llover), celebraremos el acto.",
+      "answer": "llueva",
+      "accepted": [
+        "re:^llueva$"
+      ],
+      "feedback": {
+        "correct": "Correcto: concesiva con hecho hipotético → subjuntivo.",
+        "wrong": "Usa **llueva** para eventualidad."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "concesiva"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex5",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "No participaré a menos que ___ (tener) datos suficientes.",
+      "answer": "tenga",
+      "accepted": [
+        "re:^tenga$"
+      ],
+      "feedback": {
+        "correct": "Correcto: a menos que + subjuntivo.",
+        "wrong": "Usa **tenga** tras 'a menos que'."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "condicional"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex6",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Estudia para que ___ (poder, tú) optar a la beca.",
+      "answer": "puedas",
+      "accepted": [
+        "re:^puedas$"
+      ],
+      "feedback": {
+        "correct": "Correcto: finalidad + subjuntivo.",
+        "wrong": "Usa **puedas** con para que."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "final"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex7",
+      "lessonId": "a33-clauses-advanced",
+      "type": "translate",
+      "promptMd": "Translate: **En cuanto termine la reunión, envíame el resumen.**",
+      "answer": "As soon as the meeting ends/has ended, send me the summary",
+      "accepted": [
+        "re:^as soon as the meeting (ends|has ended), send me the summary\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: en cuanto + subjuntivo para futuro.",
+        "wrong": "Incluye 'as soon as' para en cuanto."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "temporal"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex8",
+      "lessonId": "a33-clauses-advanced",
+      "type": "mcq",
+      "promptMd": "Selecciona la opción que expresa contraste correcto:",
+      "options": [
+        "Mientras estudias, yo cocino.",
+        "Mientras que estudias, cocino yo.",
+        "Mientras estudias, cocino yo.",
+        "Mientras cocines, cocino yo."
+      ],
+      "answer": "Mientras que estudias, cocino yo.",
+      "feedback": {
+        "correct": "Correcto: 'mientras que' introduce contraste entre acciones.",
+        "wrong": "Busca 'mientras que' para contraponer acciones simultáneas."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "mientras que"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex9",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Lo que más me preocupa es que ___ (perder, nosotros) credibilidad.",
+      "answer": "perdamos",
+      "accepted": [
+        "re:^perdamos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: nominal objeto de preocupación → subjuntivo.",
+        "wrong": "Usa **perdamos** (temor)."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "nominal"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex10",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Dado que ___ (ser) festivo, la oficina permanecerá cerrada.",
+      "answer": "es",
+      "accepted": [
+        "re:^es$"
+      ],
+      "feedback": {
+        "correct": "Correcto: causa real → indicativo.",
+        "wrong": "Con dado que se usa indicativo cuando la causa es cierta."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "causal"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex11",
+      "lessonId": "a33-clauses-advanced",
+      "type": "short",
+      "promptMd": "¿Diferencia entre *mientras* y *mientras que*?",
+      "answer": "'Mientras' expresa simultaneidad; 'mientras que' introduce contraste u oposición entre dos proposiciones.",
+      "accepted": [
+        "re:simultaneidad",
+        "re:contraste"
+      ],
+      "feedback": {
+        "correct": "Correcto: mientras = during; mientras que = whereas.",
+        "wrong": "Explica simultaneidad vs contraste."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "conectores"
+      }
+    },
+    {
+      "id": "a33-clauses-advanced-ex12",
+      "lessonId": "a33-clauses-advanced",
+      "type": "cloze",
+      "promptMd": "Sin que nadie ___ (notar), salieron de la sala.",
+      "answer": "lo notara",
+      "accepted": [
+        "re:^lo notara$"
+      ],
+      "feedback": {
+        "correct": "Correcto: sin que + subjuntivo para ausencia de acción.",
+        "wrong": "Usa **lo notara** tras sin que."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "sin que"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a33-clauses-advanced-fc1",
+      "front": "Cláusulas nominales",
+      "back": "Funcionan como sujeto/objeto: que vengas me alegra",
+      "tag": "nominal",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc2",
+      "front": "Modo en nominales",
+      "back": "certeza→indicativo; duda/voluntad→subjuntivo",
+      "tag": "modo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc3",
+      "front": "Relativas con cuyo",
+      "back": "expresan posesión (autor cuya obra...) ",
+      "tag": "relativa",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc4",
+      "front": "Antecedente indefinido",
+      "back": "usa subj.: busco alguien que aporte",
+      "tag": "subjuntivo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc5",
+      "front": "Concesivas",
+      "back": "aunque llueva (hipotético) → subjuntivo",
+      "tag": "concesiva",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc6",
+      "front": "Condicionales",
+      "back": "a menos que, con tal de que + subj.",
+      "tag": "condicional",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc7",
+      "front": "Conectores contraste",
+      "back": "mientras que, sin embargo, no obstante",
+      "tag": "conectores",
+      "deck": "grammar"
+    },
+    {
+      "id": "a33-clauses-advanced-fc8",
+      "front": "Sin que",
+      "back": "expresa ausencia de acción: sin que nadie lo note",
+      "tag": "sin que",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a34-connectors-academicos.json
+++ b/src/seed/a34-connectors-academicos.json
@@ -1,0 +1,303 @@
+{
+  "lessons": [
+    {
+      "id": "a34-connectors-academicos",
+      "level": "C1",
+      "title": "A34 — Academic Connectors & Cohesion",
+      "slug": "a34-connectors-academicos",
+      "tags": [
+        "connectors",
+        "discourse",
+        "academic",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🧠 A34 — Academic Connectors & Cohesion\n\n**Goal:** Enlazar ideas con conectores formales que expresen adición, contraste, consecuencia y matiz argumentativo.\n\n---\n\n## 1. Estructurar el discurso\n- Apertura: *En primer lugar, Para empezar*.\n- Progresión: *A continuación, Por otra parte, Asimismo*.\n- Cierre: *En definitiva, Por último, En suma*.\n\n## 2. Contraste y concesión\n- Contraste fuerte: *Sin embargo, No obstante, Por el contrario*.\n- Concesión: *Si bien, A pesar de, Con todo*.\n- Matiz adversativo suave: *En cambio, Mientras que*.\n\n## 3. Causa y consecuencia\n- Causa formal: *Debido a, A causa de, Considerando que*.\n- Consecuencia: *Por consiguiente, En consecuencia, De ahí que* (+ subj.).\n- Resumen causal: *Esto se debe a que...*.\n\n## 4. Ejemplificación y reformulación\n- Ejemplo: *Por ejemplo, En particular, Tal es el caso de*.\n- Reformular: *Es decir, Dicho de otro modo, En otras palabras*.\n- Aclarar contraste: *Más bien, Mejor dicho*.\n\n## 5. Precisión académica\n- Matizar alcance: *En términos generales, Hasta cierto punto, En mayor medida*.\n- Introducir hipótesis: *Cabe plantear que, Es plausible que*.\n- Referir fuentes: *Según señala X, De acuerdo con los datos de...*.\n\n---\n\n> 📝 **Resumen:** Escoge conectores según la relación lógica (adición, contraste, causa, síntesis) y mantén coherencia tonal en textos formales.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a34-connectors-academicos-ex1",
+      "lessonId": "a34-connectors-academicos",
+      "type": "mcq",
+      "promptMd": "¿Qué conector introduce contraste fuerte?",
+      "options": [
+        "Asimismo",
+        "En consecuencia",
+        "Sin embargo",
+        "En suma"
+      ],
+      "answer": "Sin embargo",
+      "feedback": {
+        "correct": "Correcto: sin embargo = contraste adversativo.",
+        "wrong": "Elige un conector adversativo fuerte como **sin embargo**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "contraste"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex2",
+      "lessonId": "a34-connectors-academicos",
+      "type": "cloze",
+      "promptMd": "___, la productividad se ha mantenido estable; por tanto, no se prevén despidos.",
+      "answer": "En efecto",
+      "accepted": [
+        "re:^En efecto$",
+        "re:^en efecto$"
+      ],
+      "feedback": {
+        "correct": "Correcto: en efecto confirma la afirmación previa.",
+        "wrong": "Usa **En efecto** para confirmar antes de la consecuencia."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "confirmación"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex3",
+      "lessonId": "a34-connectors-academicos",
+      "type": "cloze",
+      "promptMd": "La propuesta fue rechazada; ___, presentaremos una alternativa.",
+      "answer": "por lo tanto",
+      "accepted": [
+        "re:^por lo tanto$"
+      ],
+      "feedback": {
+        "correct": "Correcto: por lo tanto introduce consecuencia lógica.",
+        "wrong": "Usa **por lo tanto** para consecuencia."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "consecuencia"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex4",
+      "lessonId": "a34-connectors-academicos",
+      "type": "cloze",
+      "promptMd": "___ se observa, el mercado laboral requiere perfiles híbridos.",
+      "answer": "Como",
+      "accepted": [
+        "re:^Como$",
+        "re:^como$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'como se observa' introduce evidencia previa.",
+        "wrong": "Usa **Como se observa** para introducir evidencia."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "introducción"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex5",
+      "lessonId": "a34-connectors-academicos",
+      "type": "mcq",
+      "promptMd": "¿Qué conector introduce concesión?",
+      "options": [
+        "Dado que",
+        "Por consiguiente",
+        "Si bien",
+        "En definitiva"
+      ],
+      "answer": "Si bien",
+      "feedback": {
+        "correct": "Correcto: si bien introduce concesión en registros formales.",
+        "wrong": "Elige **Si bien** para concesión."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "concesión"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex6",
+      "lessonId": "a34-connectors-academicos",
+      "type": "cloze",
+      "promptMd": "El estudio es robusto; ___, presenta limitaciones muestrales.",
+      "answer": "con todo",
+      "accepted": [
+        "re:^con todo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: con todo introduce concesión adversativa.",
+        "wrong": "Usa **con todo** para reconocer objeciones."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "concesión"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex7",
+      "lessonId": "a34-connectors-academicos",
+      "type": "cloze",
+      "promptMd": "___ dicho de otro modo, los datos confirman la hipótesis inicial.",
+      "answer": "O",
+      "accepted": [
+        "re:^O$",
+        "re:^o$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'o dicho de otro modo' reformula la idea.",
+        "wrong": "Usa **o** para enlazar 'dicho de otro modo'."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "reformulación"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex8",
+      "lessonId": "a34-connectors-academicos",
+      "type": "translate",
+      "promptMd": "Translate: **En definitiva, la medida es viable.**",
+      "answer": "Ultimately, the measure is viable",
+      "accepted": [
+        "re:^ultimately, the measure is viable\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: en definitiva = ultimately / overall.",
+        "wrong": "Usa 'Ultimately' para 'En definitiva'."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "cierre"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex9",
+      "lessonId": "a34-connectors-academicos",
+      "type": "mcq",
+      "promptMd": "Selecciona el conector de ejemplificación:",
+      "options": [
+        "Tal es el caso de",
+        "En resumen",
+        "De ahí que",
+        "Con todo"
+      ],
+      "answer": "Tal es el caso de",
+      "feedback": {
+        "correct": "Correcto: introduce ejemplo concreto.",
+        "wrong": "Para ejemplificar, usa **Tal es el caso de**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "ejemplo"
+      }
+    },
+    {
+      "id": "a34-connectors-academicos-ex10",
+      "lessonId": "a34-connectors-academicos",
+      "type": "short",
+      "promptMd": "Propón dos conectores para introducir fuentes académicas.",
+      "answer": "Por ejemplo: 'Según señala X' y 'De acuerdo con los datos de Y'.",
+      "accepted": [
+        "re:Según señala",
+        "re:De acuerdo con"
+      ],
+      "feedback": {
+        "correct": "Correcto: citas la fuente con fórmulas formales.",
+        "wrong": "Incluye fórmulas como 'Según' o 'De acuerdo con'."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "fuentes"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a34-connectors-academicos-fc1",
+      "front": "Contraste fuerte",
+      "back": "Sin embargo, No obstante, Por el contrario",
+      "tag": "contraste",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc2",
+      "front": "Concesión",
+      "back": "Si bien, Con todo, A pesar de",
+      "tag": "concesión",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc3",
+      "front": "Consecuencia",
+      "back": "Por consiguiente, De ahí que (+subj.)",
+      "tag": "consecuencia",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc4",
+      "front": "Reformulación",
+      "back": "Es decir, Dicho de otro modo",
+      "tag": "reformulación",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc5",
+      "front": "Ejemplo",
+      "back": "Por ejemplo, En particular, Tal es el caso de",
+      "tag": "ejemplo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc6",
+      "front": "Estructura",
+      "back": "En primer lugar, Por otra parte, En suma",
+      "tag": "estructura",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc7",
+      "front": "Matizar alcance",
+      "back": "Hasta cierto punto, En términos generales",
+      "tag": "matiz",
+      "deck": "grammar"
+    },
+    {
+      "id": "a34-connectors-academicos-fc8",
+      "front": "Referir fuentes",
+      "back": "Según señala X, De acuerdo con Y",
+      "tag": "fuentes",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a35-orthography-advanced.json
+++ b/src/seed/a35-orthography-advanced.json
@@ -1,0 +1,336 @@
+{
+  "lessons": [
+    {
+      "id": "a35-orthography-advanced",
+      "level": "C1",
+      "title": "A35 — Orthography & Academic Style",
+      "slug": "a35-orthography-advanced",
+      "tags": [
+        "orthography",
+        "writing",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# ✍️ A35 — Orthography & Academic Style\n\n**Goal:** Pulir acentuación, puntuación y convenciones tipográficas de textos formales.\n\n---\n\n## 1. Acentuación avanzada\n- Monosílabos sin tilde salvo diacríticos: *de/dé, el/él, mas/más, se/sé, te/té, tu/tú, mi/mí, si/sí, aun/aún*.\n- *Sólo* y demostrativos (este, ese, aquel) solo con tilde en casos de ambigüedad extrema.\n- Hiatos con vocal cerrada tónica: *frío, país, María*.\n- Prefijos se unen sin guion salvo mayúsculas o números: *exministro, anti-EE. UU.*\n\n## 2. Enclíticos y signos\n- Verbos con pronombres: acentúa para conservar sílaba tónica: *dámelo, háganse, propónselo*.\n- ¿? ¡! dobles obligatorios; signos de exclamación/pregunta admiten entonación combinada (¿¡...!?)\n- Mayúsculas mantienen tilde: *África, Óscar*.\n\n## 3. Puntuación fina\n- Coma separa incisos explicativos: *Los resultados, sin embargo, muestran...*.\n- Punto y coma une oraciones relacionadas con conectores: *Aumentó la demanda; por consiguiente, subieron los precios*.\n- Dos puntos introducen enumeraciones, citas o conclusiones.\n\n## 4. Números y abreviaturas\n- Números del cero al diez en letras en textos formales (salvo datos técnicos).\n- Uso del espacio en símbolos: *20 %*, *15 °C*.\n- Abreviaturas cultas: *p. ej., núm., art.*; siglas sin puntos (ONU, UE).\n\n## 5. Extranjerismos y cursivas\n- Voz no adaptada → cursiva: *software, leitmotiv*.\n- Adaptadas → sin cursiva: *fútbol, suflé*.\n- Citas textuales → comillas latinas « » o inglesas “ ”, según estilo.\n\n---\n\n> 📝 **Resumen:** Revisa acentos diacríticos, coloca tildes en enclíticos, puntúa con precisión y respeta convenciones de números, abreviaturas y extranjerismos.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a35-orthography-advanced-ex1",
+      "lessonId": "a35-orthography-advanced",
+      "type": "mcq",
+      "promptMd": "Selecciona la forma con tilde diacrítica correcta.",
+      "options": [
+        "El dijo que vendría.",
+        "Él dijo que vendría."
+      ],
+      "answer": "Él dijo que vendría.",
+      "feedback": {
+        "correct": "Correcto: pronombre personal lleva tilde.",
+        "wrong": "El artículo 'el' no lleva tilde; usa **Él**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "tilde diacrítica"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex2",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Si no vienes, ___ esperaré (sí afirmativo).",
+      "answer": "sí",
+      "accepted": [
+        "re:^sí$"
+      ],
+      "feedback": {
+        "correct": "Correcto: afirmación → sí con tilde.",
+        "wrong": "Usa **sí** con tilde para afirmación."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "tilde"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex3",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Escríbelo con enclítico: **(dar + me + lo)** → ___",
+      "answer": "dámelo",
+      "accepted": [
+        "re:^dámelo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acento para mantener sílaba tónica.",
+        "wrong": "Usa **dámelo** con tilde en la 'a'."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "enclítico"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex4",
+      "lessonId": "a35-orthography-advanced",
+      "type": "mcq",
+      "promptMd": "¿Cuál respeta la recomendación actual de la RAE?",
+      "options": [
+        "Sólo tengo un minuto.",
+        "Solo tengo un minuto."
+      ],
+      "answer": "Solo tengo un minuto.",
+      "feedback": {
+        "correct": "Correcto: 'solo' sin tilde salvo ambigüedad.",
+        "wrong": "Se recomienda omitir la tilde salvo confusión real."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "solo"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex5",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Escribe correctamente con mayúscula acentuada: ___ (africa).",
+      "answer": "África",
+      "accepted": [
+        "re:^África$"
+      ],
+      "feedback": {
+        "correct": "Correcto: mayúsculas conservan tilde.",
+        "wrong": "Pon **Á** con tilde."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "mayúsculas"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex6",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Inserta la coma: *Los datos sin embargo muestran otro patrón* → ___",
+      "answer": "Los datos, sin embargo, muestran otro patrón",
+      "accepted": [
+        "re:^Los datos, sin embargo, muestran otro patrón$"
+      ],
+      "feedback": {
+        "correct": "Correcto: inciso entre comas.",
+        "wrong": "Añade comas alrededor de 'sin embargo'."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "coma"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex7",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Completa con el signo correcto: *Se aprobó la norma ___ por consiguiente, entrará en vigor mañana.*",
+      "answer": ";",
+      "accepted": [
+        "re:^;$"
+      ],
+      "feedback": {
+        "correct": "Correcto: punto y coma antes de conector consecuente.",
+        "wrong": "Usa punto y coma (;) antes de 'por consiguiente'."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "punto y coma"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex8",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Expresa la temperatura con espacios: **15°C** → ___",
+      "answer": "15 °C",
+      "accepted": [
+        "re:^15 °C$"
+      ],
+      "feedback": {
+        "correct": "Correcto: espacio entre número y símbolo.",
+        "wrong": "Escribe **15 °C** con espacio fino."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "símbolos"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex9",
+      "lessonId": "a35-orthography-advanced",
+      "type": "mcq",
+      "promptMd": "¿Cuál se escribe en cursiva en un texto académico?",
+      "options": [
+        "fútbol",
+        "software",
+        "sándwich"
+      ],
+      "answer": "software",
+      "feedback": {
+        "correct": "Correcto: extranjerismo crudo → cursiva.",
+        "wrong": "'software' no está adaptado, va en cursiva."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "extranjerismos"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex10",
+      "lessonId": "a35-orthography-advanced",
+      "type": "translate",
+      "promptMd": "Translate keeping abbreviation style: **p. ej.**",
+      "answer": "e.g.",
+      "accepted": [
+        "re:^e\\.g\\.$"
+      ],
+      "feedback": {
+        "correct": "Correcto: p. ej. equivale a e.g.",
+        "wrong": "Usa 'e.g.'"
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "abreviaturas"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex11",
+      "lessonId": "a35-orthography-advanced",
+      "type": "cloze",
+      "promptMd": "Convierte a palabras: **7** (contexto académico) → ___",
+      "answer": "siete",
+      "accepted": [
+        "re:^siete$"
+      ],
+      "feedback": {
+        "correct": "Correcto: números simples en letras.",
+        "wrong": "Escribe **siete**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "números"
+      }
+    },
+    {
+      "id": "a35-orthography-advanced-ex12",
+      "lessonId": "a35-orthography-advanced",
+      "type": "short",
+      "promptMd": "¿Cuándo se recomienda guion en prefijos?",
+      "answer": "Cuando el segundo elemento es mayúscula, número o empieza por mayúscula (anti-UE, pro-vida en uso especial).",
+      "accepted": [
+        "re:mayúscula",
+        "re:número"
+      ],
+      "feedback": {
+        "correct": "Correcto: guion solo ante mayúsculas, números o siglas difíciles.",
+        "wrong": "Menciona mayúsculas o números tras el prefijo."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "prefijos"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a35-orthography-advanced-fc1",
+      "front": "Tildes diacríticas",
+      "back": "dé/dé, sé/sé, tú/tu...",
+      "tag": "tilde",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc2",
+      "front": "Solo/sólo",
+      "back": "Solo sin tilde salvo ambigüedad",
+      "tag": "solo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc3",
+      "front": "Enclíticos",
+      "back": "dámelo, explícaselo → tilde por hiato",
+      "tag": "enclítico",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc4",
+      "front": "Mayúsculas",
+      "back": "Conservan tilde: Álvarez, Ópera",
+      "tag": "mayúsculas",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc5",
+      "front": "Punto y coma",
+      "back": "Une oraciones relacionadas con conectores",
+      "tag": "puntuación",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc6",
+      "front": "Espacio en símbolos",
+      "back": "20 %, 15 °C",
+      "tag": "símbolos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc7",
+      "front": "Prefijos",
+      "back": "Sin guion salvo mayúsculas/números",
+      "tag": "prefijos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a35-orthography-advanced-fc8",
+      "front": "Extranjerismos",
+      "back": "No adaptados → cursiva (software)",
+      "tag": "extranjerismo",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a36-register-advanced.json
+++ b/src/seed/a36-register-advanced.json
@@ -1,0 +1,297 @@
+{
+  "lessons": [
+    {
+      "id": "a36-register-advanced",
+      "level": "C1",
+      "title": "A36 — Register, Tone & Audience",
+      "slug": "a36-register-advanced",
+      "tags": [
+        "register",
+        "pragmatics",
+        "style",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🗣️ A36 — Register, Tone & Audience\n\n**Goal:** Ajustar vocabulario, formas verbales y estrategias de cortesía según contexto profesional/académico.\n\n---\n\n## 1. Tratamientos\n- **Tú** (confianza, horizontalidad); **usted** (distancia, respeto).  \n- América: uso extendido de *ustedes*; voseo en áreas específicas.  \n- En correos formales: *Estimado/a + apellido*, despedida con *Atentamente*.\n\n## 2. Léxico según registro\n- Informal: *currar, pasta, tío*.  \n- Formal: *trabajar, dinero, colega/colega* (o *compañero/a*).  \n- Evita muletillas orales (*o sea, en plan, ¿vale?*) en textos formales; usa *es decir, por consiguiente*.\n\n## 3. Atenuadores y asertividad\n- Mitigar pedidos: *¿Podría?, Le agradecería, Sería conveniente que...*\n- Hedging académico: *parece indicar, los datos sugieren, en cierta medida*.  \n- Reforzar: *es evidente, sin duda, cabe destacar*. Ajusta intensidad según audiencia.\n\n## 4. Cohesión interpersonal\n- Incluir saludos y cierres acordes: *Espero que se encuentre bien* vs *Un abrazo*.\n- En presentaciones: *Distinguidas autoridades, colegas* para audiencias formales.\n- Evita emoticonos y abreviaturas en contextos serios (*q, xfa* → inaceptable).\n\n## 5. Código y cortesía intercultural\n- En España, tutear puede llegar pronto; en México/Colombia se mantiene usted hasta confianza.  \n- Usa títulos profesionales (Dr., Lic., Ing.) según costumbre local.  \n- Observa la jerarquía en reuniones: cede la palabra, agradece contribuciones.\n\n---\n\n> 📝 **Resumen:** Identifica la relación y el medio para elegir tratamientos, léxico y fórmulas de cortesía que transmitan respeto sin perder claridad.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a36-register-advanced-ex1",
+      "lessonId": "a36-register-advanced",
+      "type": "mcq",
+      "promptMd": "¿Cuál suena más formal en un correo?",
+      "options": [
+        "Hola, ¿qué tal?",
+        "Estimado Sr. García:"
+      ],
+      "answer": "Estimado Sr. García:",
+      "feedback": {
+        "correct": "Correcto: saludo formal con título/apellido.",
+        "wrong": "Para correo formal usa 'Estimado/a ...'."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "saludo"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex2",
+      "lessonId": "a36-register-advanced",
+      "type": "cloze",
+      "promptMd": "Reformula en registro formal: *¿Me mandas el informe?* → ___",
+      "answer": "¿Podría enviarme el informe?",
+      "accepted": [
+        "re:^¿Podría enviarme el informe\\?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: condicional + pronombre de cortesía.",
+        "wrong": "Incluye '¿Podría ...?' para formalidad."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "cortesía"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex3",
+      "lessonId": "a36-register-advanced",
+      "type": "cloze",
+      "promptMd": "Elige léxico formal: *Necesitamos más ___ (pasta/dinero).*",
+      "answer": "dinero",
+      "accepted": [
+        "re:^dinero$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'dinero' es neutro/formal.",
+        "wrong": "Usa **dinero**, no 'pasta'."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "léxico"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex4",
+      "lessonId": "a36-register-advanced",
+      "type": "mcq",
+      "promptMd": "En México, para un desconocido adulto, ¿cuál es el tratamiento esperado?",
+      "options": [
+        "tú",
+        "usted",
+        "vos"
+      ],
+      "answer": "usted",
+      "feedback": {
+        "correct": "Correcto: se mantiene usted como norma de cortesía.",
+        "wrong": "Usa **usted** hasta que haya confianza."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "tratamientos"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex5",
+      "lessonId": "a36-register-advanced",
+      "type": "cloze",
+      "promptMd": "Añade cierre formal: ___\nAtentamente,\nLaura Pérez",
+      "answer": "Quedo a su disposición",
+      "accepted": [
+        "re:^Quedo a su disposición$"
+      ],
+      "feedback": {
+        "correct": "Correcto: fórmula de cierre profesional.",
+        "wrong": "Incluye frase como **Quedo a su disposición**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "cierre"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex6",
+      "lessonId": "a36-register-advanced",
+      "type": "cloze",
+      "promptMd": "Sustituye muletilla: *O sea, los resultados bajaron* → ___",
+      "answer": "Es decir, los resultados bajaron",
+      "accepted": [
+        "re:^Es decir, los resultados bajaron$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'es decir' es equivalente formal.",
+        "wrong": "Usa **Es decir** en lugar de 'O sea'."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "reformulación"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex7",
+      "lessonId": "a36-register-advanced",
+      "type": "mcq",
+      "promptMd": "¿Qué frase muestra mitigación adecuada?",
+      "options": [
+        "Necesito que entreguen esto hoy.",
+        "Sería conveniente que entregaran esto hoy.",
+        "Entreguen esto hoy."
+      ],
+      "answer": "Sería conveniente que entregaran esto hoy.",
+      "feedback": {
+        "correct": "Correcto: condicional + subjuntivo suaviza la orden.",
+        "wrong": "Elige la opción con mitigador."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "atenuación"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex8",
+      "lessonId": "a36-register-advanced",
+      "type": "translate",
+      "promptMd": "Translate: **Le agradecería que me confirmara su asistencia.**",
+      "answer": "I would appreciate it if you could confirm your attendance",
+      "accepted": [
+        "re:^I would appreciate it if you could confirm your attendance\\.?$"
+      ],
+      "feedback": {
+        "correct": "Correcto: formula de cortesía condicional.",
+        "wrong": "Usa 'I would appreciate it if...'"
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "cortesía"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex9",
+      "lessonId": "a36-register-advanced",
+      "type": "cloze",
+      "promptMd": "En una presentación formal: *___ colegas, buenas tardes.*",
+      "answer": "Distinguidos",
+      "accepted": [
+        "re:^Distinguidos$",
+        "re:^distinguidos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: fórmula protocolaria.",
+        "wrong": "Usa **Distinguidos** como vocativo formal."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "vocativo"
+      }
+    },
+    {
+      "id": "a36-register-advanced-ex10",
+      "lessonId": "a36-register-advanced",
+      "type": "short",
+      "promptMd": "Da dos ejemplos de palabras informales que evitarías en un informe.",
+      "answer": "Por ejemplo 'chungo' y 'mogollón'.",
+      "accepted": [
+        "re:chungo",
+        "re:mogoll[oó]n"
+      ],
+      "feedback": {
+        "correct": "Correcto: propones léxico coloquial a evitar.",
+        "wrong": "Menciona palabras coloquiales como ejemplo."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "léxico"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a36-register-advanced-fc1",
+      "front": "Tratamientos",
+      "back": "Tú vs usted según jerarquía",
+      "tag": "tratamientos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc2",
+      "front": "Saludo formal",
+      "back": "Estimado/a + apellido",
+      "tag": "saludo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc3",
+      "front": "Cierre formal",
+      "back": "Quedo a su disposición, Atentamente",
+      "tag": "cierre",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc4",
+      "front": "Léxico formal",
+      "back": "trabajar, asunto, informe",
+      "tag": "léxico",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc5",
+      "front": "Mitigadores",
+      "back": "Sería conveniente que..., ¿Podría...?",
+      "tag": "atenuación",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc6",
+      "front": "Hedging",
+      "back": "Los datos sugieren, parece indicar",
+      "tag": "hedging",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc7",
+      "front": "Vocativos protocolarios",
+      "back": "Distinguidas autoridades, Estimados colegas",
+      "tag": "vocativo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a36-register-advanced-fc8",
+      "front": "Evitar coloquialismos",
+      "back": "No usar 'en plan', 'currar' en informes",
+      "tag": "evitar",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/a37-error-bank.json
+++ b/src/seed/a37-error-bank.json
@@ -1,0 +1,338 @@
+{
+  "lessons": [
+    {
+      "id": "a37-error-bank",
+      "level": "C1",
+      "title": "A37 — C1 Error Bank & Self-editing",
+      "slug": "a37-error-bank",
+      "tags": [
+        "errors",
+        "self-editing",
+        "advanced",
+        "c1"
+      ],
+      "markdown": "# 🛠️ A37 — C1 Error Bank & Self-editing\n\n**Goal:** Reconocer y corregir los tropiezos típicos en producciones avanzadas, aplicando estrategias de revisión.**\n\n---\n\n## 1. Concordancia y género\n- Sustantivos en -a masculinos: *el problema, el tema, el idioma*.  \n- Concordancia verbo-sujeto tras incisos: *Los datos, junto con la encuesta, **confirman***.\n- Pronombres de objeto: *se lo dije* (no *le lo*).\n\n## 2. Preposiciones conflictivas\n- *Depender de*, *pensar en*, *soñar con*, *insistir en*.  \n- Evita calcos: *asistir a la reunión* (no *asistir la reunión*).  \n- *Solicitar un puesto* (no *aplicar a* en español europeo; en América se usa *postularse a*).\n\n## 3. Queísmo y dequeísmo\n- *Decir que*, *creer que* (sin **de**).  \n- *Asegurarse de que*, *darse cuenta de que* (con **de**).  \n- Usa prueba de sustituir por *esto*: si cabe *de esto*, mantén la preposición.\n\n## 4. Acentos interrogativos y demostrativos\n- Tildes obligatorias en interrogativos/exclamativos: *qué, cuál, cómo, cuándo*.  \n- Demostrativos sin tilde salvo ambigüedad: *este informe*, *aquello*.  \n- Diferencia *más/mas*, *aun/aún*.\n\n## 5. Estrategia de autoedición\n- Lee en voz alta para detectar registros coloquiales.  \n- Revisa lista de conectores y variedad léxica.  \n- Comprueba cifras, preposiciones y colocaciones con corpus/RAE.\n\n---\n\n> 📝 **Resumen:** Pasa un filtro de concordancia, preposiciones, tilde diacrítica y falsos amigos antes de entregar un texto. Anota tus errores recurrentes y crea listas de comprobación.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "a37-error-bank-ex1",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Corrige: *La problema principal es...* → ___",
+      "answer": "El problema principal es...",
+      "accepted": [
+        "re:^El problema principal es\\.\\.\\.$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'problema' es masculino.",
+        "wrong": "Usa **el problema**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "género"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex2",
+      "lessonId": "a37-error-bank",
+      "type": "mcq",
+      "promptMd": "Selecciona la opción correcta:",
+      "options": [
+        "Depende en los resultados.",
+        "Depende de los resultados."
+      ],
+      "answer": "Depende de los resultados.",
+      "feedback": {
+        "correct": "Correcto: verbo depender rige 'de'.",
+        "wrong": "La preposición correcta es **de**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "preposición"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex3",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Dijo ___ vendría mañana (corrige dequeísmo).",
+      "answer": "que",
+      "accepted": [
+        "re:^que$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'decir' no lleva 'de'.",
+        "wrong": "Usa solo **que**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "dequeísmo"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex4",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Asegúrate ___ entregar el informe (añade preposición correcta).",
+      "answer": "de",
+      "accepted": [
+        "re:^de$"
+      ],
+      "feedback": {
+        "correct": "Correcto: asegurarse de + infinitivo/que.",
+        "wrong": "Debe ser **de**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "queísmo"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex5",
+      "lessonId": "a37-error-bank",
+      "type": "mcq",
+      "promptMd": "¿Cuál es la colocación natural?",
+      "options": [
+        "Aplicar a un puesto",
+        "Solicitar un puesto",
+        "Aplicarse a un puesto"
+      ],
+      "answer": "Solicitar un puesto",
+      "feedback": {
+        "correct": "Correcto: en español formal decimos 'solicitar un puesto'.",
+        "wrong": "Prefiere **solicitar** en lugar de 'aplicar'."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "falso amigo"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex6",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Pon tilde si corresponde: *¿___ piensas hacer?*",
+      "answer": "Qué",
+      "accepted": [
+        "re:^Qué$",
+        "re:^qué$"
+      ],
+      "feedback": {
+        "correct": "Correcto: interrogativo lleva tilde.",
+        "wrong": "Añade tilde en **qué**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "interrogativos"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex7",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Reordena clíticos: *Le lo expliqué* → ___",
+      "answer": "Se lo expliqué",
+      "accepted": [
+        "re:^Se lo expliqué$"
+      ],
+      "feedback": {
+        "correct": "Correcto: le/les + lo/la se convierte en se lo/la.",
+        "wrong": "Cambia 'le lo' por **se lo**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "clíticos"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex8",
+      "lessonId": "a37-error-bank",
+      "type": "translate",
+      "promptMd": "Correct the calque: *Assist the meeting* → ___",
+      "answer": "Asistir a la reunión",
+      "accepted": [
+        "re:^Asistir a la reunión$"
+      ],
+      "feedback": {
+        "correct": "Correcto: 'asistir' requiere preposición 'a'.",
+        "wrong": "Traduce como **asistir a la reunión**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read",
+          "write"
+        ],
+        "topic": "preposición"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex9",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Comparativo correcto: *más grande ___ pequeño* (elige conector).",
+      "answer": "que",
+      "accepted": [
+        "re:^que$"
+      ],
+      "feedback": {
+        "correct": "Correcto: comparativo de superioridad usa 'más ... que'.",
+        "wrong": "Usa **que** en comparativo."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "comparativo"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex10",
+      "lessonId": "a37-error-bank",
+      "type": "mcq",
+      "promptMd": "Identifica la oración bien puntuada:",
+      "options": [
+        "Los datos muestran que, sin embargo debemos esperar.",
+        "Los datos muestran que, sin embargo, debemos esperar.",
+        "Los datos muestran, que sin embargo, debemos esperar."
+      ],
+      "answer": "Los datos muestran que, sin embargo, debemos esperar.",
+      "feedback": {
+        "correct": "Correcto: incisos entre comas.",
+        "wrong": "Coloca comas a ambos lados de 'sin embargo'."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "puntuación"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex11",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "Evita 'de más': *Esto no tiene nada ___ ver con el informe.*",
+      "answer": "que",
+      "accepted": [
+        "re:^que$"
+      ],
+      "feedback": {
+        "correct": "Correcto: la expresión es 'nada que ver'.",
+        "wrong": "Usa **que** (nada que ver)."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "colocación"
+      }
+    },
+    {
+      "id": "a37-error-bank-ex12",
+      "lessonId": "a37-error-bank",
+      "type": "short",
+      "promptMd": "Menciona dos puntos de tu checklist de revisión final.",
+      "answer": "Por ejemplo: comprobar preposiciones fijas y verificar tildes interrogativas.",
+      "accepted": [
+        "re:preposiciones",
+        "re:tildes"
+      ],
+      "feedback": {
+        "correct": "Correcto: propones elementos clave de revisión.",
+        "wrong": "Incluye aspectos como preposiciones, tildes, concordancia."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "autoedición"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "a37-error-bank-fc1",
+      "front": "Género irregular",
+      "back": "el problema, el tema, el mapa",
+      "tag": "género",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc2",
+      "front": "Preposiciones clave",
+      "back": "depender de, soñar con, insistir en",
+      "tag": "preposición",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc3",
+      "front": "Queísmo/dequeísmo",
+      "back": "asegurarse de que vs decir que",
+      "tag": "queísmo",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc4",
+      "front": "Clíticos",
+      "back": "le + lo → se lo",
+      "tag": "clíticos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc5",
+      "front": "Falsos amigos",
+      "back": "solicitar un puesto (no aplicar)",
+      "tag": "falsos amigos",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc6",
+      "front": "Tildes interrogativas",
+      "back": "qué, cuándo, cómo siempre con tilde",
+      "tag": "tildes",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc7",
+      "front": "Checklist",
+      "back": "preposiciones, concordancia, puntuación",
+      "tag": "revisión",
+      "deck": "grammar"
+    },
+    {
+      "id": "a37-error-bank-fc8",
+      "front": "Locuciones",
+      "back": "nada que ver, tener en cuenta",
+      "tag": "colocaciones",
+      "deck": "grammar"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add C1 lessons, exercises, and flashcards for advanced article usage and clitic/se management
- build out tense, mood, and discourse control modules (timeline mastery, indicative contrasts, subjunctive concordance, imperatives etiquette, periphrasis, ser/estar, por/para)
- deliver advanced support for clauses, academic connectors, orthography, register, and an error bank for self-editing

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd83f73518832489b08972dbcb1f14