### PR TITLE
Add irregular verb atlas lessons and flashcards

### DIFF
--- a/src/seed/iv-irregular-atlas-flashcards.csv
+++ b/src/seed/iv-irregular-atlas-flashcards.csv
@@ -1,0 +1,37 @@
+id,front,back,tag,deck
+iv-a-abrir,abrir — formas clave,yo abro; pret. yo abrí; subj. yo abra; participio abierto. Nota: Participio irregular abierto; resto regular.,iv-atlas>a–c,verbs
+iv-a-andar,andar — formas clave,yo ando; pret. yo anduve; subj. yo ande; participio andado. Nota: Pretérito con raíz anduv- y subjuntivo pretérito anduviera.,iv-atlas>a–c,verbs
+iv-b-bendecir,bendecir — formas clave,"yo bendigo; pret. yo bendije; subj. yo bendiga; participio bendecido (verbal) / bendito (adjetivo). Nota: Como *decir*: yo bendigo, pretérito bendije, participio verbal *bendecido* (adjetivo *bendito*).",iv-atlas>a–c,verbs
+iv-c-caber,caber — formas clave,yo quepo; pret. yo cupe; subj. yo quepa; participio cabido. Nota: Yo quepo; pretérito cupe; futuro cabré; subjuntivo presente quepa.,iv-atlas>a–c,verbs
+iv-c-caer,caer — formas clave,"yo caigo; pret. yo caí; subj. yo caiga; participio caído. Nota: Yo caigo; pretérito con y (cayó, cayeron); participio caído.",iv-atlas>a–c,verbs
+iv-c-conducir,conducir — formas clave,yo conduzco; pret. yo conduje; subj. yo conduzca; participio conducido. Nota: Yo conduzco; pretérito conduje con 3ª plural -eron.,iv-atlas>a–c,verbs
+iv-c-cerrar,cerrar — formas clave,yo cierro; pret. yo cerré; subj. yo cierre; participio cerrado. Nota: Cambio vocálico e→ie excepto en nosotros/vosotros.,iv-atlas>a–c,verbs
+iv-c-construir,construir — formas clave,"yo construyo; pret. yo construí; subj. yo construya; participio construido. Nota: Cambio i→y en presente, pretérito y subjuntivo; nosotros conservan i.",iv-atlas>a–c,verbs
+iv-d-decir,decir — formas clave,yo digo; pret. yo dije; subj. yo diga; participio dicho. Nota: Yo digo; pretérito dije; participio dicho.,iv-atlas>d–l,verbs
+iv-d-dormir,dormir — formas clave,yo duermo; pret. yo dormí; subj. yo duerma; participio dormido. Nota: Cambio o→ue/e→u; pretérito 3ª persona durmió/durmieron.,iv-atlas>d–l,verbs
+iv-e-estar,estar — formas clave,yo estoy; pret. yo estuve; subj. yo esté; participio estado. Nota: Yo estoy; pretérito estuve; subjuntivo esté.,iv-atlas>d–l,verbs
+iv-f-freir,freír — formas clave,yo frío; pret. yo freí; subj. yo fría; participio freído / frito. Nota: Acentos en presente (frío); participio doble *freído/frito*.,iv-atlas>d–l,verbs
+iv-h-haber,haber — formas clave,"yo he; pret. yo hube; subj. yo haya; participio habido (raro). Nota: Auxiliar: he, has, ha; pretérito hube; subjuntivo haya.",iv-atlas>d–l,verbs
+iv-h-hacer,hacer — formas clave,yo hago; pret. yo hice; subj. yo haga; participio hecho. Nota: Yo hago; pretérito hice (3ª hizo); futuro haré.,iv-atlas>d–l,verbs
+iv-i-ir,ir — formas clave,"yo voy; pret. yo fui; subj. yo vaya; participio ido. Nota: Suplétivo: presente voy, pretérito fui, subjuntivo vaya.",iv-atlas>d–l,verbs
+iv-j-jugar,jugar — formas clave,yo juego; pret. yo jugué; subj. yo juegue; participio jugado. Nota: Cambio u→ue; pretérito yo jugué con g; subjuntivo juegue.,iv-atlas>d–l,verbs
+iv-l-leer,leer — formas clave,"yo leo; pret. yo leí; subj. yo lea; participio leído. Nota: Pretérito con y (leyó, leyeron); gerundio leyendo.",iv-atlas>d–l,verbs
+iv-m-morir,morir — formas clave,yo muero; pret. yo morí; subj. yo muera; participio muerto. Nota: Cambio o→ue/e→u; participio irregular muerto.,iv-atlas>m–s,verbs
+iv-o-oir,oír — formas clave,"yo oigo; pret. yo oí; subj. yo oiga; participio oído. Nota: Formas con y (oigo, oyes); pretérito oyó, oyeron.",iv-atlas>m–s,verbs
+iv-p-pedir,pedir — formas clave,yo pido; pret. yo pedí; subj. yo pida; participio pedido. Nota: Cambio e→i; pretérito 3ª persona pidió/pidieron.,iv-atlas>m–s,verbs
+iv-p-poder,poder — formas clave,"yo puedo; pret. yo pude; subj. yo pueda; participio podido. Nota: Raíz irregular: presente pued-, pretérito pud-, futuro podr-.",iv-atlas>m–s,verbs
+iv-p-poner,poner — formas clave,yo pongo; pret. yo puse; subj. yo ponga; participio puesto. Nota: Yo pongo; pretérito puse; futuro pondré; participio puesto.,iv-atlas>m–s,verbs
+iv-q-querer,querer — formas clave,yo quiero; pret. yo quise; subj. yo quiera; participio querido. Nota: Cambio e→ie; pretérito quis-; futuro querr-.,iv-atlas>m–s,verbs
+iv-r-reir,reír — formas clave,"yo río; pret. yo reí; subj. yo ría; participio reído. Nota: Acentos en presente (río); pretérito rió, rieron; gerundio riendo.",iv-atlas>m–s,verbs
+iv-s-saber,saber — formas clave,yo sé; pret. yo supe; subj. yo sepa; participio sabido. Nota: Yo sé; pretérito supe; subjuntivo presente sepa.,iv-atlas>m–s,verbs
+iv-s-salir,salir — formas clave,yo salgo; pret. yo salí; subj. yo salga; participio salido. Nota: Yo salgo; futuro saldré; subjuntivo presente salga.,iv-atlas>m–s,verbs
+iv-s-ser,ser — formas clave,"yo soy; pret. yo fui; subj. yo sea; participio sido. Nota: Presente soy, eres; pretérito fui; imperfecto era; subjuntivo sea/fuera.",iv-atlas>m–s,verbs
+iv-t-tener,tener — formas clave,yo tengo; pret. yo tuve; subj. yo tenga; participio tenido. Nota: Yo tengo; pretérito tuve; futuro tendré; subjuntivo tenga.,iv-atlas>t–z,verbs
+iv-t-traer,traer — formas clave,yo traigo; pret. yo traje; subj. yo traiga; participio traído. Nota: Yo traigo; pretérito traje (3ª trajeron); gerundio trayendo.,iv-atlas>t–z,verbs
+iv-t-traducir,traducir — formas clave,yo traduzco; pret. yo traduje; subj. yo traduzca; participio traducido. Nota: Yo traduzco; pretérito traduje (3ª tradujeron); subjuntivo traduzca.,iv-atlas>t–z,verbs
+iv-v-valer,valer — formas clave,yo valgo; pret. yo valí; subj. yo valga; participio valido. Nota: Yo valgo; futuro valdré; subjuntivo valga.,iv-atlas>t–z,verbs
+iv-v-venir,venir — formas clave,yo vengo; pret. yo vine; subj. yo venga; participio venido. Nota: Yo vengo; presente vien-; pretérito vine; futuro vendré.,iv-atlas>t–z,verbs
+iv-v-ver,ver — formas clave,"yo veo; pret. yo vi; subj. yo vea; participio visto. Nota: Yo veo; pretérito vi, viste, vio sin acentos; participio visto.",iv-atlas>t–z,verbs
+iv-v-volver,volver — formas clave,yo vuelvo; pret. yo volví; subj. yo vuelva; participio vuelto. Nota: Cambio o→ue; participio irregular vuelto; futuro volveré.,iv-atlas>t–z,verbs
+iv-y-yacer,yacer — formas clave,yo yazco; pret. yo yací; subj. yo yazca; participio yacido. Nota: Yo yazco (también *yago*); pretérito yací/yació; subjuntivo yazca.,iv-atlas>t–z,verbs
+iv-z-zurcir,zurcir — formas clave,yo zurzo; pret. yo zurcí; subj. yo zurza; participio zurcido. Nota: Yo zurzo; subjuntivo zurza; 2ª pl. imperativo zurcid.,iv-atlas>t–z,verbs

--- a/src/seed/iv-irregular-atlas.json
+++ b/src/seed/iv-irregular-atlas.json
@@ -1,0 +1,1940 @@
+{
+  "lessons": [
+    {
+      "id": "iv-a-c",
+      "level": "C1",
+      "title": "IV-A — Irregular Verb Atlas (A–C)",
+      "slug": "iv-a-c",
+      "tags": [
+        "verbs",
+        "irregular",
+        "reference",
+        "atlas",
+        "iv-series",
+        "a-c"
+      ],
+      "markdown": "# 📚 IV-A — Irregular Verb Atlas (A–C)\n\n**Objetivo:** consolidar las irregularidades clave del tramo alfabético.\n\n---\n\n**Foco del atlas:** participios irregulares (-ierto), raíces de pretérito con *-uv-/-ij-*,\ny cambios vocálicos o/y (cierro, construyo). Observa la columna de notas para fijar qué\nparte se altera (participio, raíz, diptongo o grafía).\n\n## 🧭 Cómo estudiar\n- Identifica la *pieza irregular* (participio, raíz, consonante añadida) y combínala con las\n  terminaciones regulares.\n- Repite en voz alta los imperativos; fijan la alternancia entre formas fuertes y débiles.\n\n### Abrir — to open\n\n*Irregularidad clave:* Participio irregular **abierto**; resto regular.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | abro | abres | abre | abrimos | abrís | abren |\n| Pretérito indefinido | abrí | abriste | abrió | abrimos | abristeis | abrieron |\n| Imperfecto | abría | abrías | abría | abríamos | abríais | abrían |\n| Futuro | abriré | abrirás | abrirá | abriremos | abriréis | abrirán |\n| Subjuntivo presente | abra | abras | abra | abramos | abráis | abran |\n| Subjuntivo imperfecto | abriera | abrieras | abriera | abriéramos | abrierais | abrieran |\n| Imperativo (+/-) | — | abre / no abras | abra / no abra | abramos / no abramos | abrid / no abráis | abran / no abran |\n\n**Participio:** abierto. **Gerundio:** abriendo.\n\n**Ejemplos**\n- *Hemos abierto todas las ventanas para ventilar.* — We have opened every window to air things out.\n- *Si abrieras la mente, verías otras opciones.* — If you opened your mind, you would see other options.\n\n### Andar — to walk\n\n*Irregularidad clave:* Pretérito con raíz **anduv-** y subjuntivo pretérito **anduviera**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | ando | andas | anda | andamos | andáis | andan |\n| Pretérito indefinido | anduve | anduviste | anduvo | anduvimos | anduvisteis | anduvieron |\n| Imperfecto | andaba | andabas | andaba | andábamos | andabais | andaban |\n| Futuro | andaré | andarás | andará | andaremos | andaréis | andarán |\n| Subjuntivo presente | ande | andes | ande | andemos | andéis | anden |\n| Subjuntivo imperfecto | anduviera | anduvieras | anduviera | anduviéramos | anduvierais | anduvieran |\n| Imperativo (+/-) | — | anda / no andes | ande / no ande | andemos / no andemos | andad / no andéis | anden / no anden |\n\n**Participio:** andado. **Gerundio:** andando.\n\n**Ejemplos**\n- *Ayer anduvimos diez kilómetros por la montaña.* — Yesterday we walked ten kilometres through the mountain.\n- *Cuando andes con cuidado, evitarás tropezar.* — When you walk carefully, you will avoid tripping.\n\n### Bendecir — to bless\n\n*Irregularidad clave:* Como *decir*: yo **bendigo**, pretérito **bendije**, participio verbal *bendecido* (adjetivo *bendito*).\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | bendigo | bendices | bendice | bendecimos | bendecís | bendicen |\n| Pretérito indefinido | bendije | bendijiste | bendijo | bendijimos | bendijisteis | bendijeron |\n| Imperfecto | bendecía | bendecías | bendecía | bendecíamos | bendecíais | bendecían |\n| Futuro | bendeciré | bendecirás | bendecirá | bendeciremos | bendeciréis | bendecirán |\n| Subjuntivo presente | bendiga | bendigas | bendiga | bendigamos | bendigáis | bendigan |\n| Subjuntivo imperfecto | bendijera | bendijeras | bendijera | bendijéramos | bendijerais | bendijeran |\n| Imperativo (+/-) | — | bendice / no bendigas | bendiga / no bendiga | bendigamos / no bendigamos | bendecid / no bendigáis | bendigan / no bendigan |\n\n**Participio:** bendecido (verbal) / bendito (adjetivo). **Gerundio:** bendiciendo.\n\n**Ejemplos**\n- *El sacerdote bendijo el agua antes de la ceremonia.* — The priest blessed the water before the ceremony.\n- *Que Dios te bendiga en cada paso que des.* — May God bless you in every step you take.\n\n### Caber — to fit\n\n*Irregularidad clave:* Yo **quepo**; pretérito **cupe**; futuro **cabré**; subjuntivo presente **quepa**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | quepo | cabes | cabe | cabemos | cabéis | caben |\n| Pretérito indefinido | cupe | cupiste | cupo | cupimos | cupisteis | cupieron |\n| Imperfecto | cabía | cabías | cabía | cabíamos | cabíais | cabían |\n| Futuro | cabré | cabrás | cabrá | cabremos | cabréis | cabrán |\n| Subjuntivo presente | quepa | quepas | quepa | quepamos | quepáis | quepan |\n| Subjuntivo imperfecto | cupiera | cupieras | cupiera | cupiéramos | cupierais | cupieran |\n| Imperativo (+/-) | — | cabe / no quepas | quepa / no quepa | quepamos / no quepamos | cabed / no quepáis | quepan / no quepan |\n\n**Participio:** cabido. **Gerundio:** cabiendo.\n\n**Ejemplos**\n- *En la maleta no cupieron todos los libros.* — Not all the books fit in the suitcase.\n- *Ojalá que quepas en el equipo definitivo.* — I hope you fit on the final team.\n\n### Caer — to fall\n\n*Irregularidad clave:* Yo **caigo**; pretérito con y (**cayó, cayeron**); participio **caído**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | caigo | caes | cae | caemos | caéis | caen |\n| Pretérito indefinido | caí | caíste | cayó | caímos | caísteis | cayeron |\n| Imperfecto | caía | caías | caía | caíamos | caíais | caían |\n| Futuro | caeré | caerás | caerá | caeremos | caeréis | caerán |\n| Subjuntivo presente | caiga | caigas | caiga | caigamos | caigáis | caigan |\n| Subjuntivo imperfecto | cayera | cayeras | cayera | cayéramos | cayerais | cayeran |\n| Imperativo (+/-) | — | cae / no caigas | caiga / no caiga | caigamos / no caigamos | caed / no caigáis | caigan / no caigan |\n\n**Participio:** caído. **Gerundio:** cayendo.\n\n**Ejemplos**\n- *Se cayó porque no miró el escalón.* — He fell because he didn’t look at the step.\n- *No dejes que caiga la moral del equipo.* — Don’t let the team’s morale drop.\n\n### Conducir — to drive\n\n*Irregularidad clave:* Yo **conduzco**; pretérito **conduje** con 3ª plural **-eron**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | conduzco | conduces | conduce | conducimos | conducís | conducen |\n| Pretérito indefinido | conduje | condujiste | condujo | condujimos | condujisteis | condujeron |\n| Imperfecto | conducía | conducías | conducía | conducíamos | conducíais | conducían |\n| Futuro | conduciré | conducirás | conducirá | conduciremos | conduciréis | conducirán |\n| Subjuntivo presente | conduzca | conduzcas | conduzca | conduzcamos | conduzcáis | conduzcan |\n| Subjuntivo imperfecto | condujera | condujeras | condujera | condujéramos | condujerais | condujeran |\n| Imperativo (+/-) | — | conduce / no conduzcas | conduzca / no conduzca | conduzcamos / no conduzcamos | conducid / no conduzcáis | conduzcan / no conduzcan |\n\n**Participio:** conducido. **Gerundio:** conduciendo.\n\n**Ejemplos**\n- *Ayer conduje durante cinco horas seguidas.* — Yesterday I drove for five straight hours.\n- *Conduzcan con prudencia cuando nieve.* — Drive carefully when it snows.\n\n### Cerrar — to close\n\n*Irregularidad clave:* Cambio vocálico e→ie excepto en nosotros/vosotros.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | cierro | cierras | cierra | cerramos | cerráis | cierran |\n| Pretérito indefinido | cerré | cerraste | cerró | cerramos | cerrasteis | cerraron |\n| Imperfecto | cerraba | cerrabas | cerraba | cerrábamos | cerrabais | cerraban |\n| Futuro | cerraré | cerrarás | cerrará | cerraremos | cerraréis | cerrarán |\n| Subjuntivo presente | cierre | cierres | cierre | cerremos | cerréis | cierren |\n| Subjuntivo imperfecto | cerrara | cerraras | cerrara | cerráramos | cerrarais | cerraran |\n| Imperativo (+/-) | — | cierra / no cierres | cierre / no cierre | cerremos / no cerremos | cerrad / no cerréis | cierren / no cierren |\n\n**Participio:** cerrado. **Gerundio:** cerrando.\n\n**Ejemplos**\n- *Cierro la tienda a las ocho en punto.* — I close the shop at eight o’clock sharp.\n- *Es necesario que cierres la puerta con llave.* — It’s necessary that you lock the door.\n\n### Construir — to build\n\n*Irregularidad clave:* Cambio i→y en presente, pretérito y subjuntivo; nosotros conservan i.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | construyo | construyes | construye | construimos | construís | construyen |\n| Pretérito indefinido | construí | construiste | construyó | construimos | construisteis | construyeron |\n| Imperfecto | construía | construías | construía | construíamos | construíais | construían |\n| Futuro | construiré | construirás | construirá | construiremos | construiréis | construirán |\n| Subjuntivo presente | construya | construyas | construya | construyamos | construyáis | construyan |\n| Subjuntivo imperfecto | construyera | construyeras | construyera | construyéramos | construyerais | construyeran |\n| Imperativo (+/-) | — | construye / no construyas | construya / no construya | construyamos / no construyamos | construid / no construyáis | construyan / no construyan |\n\n**Participio:** construido. **Gerundio:** construyendo.\n\n**Ejemplos**\n- *Construyeron un puente sobre el río.* — They built a bridge over the river.\n- *Espero que construyas tu proyecto con calma.* — I hope you build your project calmly.\n\n---\n\n> 📝 **Resumen rápido:** detecta la pieza irregular → combina con las terminaciones regulares; refuerza participios y subjuntivos con producción oral.",
+      "references": []
+    },
+    {
+      "id": "iv-d-l",
+      "level": "C1",
+      "title": "IV-B — Irregular Verb Atlas (D–L)",
+      "slug": "iv-d-l",
+      "tags": [
+        "verbs",
+        "irregular",
+        "reference",
+        "atlas",
+        "iv-series",
+        "d-l"
+      ],
+      "markdown": "# 📚 IV-B — Irregular Verb Atlas (D–L)\n\n**Objetivo:** consolidar las irregularidades clave del tramo alfabético.\n\n---\n\n**Foco del atlas:** verbos con consonante insertada (dij-, traj-), vocales cambiantes en 3.ª\npersona (durmió) y participios cortos (dicho, hecho, frito). Mezcla auxiliares (*haber*, *ir*)\ncon verbos léxicos de alta frecuencia para dominar los cimientos.\n\n## 🧭 Cómo estudiar\n- Repite los seis valores del pretérito en voz corrida (dije, dijiste...).\n- Controla los acentos en verbos con hiatos (*oír, leer, freír*).\n- Revisa participios dobles: `freído` (verbal) vs. `frito` (adjetivo).\n\n### Decir — to say\n\n*Irregularidad clave:* Yo **digo**; pretérito **dije**; participio **dicho**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | digo | dices | dice | decimos | decís | dicen |\n| Pretérito indefinido | dije | dijiste | dijo | dijimos | dijisteis | dijeron |\n| Imperfecto | decía | decías | decía | decíamos | decíais | decían |\n| Futuro | diré | dirás | dirá | diremos | diréis | dirán |\n| Subjuntivo presente | diga | digas | diga | digamos | digáis | digan |\n| Subjuntivo imperfecto | dijera | dijeras | dijera | dijéramos | dijerais | dijeran |\n| Imperativo (+/-) | — | di / no digas | diga / no diga | digamos / no digamos | decid / no digáis | digan / no digan |\n\n**Participio:** dicho. **Gerundio:** diciendo.\n\n**Ejemplos**\n- *Siempre digo la verdad aunque duela.* — I always tell the truth even if it hurts.\n- *Nos pidieron que dijéramos la verdad.* — They asked us to tell the truth.\n\n### Dormir — to sleep\n\n*Irregularidad clave:* Cambio o→ue/e→u; pretérito 3ª persona **durmió/durmieron**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | duermo | duermes | duerme | dormimos | dormís | duermen |\n| Pretérito indefinido | dormí | dormiste | durmió | dormimos | dormisteis | durmieron |\n| Imperfecto | dormía | dormías | dormía | dormíamos | dormíais | dormían |\n| Futuro | dormiré | dormirás | dormirá | dormiremos | dormiréis | dormirán |\n| Subjuntivo presente | duerma | duermas | duerma | durmamos | durmáis | duerman |\n| Subjuntivo imperfecto | durmiera | durmieras | durmiera | durmiéramos | durmierais | durmieran |\n| Imperativo (+/-) | — | duerme / no duermas | duerma / no duerma | durmamos / no durmamos | dormid / no durmáis | duerman / no duerman |\n\n**Participio:** dormido. **Gerundio:** durmiendo.\n\n**Ejemplos**\n- *Anoche dormí como un tronco.* — Last night I slept like a log.\n- *Es necesario que duermas ocho horas diarias.* — It’s necessary that you sleep eight hours a day.\n\n### Estar — to be (state)\n\n*Irregularidad clave:* Yo **estoy**; pretérito **estuve**; subjuntivo **esté**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | estoy | estás | está | estamos | estáis | están |\n| Pretérito indefinido | estuve | estuviste | estuvo | estuvimos | estuvisteis | estuvieron |\n| Imperfecto | estaba | estabas | estaba | estábamos | estabais | estaban |\n| Futuro | estaré | estarás | estará | estaremos | estaréis | estarán |\n| Subjuntivo presente | esté | estés | esté | estemos | estéis | estén |\n| Subjuntivo imperfecto | estuviera | estuvieras | estuviera | estuviéramos | estuvierais | estuvieran |\n| Imperativo (+/-) | — | está / no estés | esté / no esté | estemos / no estemos | estad / no estéis | estén / no estén |\n\n**Participio:** estado. **Gerundio:** estando.\n\n**Ejemplos**\n- *Estoy muy contento con los resultados.* — I am very happy with the results.\n- *Si estuvieras aquí, entenderías la situación.* — If you were here, you would understand the situation.\n\n### Freír — to fry\n\n*Irregularidad clave:* Acentos en presente (**frío**); participio doble *freído/frito*.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | frío | fríes | fríe | freímos | freís | fríen |\n| Pretérito indefinido | freí | freíste | frió | freímos | freísteis | frieron |\n| Imperfecto | freía | freías | freía | freíamos | freíais | freían |\n| Futuro | freiré | freirás | freirá | freiremos | freiréis | freirán |\n| Subjuntivo presente | fría | frías | fría | friamos | friáis | frían |\n| Subjuntivo imperfecto | friera | frieras | friera | friéramos | frierais | frieran |\n| Imperativo (+/-) | — | fríe / no frías | fría / no fría | friamos / no friamos | freíd / no friáis | frían / no frían |\n\n**Participio:** freído / frito. **Gerundio:** friendo.\n\n**Ejemplos**\n- *Frío los huevos con aceite de oliva.* — I fry the eggs in olive oil.\n- *Es mejor que frías las patatas en dos tandas.* — It’s better if you fry the potatoes in two batches.\n\n### Haber — to have (aux.)\n\n*Irregularidad clave:* Auxiliar: **he, has, ha**; pretérito **hube**; subjuntivo **haya**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | he | has | ha | hemos | habéis | han |\n| Pretérito indefinido | hube | hubiste | hubo | hubimos | hubisteis | hubieron |\n| Imperfecto | había | habías | había | habíamos | habíais | habían |\n| Futuro | habré | habrás | habrá | habremos | habréis | habrán |\n| Subjuntivo presente | haya | hayas | haya | hayamos | hayáis | hayan |\n| Subjuntivo imperfecto | hubiera | hubieras | hubiera | hubiéramos | hubierais | hubieran |\n| Imperativo (+/-) | — | he / no hayas | haya / no haya | hayamos / no hayamos | habed / no hayáis | hayan / no hayan |\n\n**Participio:** habido (raro). **Gerundio:** habiendo.\n\n**Ejemplos**\n- *Ha habido muchos cambios en la empresa.* — There have been many changes in the company.\n- *Espero que hayas descansado lo suficiente.* — I hope you have rested enough.\n\n### Hacer — to do / make\n\n*Irregularidad clave:* Yo **hago**; pretérito **hice** (3ª hizo); futuro **haré**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | hago | haces | hace | hacemos | hacéis | hacen |\n| Pretérito indefinido | hice | hiciste | hizo | hicimos | hicisteis | hicieron |\n| Imperfecto | hacía | hacías | hacía | hacíamos | hacíais | hacían |\n| Futuro | haré | harás | hará | haremos | haréis | harán |\n| Subjuntivo presente | haga | hagas | haga | hagamos | hagáis | hagan |\n| Subjuntivo imperfecto | hiciera | hicieras | hiciera | hiciéramos | hicierais | hicieran |\n| Imperativo (+/-) | — | haz / no hagas | haga / no haga | hagamos / no hagamos | haced / no hagáis | hagan / no hagan |\n\n**Participio:** hecho. **Gerundio:** haciendo.\n\n**Ejemplos**\n- *Hicimos un pastel para la fiesta.* — We made a cake for the party.\n- *Ojalá hagas lo correcto.* — I hope you do the right thing.\n\n### Ir — to go\n\n*Irregularidad clave:* Suplétivo: presente **voy**, pretérito **fui**, subjuntivo **vaya**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | voy | vas | va | vamos | vais | van |\n| Pretérito indefinido | fui | fuiste | fue | fuimos | fuisteis | fueron |\n| Imperfecto | iba | ibas | iba | íbamos | ibais | iban |\n| Futuro | iré | irás | irá | iremos | iréis | irán |\n| Subjuntivo presente | vaya | vayas | vaya | vayamos | vayáis | vayan |\n| Subjuntivo imperfecto | fuera | fueras | fuera | fuéramos | fuerais | fueran |\n| Imperativo (+/-) | — | ve / no vayas | vaya / no vaya | vamos / no vayamos | id / no vayáis | vayan / no vayan |\n\n**Participio:** ido. **Gerundio:** yendo.\n\n**Ejemplos**\n- *Vamos al cine todos los viernes.* — We go to the cinema every Friday.\n- *Quería que fueras conmigo al concierto.* — I wanted you to go with me to the concert.\n\n### Jugar — to play\n\n*Irregularidad clave:* Cambio u→ue; pretérito yo **jugué** con g; subjuntivo **juegue**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | juego | juegas | juega | jugamos | jugáis | juegan |\n| Pretérito indefinido | jugué | jugaste | jugó | jugamos | jugasteis | jugaron |\n| Imperfecto | jugaba | jugabas | jugaba | jugábamos | jugabais | jugaban |\n| Futuro | jugaré | jugarás | jugará | jugaremos | jugaréis | jugarán |\n| Subjuntivo presente | juegue | juegues | juegue | juguemos | juguéis | jueguen |\n| Subjuntivo imperfecto | jugara | jugaras | jugara | jugáramos | jugarais | jugaran |\n| Imperativo (+/-) | — | juega / no juegues | juegue / no juegue | juguemos / no juguemos | jugad / no juguéis | jueguen / no jueguen |\n\n**Participio:** jugado. **Gerundio:** jugando.\n\n**Ejemplos**\n- *Jugué al baloncesto en la universidad.* — I played basketball in university.\n- *Espero que juegues con nosotros mañana.* — I hope you play with us tomorrow.\n\n### Leer — to read\n\n*Irregularidad clave:* Pretérito con y (**leyó, leyeron**); gerundio **leyendo**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | leo | lees | lee | leemos | leéis | leen |\n| Pretérito indefinido | leí | leíste | leyó | leímos | leísteis | leyeron |\n| Imperfecto | leía | leías | leía | leíamos | leíais | leían |\n| Futuro | leeré | leerás | leerá | leeremos | leeréis | leerán |\n| Subjuntivo presente | lea | leas | lea | leamos | leáis | lean |\n| Subjuntivo imperfecto | leyera | leyeras | leyera | leyéramos | leyerais | leyeran |\n| Imperativo (+/-) | — | lee / no leas | lea / no lea | leamos / no leamos | leed / no leáis | lean / no lean |\n\n**Participio:** leído. **Gerundio:** leyendo.\n\n**Ejemplos**\n- *Leí el informe en detalle.* — I read the report in detail.\n- *Es importante que leas las instrucciones.* — It is important that you read the instructions.\n\n---\n\n> 📝 **Resumen rápido:** detecta la pieza irregular → combina con las terminaciones regulares; refuerza participios y subjuntivos con producción oral.",
+      "references": []
+    },
+    {
+      "id": "iv-m-s",
+      "level": "C1",
+      "title": "IV-C — Irregular Verb Atlas (M–S)",
+      "slug": "iv-m-s",
+      "tags": [
+        "verbs",
+        "irregular",
+        "reference",
+        "atlas",
+        "iv-series",
+        "m-s"
+      ],
+      "markdown": "# 📚 IV-C — Irregular Verb Atlas (M–S)\n\n**Objetivo:** consolidar las irregularidades clave del tramo alfabético.\n\n---\n\n**Foco del atlas:** alternancias vocálicas e→i / o→u en presente y pasado (pedir, morir),\nraíces supletivas en pretérito (pud-, pus-, quis-, sup-), y participios anómalos (*muerto*,\n*puesto*, *vuelto*). También aparecen estructuras con subjuntivo obligatorio.\n\n## 🧭 Cómo estudiar\n- Agrupa por familias de raíz: *(pud- / pus- / sup-)* comparten terminaciones.\n- Verifica el cambio vocálico sólo en las \"formas fuertes\" (yo, tú, él, ellos).\n- Practica las frases con subjuntivo para automatizar disparadores como *ojalá que...*.\n\n### Morir — to die\n\n*Irregularidad clave:* Cambio o→ue/e→u; participio irregular **muerto**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | muero | mueres | muere | morimos | morís | mueren |\n| Pretérito indefinido | morí | moriste | murió | morimos | moristeis | murieron |\n| Imperfecto | moría | morías | moría | moríamos | moríais | morían |\n| Futuro | moriré | morirás | morirá | moriremos | moriréis | morirán |\n| Subjuntivo presente | muera | mueras | muera | muramos | muráis | mueran |\n| Subjuntivo imperfecto | muriera | murieras | muriera | muriéramos | murierais | murieran |\n| Imperativo (+/-) | — | muere / no mueras | muera / no muera | muramos / no muramos | morid / no muráis | mueran / no mueran |\n\n**Participio:** muerto. **Gerundio:** muriendo.\n\n**Ejemplos**\n- *El héroe murió defendiendo su tierra.* — The hero died defending his land.\n- *Ojalá no mueran tantas abejas este año.* — Hopefully not so many bees die this year.\n\n### Oír — to hear\n\n*Irregularidad clave:* Formas con y (**oigo, oyes**); pretérito **oyó, oyeron**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | oigo | oyes | oye | oímos | oís | oyen |\n| Pretérito indefinido | oí | oíste | oyó | oímos | oísteis | oyeron |\n| Imperfecto | oía | oías | oía | oíamos | oíais | oían |\n| Futuro | oiré | oirás | oirá | oiremos | oiréis | oirán |\n| Subjuntivo presente | oiga | oigas | oiga | oigamos | oigáis | oigan |\n| Subjuntivo imperfecto | oyera | oyeras | oyera | oyéramos | oyerais | oyeran |\n| Imperativo (+/-) | — | oye / no oigas | oiga / no oiga | oigamos / no oigamos | oíd / no oigáis | oigan / no oigan |\n\n**Participio:** oído. **Gerundio:** oyendo.\n\n**Ejemplos**\n- *¿Oíste ese ruido extraño?* — Did you hear that strange noise?\n- *Espero que oigas bien las instrucciones.* — I hope you hear the instructions well.\n\n### Pedir — to request\n\n*Irregularidad clave:* Cambio e→i; pretérito 3ª persona **pidió/pidieron**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | pido | pides | pide | pedimos | pedís | piden |\n| Pretérito indefinido | pedí | pediste | pidió | pedimos | pedisteis | pidieron |\n| Imperfecto | pedía | pedías | pedía | pedíamos | pedíais | pedían |\n| Futuro | pediré | pedirás | pedirá | pediremos | pediréis | pedirán |\n| Subjuntivo presente | pida | pidas | pida | pidamos | pidáis | pidan |\n| Subjuntivo imperfecto | pidiera | pidieras | pidiera | pidiéramos | pidierais | pidieran |\n| Imperativo (+/-) | — | pide / no pidas | pida / no pida | pidamos / no pidamos | pedid / no pidáis | pidan / no pidan |\n\n**Participio:** pedido. **Gerundio:** pidiendo.\n\n**Ejemplos**\n- *Pidió ayuda cuando vio el problema.* — She asked for help when she saw the problem.\n- *Te sugiero que pidas la beca este año.* — I suggest you apply for the scholarship this year.\n\n### Poder — to be able to\n\n*Irregularidad clave:* Raíz irregular: presente **pued-**, pretérito **pud-**, futuro **podr-**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | puedo | puedes | puede | podemos | podéis | pueden |\n| Pretérito indefinido | pude | pudiste | pudo | pudimos | pudisteis | pudieron |\n| Imperfecto | podía | podías | podía | podíamos | podíais | podían |\n| Futuro | podré | podrás | podrá | podremos | podréis | podrán |\n| Subjuntivo presente | pueda | puedas | pueda | podamos | podáis | puedan |\n| Subjuntivo imperfecto | pudiera | pudieras | pudiera | pudiéramos | pudierais | pudieran |\n| Imperativo (+/-) | — | puede / no puedas | pueda / no pueda | podamos / no podamos | poded / no podáis | puedan / no puedan |\n\n**Participio:** podido. **Gerundio:** pudiendo.\n\n**Ejemplos**\n- *No pude asistir a la reunión.* — I couldn’t attend the meeting.\n- *Cuando puedas, llámame.* — When you can, call me.\n\n### Poner — to put\n\n*Irregularidad clave:* Yo **pongo**; pretérito **puse**; futuro **pondré**; participio **puesto**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | pongo | pones | pone | ponemos | ponéis | ponen |\n| Pretérito indefinido | puse | pusiste | puso | pusimos | pusisteis | pusieron |\n| Imperfecto | ponía | ponías | ponía | poníamos | poníais | ponían |\n| Futuro | pondré | pondrás | pondrá | pondremos | pondréis | pondrán |\n| Subjuntivo presente | ponga | pongas | ponga | pongamos | pongáis | pongan |\n| Subjuntivo imperfecto | pusiera | pusieras | pusiera | pusiéramos | pusierais | pusieran |\n| Imperativo (+/-) | — | pon / no pongas | ponga / no ponga | pongamos / no pongamos | poned / no pongáis | pongan / no pongan |\n\n**Participio:** puesto. **Gerundio:** poniendo.\n\n**Ejemplos**\n- *Puse los platos en la mesa.* — I put the plates on the table.\n- *Es necesario que pongas más atención.* — It is necessary that you pay more attention.\n\n### Querer — to want / love\n\n*Irregularidad clave:* Cambio e→ie; pretérito **quis-**; futuro **querr-**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | quiero | quieres | quiere | queremos | queréis | quieren |\n| Pretérito indefinido | quise | quisiste | quiso | quisimos | quisisteis | quisieron |\n| Imperfecto | quería | querías | quería | queríamos | queríais | querían |\n| Futuro | querré | querrás | querrá | querremos | querréis | querrán |\n| Subjuntivo presente | quiera | quieras | quiera | queramos | queráis | quieran |\n| Subjuntivo imperfecto | quisiera | quisieras | quisiera | quisiéramos | quisierais | quisieran |\n| Imperativo (+/-) | — | quiere / no quieras | quiera / no quiera | queramos / no queramos | quered / no queráis | quieran / no quieran |\n\n**Participio:** querido. **Gerundio:** queriendo.\n\n**Ejemplos**\n- *Quise ayudarte pero llegué tarde.* — I wanted to help you but I arrived late.\n- *Quiero que quieras la paz tanto como yo.* — I want you to want peace as much as I do.\n\n### Reír — to laugh\n\n*Irregularidad clave:* Acentos en presente (**río**); pretérito **rió, rieron**; gerundio **riendo**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | río | ríes | ríe | reímos | reís | ríen |\n| Pretérito indefinido | reí | reíste | rió | reímos | reísteis | rieron |\n| Imperfecto | reía | reías | reía | reíamos | reíais | reían |\n| Futuro | reiré | reirás | reirá | reiremos | reiréis | reirán |\n| Subjuntivo presente | ría | rías | ría | riamos | riáis | rían |\n| Subjuntivo imperfecto | riera | rieras | riera | riéramos | rierais | rieran |\n| Imperativo (+/-) | — | ríe / no rías | ría / no ría | riamos / no riamos | reíd / no riáis | rían / no rían |\n\n**Participio:** reído. **Gerundio:** riendo.\n\n**Ejemplos**\n- *Nos reímos mucho con esa película.* — We laughed a lot with that movie.\n- *Ojalá rías de nuevo pronto.* — I hope you laugh again soon.\n\n### Saber — to know\n\n*Irregularidad clave:* Yo **sé**; pretérito **supe**; subjuntivo presente **sepa**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | sé | sabes | sabe | sabemos | sabéis | saben |\n| Pretérito indefinido | supe | supiste | supo | supimos | supisteis | supieron |\n| Imperfecto | sabía | sabías | sabía | sabíamos | sabíais | sabían |\n| Futuro | sabré | sabrás | sabrá | sabremos | sabréis | sabrán |\n| Subjuntivo presente | sepa | sepas | sepa | sepamos | sepáis | sepan |\n| Subjuntivo imperfecto | supiera | supieras | supiera | supiéramos | supierais | supieran |\n| Imperativo (+/-) | — | sabe / no sepas | sepa / no sepa | sepamos / no sepamos | sabed / no sepáis | sepan / no sepan |\n\n**Participio:** sabido. **Gerundio:** sabiendo.\n\n**Ejemplos**\n- *Supe la verdad demasiado tarde.* — I found out the truth too late.\n- *Quiero que sepas que confío en ti.* — I want you to know that I trust you.\n\n### Salir — to go out / leave\n\n*Irregularidad clave:* Yo **salgo**; futuro **saldré**; subjuntivo presente **salga**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | salgo | sales | sale | salimos | salís | salen |\n| Pretérito indefinido | salí | saliste | salió | salimos | salisteis | salieron |\n| Imperfecto | salía | salías | salía | salíamos | salíais | salían |\n| Futuro | saldré | saldrás | saldrá | saldremos | saldréis | saldrán |\n| Subjuntivo presente | salga | salgas | salga | salgamos | salgáis | salgan |\n| Subjuntivo imperfecto | saliera | salieras | saliera | saliéramos | salierais | salieran |\n| Imperativo (+/-) | — | sal / no salgas | salga / no salga | salgamos / no salgamos | salid / no salgáis | salgan / no salgan |\n\n**Participio:** salido. **Gerundio:** saliendo.\n\n**Ejemplos**\n- *Salí temprano para evitar el tráfico.* — I left early to avoid traffic.\n- *Es mejor que salgas antes de las cinco.* — It’s better that you leave before five.\n\n### Ser — to be (essence)\n\n*Irregularidad clave:* Presente **soy, eres**; pretérito **fui**; imperfecto **era**; subjuntivo **sea/fuera**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | soy | eres | es | somos | sois | son |\n| Pretérito indefinido | fui | fuiste | fue | fuimos | fuisteis | fueron |\n| Imperfecto | era | eras | era | éramos | erais | eran |\n| Futuro | seré | serás | será | seremos | seréis | serán |\n| Subjuntivo presente | sea | seas | sea | seamos | seáis | sean |\n| Subjuntivo imperfecto | fuera | fueras | fuera | fuéramos | fuerais | fueran |\n| Imperativo (+/-) | — | sé / no seas | sea / no sea | seamos / no seamos | sed / no seáis | sean / no sean |\n\n**Participio:** sido. **Gerundio:** siendo.\n\n**Ejemplos**\n- *Somos responsables de nuestras decisiones.* — We are responsible for our decisions.\n- *Quería que fueras sincero conmigo.* — I wanted you to be honest with me.\n\n---\n\n> 📝 **Resumen rápido:** detecta la pieza irregular → combina con las terminaciones regulares; refuerza participios y subjuntivos con producción oral.",
+      "references": []
+    },
+    {
+      "id": "iv-t-z",
+      "level": "C1",
+      "title": "IV-D — Irregular Verb Atlas (T–Z)",
+      "slug": "iv-t-z",
+      "tags": [
+        "verbs",
+        "irregular",
+        "reference",
+        "atlas",
+        "iv-series",
+        "t-z"
+      ],
+      "markdown": "# 📚 IV-D — Irregular Verb Atlas (T–Z)\n\n**Objetivo:** consolidar las irregularidades clave del tramo alfabético.\n\n---\n\n**Foco del atlas:** verbos en *-go* (tener, venir), raíces con *-j-* (traer, traducir),\ncambios de grafía en z/y (yacer, zurcir) y futuros con consonante añadida (*valdré*,\n*vendré*). Cierra el recorrido alfabético reforzando patrones recurrentes.\n\n## 🧭 Cómo estudiar\n- Memoriza las raíces de futuro/condicional (tendr-, vendr-, valdr-).\n- Observa los imperativos: *ven/pon/ten/sal* carecen de -s en positivo.\n- Atención a los alomorfos de **yacer** (*yazco, yago*) para contextos literarios.\n\n### Tener — to have\n\n*Irregularidad clave:* Yo **tengo**; pretérito **tuve**; futuro **tendré**; subjuntivo **tenga**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | tengo | tienes | tiene | tenemos | tenéis | tienen |\n| Pretérito indefinido | tuve | tuviste | tuvo | tuvimos | tuvisteis | tuvieron |\n| Imperfecto | tenía | tenías | tenía | teníamos | teníais | tenían |\n| Futuro | tendré | tendrás | tendrá | tendremos | tendréis | tendrán |\n| Subjuntivo presente | tenga | tengas | tenga | tengamos | tengáis | tengan |\n| Subjuntivo imperfecto | tuviera | tuvieras | tuviera | tuviéramos | tuvierais | tuvieran |\n| Imperativo (+/-) | — | ten / no tengas | tenga / no tenga | tengamos / no tengamos | tened / no tengáis | tengan / no tengan |\n\n**Participio:** tenido. **Gerundio:** teniendo.\n\n**Ejemplos**\n- *Tuve que salir antes de la reunión.* — I had to leave before the meeting.\n- *Es vital que tengas paciencia.* — It’s vital that you have patience.\n\n### Traer — to bring\n\n*Irregularidad clave:* Yo **traigo**; pretérito **traje** (3ª trajeron); gerundio **trayendo**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | traigo | traes | trae | traemos | traéis | traen |\n| Pretérito indefinido | traje | trajiste | trajo | trajimos | trajisteis | trajeron |\n| Imperfecto | traía | traías | traía | traíamos | traíais | traían |\n| Futuro | traeré | traerás | traerá | traeremos | traeréis | traerán |\n| Subjuntivo presente | traiga | traigas | traiga | traigamos | traigáis | traigan |\n| Subjuntivo imperfecto | trajera | trajeras | trajera | trajéramos | trajerais | trajeran |\n| Imperativo (+/-) | — | trae / no traigas | traiga / no traiga | traigamos / no traigamos | traed / no traigáis | traigan / no traigan |\n\n**Participio:** traído. **Gerundio:** trayendo.\n\n**Ejemplos**\n- *Traje los documentos firmados.* — I brought the signed documents.\n- *Quiero que traigas pan para la cena.* — I want you to bring bread for dinner.\n\n### Traducir — to translate\n\n*Irregularidad clave:* Yo **traduzco**; pretérito **traduje** (3ª tradujeron); subjuntivo **traduzca**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | traduzco | traduces | traduce | traducimos | traducís | traducen |\n| Pretérito indefinido | traduje | tradujiste | tradujo | tradujimos | tradujisteis | tradujeron |\n| Imperfecto | traducía | traducías | traducía | traducíamos | traducíais | traducían |\n| Futuro | traduciré | traducirás | traducirá | traduciremos | traduciréis | traducirán |\n| Subjuntivo presente | traduzca | traduzcas | traduzca | traduzcamos | traduzcáis | traduzcan |\n| Subjuntivo imperfecto | tradujera | tradujeras | tradujera | tradujéramos | tradujerais | tradujeran |\n| Imperativo (+/-) | — | traduce / no traduzcas | traduzca / no traduzca | traduzcamos / no traduzcamos | traducid / no traduzcáis | traduzcan / no traduzcan |\n\n**Participio:** traducido. **Gerundio:** traduciendo.\n\n**Ejemplos**\n- *Tradujimos el artículo al español.* — We translated the article into Spanish.\n- *Es necesario que traduzcas bien los matices.* — It’s necessary that you translate the nuances well.\n\n### Valer — to be worth\n\n*Irregularidad clave:* Yo **valgo**; futuro **valdré**; subjuntivo **valga**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | valgo | vales | vale | valemos | valéis | valen |\n| Pretérito indefinido | valí | valiste | valió | valimos | valisteis | valieron |\n| Imperfecto | valía | valías | valía | valíamos | valíais | valían |\n| Futuro | valdré | valdrás | valdrá | valdremos | valdréis | valdrán |\n| Subjuntivo presente | valga | valgas | valga | valgamos | valgáis | valgan |\n| Subjuntivo imperfecto | valiera | valieras | valiera | valiéramos | valierais | valieran |\n| Imperativo (+/-) | — | vale / no valgas | valga / no valga | valgamos / no valgamos | valed / no valgáis | valgan / no valgan |\n\n**Participio:** valido. **Gerundio:** valiendo.\n\n**Ejemplos**\n- *Ese cuadro valió millones en la subasta.* — That painting was worth millions at the auction.\n- *¿Crees que valga la pena seguir intentándolo?* — Do you think it is worth continuing to try?\n\n### Venir — to come\n\n*Irregularidad clave:* Yo **vengo**; presente **vien-**; pretérito **vine**; futuro **vendré**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | vengo | vienes | viene | venimos | venís | vienen |\n| Pretérito indefinido | vine | viniste | vino | vinimos | vinisteis | vinieron |\n| Imperfecto | venía | venías | venía | veníamos | veníais | venían |\n| Futuro | vendré | vendrás | vendrá | vendremos | vendréis | vendrán |\n| Subjuntivo presente | venga | vengas | venga | vengamos | vengáis | vengan |\n| Subjuntivo imperfecto | viniera | vinieras | viniera | viniéramos | vinierais | vinieran |\n| Imperativo (+/-) | — | ven / no vengas | venga / no venga | vengamos / no vengamos | venid / no vengáis | vengan / no vengan |\n\n**Participio:** venido. **Gerundio:** viniendo.\n\n**Ejemplos**\n- *Vine a ayudarte con la mudanza.* — I came to help you with the move.\n- *Espero que vengas temprano mañana.* — I hope you come early tomorrow.\n\n### Ver — to see\n\n*Irregularidad clave:* Yo **veo**; pretérito **vi, viste, vio** sin acentos; participio **visto**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | veo | ves | ve | vemos | veis | ven |\n| Pretérito indefinido | vi | viste | vio | vimos | visteis | vieron |\n| Imperfecto | veía | veías | veía | veíamos | veíais | veían |\n| Futuro | veré | verás | verá | veremos | veréis | verán |\n| Subjuntivo presente | vea | veas | vea | veamos | veáis | vean |\n| Subjuntivo imperfecto | viera | vieras | viera | viéramos | vierais | vieran |\n| Imperativo (+/-) | — | ve / no veas | vea / no vea | veamos / no veamos | ved / no veáis | vean / no vean |\n\n**Participio:** visto. **Gerundio:** viendo.\n\n**Ejemplos**\n- *He visto esa película tres veces.* — I have seen that film three times.\n- *Ojalá vieras lo que yo veo.* — I wish you could see what I see.\n\n### Volver — to return\n\n*Irregularidad clave:* Cambio o→ue; participio irregular **vuelto**; futuro **volveré**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | vuelvo | vuelves | vuelve | volvemos | volvéis | vuelven |\n| Pretérito indefinido | volví | volviste | volvió | volvimos | volvisteis | volvieron |\n| Imperfecto | volvía | volvías | volvía | volvíamos | volvíais | volvían |\n| Futuro | volveré | volverás | volverá | volveremos | volveréis | volverán |\n| Subjuntivo presente | vuelva | vuelvas | vuelva | volvamos | volváis | vuelvan |\n| Subjuntivo imperfecto | volviera | volvieras | volviera | volviéramos | volvierais | volvieran |\n| Imperativo (+/-) | — | vuelve / no vuelvas | vuelva / no vuelva | volvamos / no volvamos | volved / no volváis | vuelvan / no vuelvan |\n\n**Participio:** vuelto. **Gerundio:** volviendo.\n\n**Ejemplos**\n- *Volví tarde del trabajo.* — I got back late from work.\n- *Cuando vuelvas, tráeme recuerdos.* — When you come back, bring me souvenirs.\n\n### Yacer — to lie (at rest)\n\n*Irregularidad clave:* Yo **yazco** (también *yago*); pretérito **yací/yació**; subjuntivo **yazca**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | yazco | yaces | yace | yacemos | yacéis | yacen |\n| Pretérito indefinido | yací | yaciste | yació | yacimos | yacisteis | yacieron |\n| Imperfecto | yacía | yacías | yacía | yacíamos | yacíais | yacían |\n| Futuro | yaceré | yacerás | yacerá | yaceremos | yaceréis | yacerán |\n| Subjuntivo presente | yazca | yazcas | yazca | yazcamos | yazcáis | yazcan |\n| Subjuntivo imperfecto | yaciera | yacieras | yaciera | yaciéramos | yacierais | yacieran |\n| Imperativo (+/-) | — | yace / no yazcas | yazca / no yazca | yazcamos / no yazcamos | yaced / no yazcáis | yazcan / no yazcan |\n\n**Participio:** yacido. **Gerundio:** yaciendo.\n\n**Ejemplos**\n- *El guerrero yace en la tumba de sus ancestros.* — The warrior lies in his ancestors’ tomb.\n- *Cuando yazcas tan cansado, descansa un poco.* — When you lie exhausted, rest a little.\n\n### Zurcir — to darn / mend\n\n*Irregularidad clave:* Yo **zurzo**; subjuntivo **zurza**; 2ª pl. imperativo **zurcid**.\n\n| Tiempo | yo | tú | él/ella/Ud. | nosotros | vosotros | ellos/Uds. |\n|---|---|---|---|---|---|---|\n| Presente | zurzo | zurces | zurce | zurcimos | zurcís | zurcen |\n| Pretérito indefinido | zurcí | zurciste | zurció | zurcimos | zurcisteis | zurcieron |\n| Imperfecto | zurcía | zurcías | zurcía | zurcíamos | zurcíais | zurcían |\n| Futuro | zurciré | zurcirás | zurcirá | zurciremos | zurciréis | zurcirán |\n| Subjuntivo presente | zurza | zurzas | zurza | zurzamos | zurzáis | zurzan |\n| Subjuntivo imperfecto | zurciera | zurcieras | zurciera | zurciéramos | zurcierais | zurcieran |\n| Imperativo (+/-) | — | zurce / no zurzas | zurza / no zurza | zurzamos / no zurzamos | zurcid / no zurzáis | zurzan / no zurzan |\n\n**Participio:** zurcido. **Gerundio:** zurciendo.\n\n**Ejemplos**\n- *Zurzo los calcetines viejos a mano.* — I darn the old socks by hand.\n- *Es necesario que zurzas la red antes del viaje.* — It’s necessary that you darn the net before the trip.\n\n---\n\n> 📝 **Resumen rápido:** detecta la pieza irregular → combina con las terminaciones regulares; refuerza participios y subjuntivos con producción oral.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "iv-a-c-ex01",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "Hemos ___ todas las ventanas para ventilar. (participio)",
+      "answer": "abierto",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Participio irregular con -ierto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "abrir cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex02",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **If you opened your mind, you would see other options.**",
+      "answer": "Si abrieras la mente, verías otras opciones.",
+      "accepted": [
+        "re:^Si\\ abrieras\\ la\\ mente,\\ verías\\ otras\\ opciones\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Si abrieras la mente, verías otras opciones.",
+        "wrong": "Recuerda: Si abrieras la mente, verías otras opciones."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "abrir traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex03",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "Ayer ___ diez kilómetros por la montaña. (pretérito nosotros)",
+      "answer": "anduvimos",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz anduv- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "andar cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex04",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **When you walk carefully, you will avoid tripping.**",
+      "answer": "Cuando andes con cuidado, evitarás tropezar.",
+      "accepted": [
+        "re:^Cuando\\ andes\\ con\\ cuidado,\\ evitarás\\ tropezar\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Cuando andes con cuidado, evitarás tropezar.",
+        "wrong": "Recuerda: Cuando andes con cuidado, evitarás tropezar."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "andar traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex05",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "El sacerdote ___ el agua antes de la ceremonia. (pretérito él)",
+      "answer": "bendijo",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz bendij- + terminación -o."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "bendecir cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex06",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **May God bless you in every step you take.**",
+      "answer": "Que Dios te bendiga en cada paso que des.",
+      "accepted": [
+        "re:^Que\\ Dios\\ te\\ bendiga\\ en\\ cada\\ paso\\ que\\ des\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Que Dios te bendiga en cada paso que des.",
+        "wrong": "Recuerda: Que Dios te bendiga en cada paso que des."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "bendecir traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex07",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "En la maleta no ___ todos los libros. (pretérito ellos)",
+      "answer": "cupieron",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz cup- + -ieron."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "caber cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex08",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you fit on the final team.**",
+      "answer": "Ojalá que quepas en el equipo definitivo.",
+      "accepted": [
+        "re:^Ojalá\\ que\\ quepas\\ en\\ el\\ equipo\\ definitivo\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Ojalá que quepas en el equipo definitivo.",
+        "wrong": "Recuerda: Ojalá que quepas en el equipo definitivo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "caber traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex09",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "Se ___ porque no miró el escalón. (pretérito él)",
+      "answer": "cayó",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Cambio i→y en 3ª persona."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "caer cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex10",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **Don’t let the team’s morale drop.**",
+      "answer": "No dejes que caiga la moral del equipo.",
+      "accepted": [
+        "re:^No\\ dejes\\ que\\ caiga\\ la\\ moral\\ del\\ equipo\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: No dejes que caiga la moral del equipo.",
+        "wrong": "Recuerda: No dejes que caiga la moral del equipo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "caer traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex11",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "Ayer ___ durante cinco horas seguidas. (pretérito yo)",
+      "answer": "conduje",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz conduj- con j en 1ª persona."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "conducir cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex12",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **Drive carefully when it snows.**",
+      "answer": "Conduzcan con prudencia cuando nieve.",
+      "accepted": [
+        "re:^Conduzcan\\ con\\ prudencia\\ cuando\\ nieve\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Conduzcan con prudencia cuando nieve.",
+        "wrong": "Recuerda: Conduzcan con prudencia cuando nieve."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "conducir traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex13",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "___ la tienda a las ocho en punto. (presente yo)",
+      "answer": "Cierro",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Diptongo ie en las formas fuertes."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "cerrar cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex14",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s necessary that you lock the door.**",
+      "answer": "Es necesario que cierres la puerta con llave.",
+      "accepted": [
+        "re:^Es\\ necesario\\ que\\ cierres\\ la\\ puerta\\ con\\ llave\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es necesario que cierres la puerta con llave.",
+        "wrong": "Recuerda: Es necesario que cierres la puerta con llave."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "cerrar traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex15",
+      "lessonId": "iv-a-c",
+      "type": "cloze",
+      "promptMd": "___ un puente sobre el río. (pretérito ellos)",
+      "answer": "Construyeron",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Cambio i→y en 3ª persona."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "construir cloze"
+      }
+    },
+    {
+      "id": "iv-a-c-ex16",
+      "lessonId": "iv-a-c",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you build your project calmly.**",
+      "answer": "Espero que construyas tu proyecto con calma.",
+      "accepted": [
+        "re:^Espero\\ que\\ construyas\\ tu\\ proyecto\\ con\\ calma\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Espero que construyas tu proyecto con calma.",
+        "wrong": "Recuerda: Espero que construyas tu proyecto con calma."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "construir traducción"
+      }
+    },
+    {
+      "id": "iv-a-c-ex17",
+      "lessonId": "iv-a-c",
+      "type": "conjugate",
+      "promptMd": "Conjuga **andar** en pretérito indefinido.",
+      "answer": [
+        "anduve",
+        "anduviste",
+        "anduvo",
+        "anduvimos",
+        "anduvisteis",
+        "anduvieron"
+      ],
+      "feedback": {
+        "correct": "Perfecto: Pretérito indefinido de *andar* sigue Pretérito con raíz anduv- y subjuntivo pretérito anduviera..",
+        "wrong": "Revisa la irregularidad: Pretérito con raíz anduv- y subjuntivo pretérito anduviera.."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "anduv- pretérito"
+      }
+    },
+    {
+      "id": "iv-a-c-ex18",
+      "lessonId": "iv-a-c",
+      "type": "conjugate",
+      "promptMd": "Conjuga **caber** en presente de subjuntivo.",
+      "answer": [
+        "quepa",
+        "quepas",
+        "quepa",
+        "quepamos",
+        "quepáis",
+        "quepan"
+      ],
+      "feedback": {
+        "correct": "Perfecto: Subjuntivo presente de *caber* sigue Yo quepo; pretérito cupe; futuro cabré; subjuntivo presente quepa..",
+        "wrong": "Revisa la irregularidad: Yo quepo; pretérito cupe; futuro cabré; subjuntivo presente quepa.."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "quepa subjuntivo"
+      }
+    },
+    {
+      "id": "iv-a-c-ex19",
+      "lessonId": "iv-a-c",
+      "type": "mcq",
+      "promptMd": "¿Cuál es el participio pasado que se usa con **haber** para *abrir*?",
+      "options": [
+        "abrido",
+        "abierto",
+        "abrado",
+        "abrierto"
+      ],
+      "answer": "abierto",
+      "feedback": {
+        "correct": "Correcto: *abrir* → **abierto** con haber.",
+        "wrong": "Recuerda que *abrir* forma el participio irregular **abierto**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "participio abierto"
+      }
+    },
+    {
+      "id": "iv-a-c-ex20",
+      "lessonId": "iv-a-c",
+      "type": "multi",
+      "promptMd": "Selecciona las oraciones que usan correctamente las formas con **y** de *construir*.",
+      "options": [
+        "Ellos construyeron un puente resistente.",
+        "Si construieramos refugios, aguantarían la lluvia.",
+        "Espero que construyas tu proyecto con calma.",
+        "Construyímos la casa en dos semanas."
+      ],
+      "answer": [
+        "Ellos construyeron un puente resistente.",
+        "Espero que construyas tu proyecto con calma."
+      ],
+      "feedback": {
+        "correct": "Bien: construyeron / construyas son formas con y correctas.",
+        "wrong": "Recuerda: *construyéramos* lleva y y tilde; *construimos* no lleva y."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "cambio i→y"
+      }
+    },
+    {
+      "id": "iv-d-l-ex01",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "Siempre ___ la verdad aunque duela. (presente yo)",
+      "answer": "digo",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Yo con g: digo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "decir cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex02",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **They asked us to tell the truth.**",
+      "answer": "Nos pidieron que dijéramos la verdad.",
+      "accepted": [
+        "re:^Nos\\ pidieron\\ que\\ dijéramos\\ la\\ verdad\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Nos pidieron que dijéramos la verdad.",
+        "wrong": "Recuerda: Nos pidieron que dijéramos la verdad."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "decir traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex03",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "Anoche ___ como un tronco. (pretérito yo)",
+      "answer": "dormí",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Pretérito regular excepto 3ª persona."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "dormir cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex04",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s necessary that you sleep eight hours a day.**",
+      "answer": "Es necesario que duermas ocho horas diarias.",
+      "accepted": [
+        "re:^Es\\ necesario\\ que\\ duermas\\ ocho\\ horas\\ diarias\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es necesario que duermas ocho horas diarias.",
+        "wrong": "Recuerda: Es necesario que duermas ocho horas diarias."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "dormir traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex05",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ muy contento con los resultados. (presente yo)",
+      "answer": "Estoy",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Primera persona irregular con -oy."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex06",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **If you were here, you would understand the situation.**",
+      "answer": "Si estuvieras aquí, entenderías la situación.",
+      "accepted": [
+        "re:^Si\\ estuvieras\\ aquí,\\ entenderías\\ la\\ situación\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Si estuvieras aquí, entenderías la situación.",
+        "wrong": "Recuerda: Si estuvieras aquí, entenderías la situación."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "estar traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex07",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ los huevos con aceite de oliva. (presente yo)",
+      "answer": "Frío",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Acento para mantener diptongo: frío."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "freír cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex08",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s better if you fry the potatoes in two batches.**",
+      "answer": "Es mejor que frías las patatas en dos tandas.",
+      "accepted": [
+        "re:^Es\\ mejor\\ que\\ frías\\ las\\ patatas\\ en\\ dos\\ tandas\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es mejor que frías las patatas en dos tandas.",
+        "wrong": "Recuerda: Es mejor que frías las patatas en dos tandas."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "freír traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex09",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ habido muchos cambios en la empresa. (pretérito perfecto)",
+      "answer": "Ha",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: 3ª persona singular del presente de haber."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "haber cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex10",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you have rested enough.**",
+      "answer": "Espero que hayas descansado lo suficiente.",
+      "accepted": [
+        "re:^Espero\\ que\\ hayas\\ descansado\\ lo\\ suficiente\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Espero que hayas descansado lo suficiente.",
+        "wrong": "Recuerda: Espero que hayas descansado lo suficiente."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "haber traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex11",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ un pastel para la fiesta. (pretérito nosotros)",
+      "answer": "Hicimos",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz hic- con c→z en 3ª singular."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "hacer cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex12",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you do the right thing.**",
+      "answer": "Ojalá hagas lo correcto.",
+      "accepted": [
+        "re:^Ojalá\\ hagas\\ lo\\ correcto\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Ojalá hagas lo correcto.",
+        "wrong": "Recuerda: Ojalá hagas lo correcto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "hacer traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex13",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ al cine todos los viernes. (presente nosotros)",
+      "answer": "Vamos",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Nosotros conserva -amos."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ir cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex14",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I wanted you to go with me to the concert.**",
+      "answer": "Quería que fueras conmigo al concierto.",
+      "accepted": [
+        "re:^Quería\\ que\\ fueras\\ conmigo\\ al\\ concierto\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Quería que fueras conmigo al concierto.",
+        "wrong": "Recuerda: Quería que fueras conmigo al concierto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ir traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex15",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ al baloncesto en la universidad. (pretérito yo)",
+      "answer": "Jugué",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: g + u para conservar el sonido /g/."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "jugar cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex16",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you play with us tomorrow.**",
+      "answer": "Espero que juegues con nosotros mañana.",
+      "accepted": [
+        "re:^Espero\\ que\\ juegues\\ con\\ nosotros\\ mañana\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Espero que juegues con nosotros mañana.",
+        "wrong": "Recuerda: Espero que juegues con nosotros mañana."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "jugar traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex17",
+      "lessonId": "iv-d-l",
+      "type": "cloze",
+      "promptMd": "___ el informe en detalle. (pretérito yo)",
+      "answer": "Leí",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Acento en -í para romper diptongo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "leer cloze"
+      }
+    },
+    {
+      "id": "iv-d-l-ex18",
+      "lessonId": "iv-d-l",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It is important that you read the instructions.**",
+      "answer": "Es importante que leas las instrucciones.",
+      "accepted": [
+        "re:^Es\\ importante\\ que\\ leas\\ las\\ instrucciones\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es importante que leas las instrucciones.",
+        "wrong": "Recuerda: Es importante que leas las instrucciones."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "leer traducción"
+      }
+    },
+    {
+      "id": "iv-d-l-ex19",
+      "lessonId": "iv-d-l",
+      "type": "conjugate",
+      "promptMd": "Conjuga **ir** en pretérito imperfecto.",
+      "answer": [
+        "iba",
+        "ibas",
+        "iba",
+        "íbamos",
+        "ibais",
+        "iban"
+      ],
+      "feedback": {
+        "correct": "Perfecto: Imperfecto de *ir* sigue Suplétivo: presente voy, pretérito fui, subjuntivo vaya..",
+        "wrong": "Revisa la irregularidad: Suplétivo: presente voy, pretérito fui, subjuntivo vaya.."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "iba, ibas..."
+      }
+    },
+    {
+      "id": "iv-d-l-ex20",
+      "lessonId": "iv-d-l",
+      "type": "mcq",
+      "promptMd": "Elige el participio adjetivo más usado de **freír**.",
+      "options": [
+        "frito",
+        "freído",
+        "friado",
+        "freido"
+      ],
+      "answer": "frito",
+      "feedback": {
+        "correct": "Exacto: *frito* es el participio adjetivo habitual (aunque *freído* existe como verbal).",
+        "wrong": "La forma más extendida como adjetivo es **frito**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "participio doble"
+      }
+    },
+    {
+      "id": "iv-m-s-ex01",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "El héroe ___ defendiendo su tierra. (pretérito él)",
+      "answer": "murió",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Cambio e→u en 3ª persona."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "morir cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex02",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **Hopefully not so many bees die this year.**",
+      "answer": "Ojalá no mueran tantas abejas este año.",
+      "accepted": [
+        "re:^Ojalá\\ no\\ mueran\\ tantas\\ abejas\\ este\\ año\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Ojalá no mueran tantas abejas este año.",
+        "wrong": "Recuerda: Ojalá no mueran tantas abejas este año."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "morir traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex03",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "¿___ ese ruido extraño? (pretérito tú)",
+      "answer": "Oíste",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Acento en -í por hiato."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "oír cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex04",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you hear the instructions well.**",
+      "answer": "Espero que oigas bien las instrucciones.",
+      "accepted": [
+        "re:^Espero\\ que\\ oigas\\ bien\\ las\\ instrucciones\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Espero que oigas bien las instrucciones.",
+        "wrong": "Recuerda: Espero que oigas bien las instrucciones."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "oír traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex05",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "___ ayuda cuando vio el problema. (pretérito él/ella)",
+      "answer": "Pidió",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Cambio e→i en 3ª persona."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "pedir cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex06",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I suggest you apply for the scholarship this year.**",
+      "answer": "Te sugiero que pidas la beca este año.",
+      "accepted": [
+        "re:^Te\\ sugiero\\ que\\ pidas\\ la\\ beca\\ este\\ año\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Te sugiero que pidas la beca este año.",
+        "wrong": "Recuerda: Te sugiero que pidas la beca este año."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "pedir traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex07",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "No ___ asistir a la reunión. (pretérito yo)",
+      "answer": "pude",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz pud- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "poder cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex08",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **When you can, call me.**",
+      "answer": "Cuando puedas, llámame.",
+      "accepted": [
+        "re:^Cuando\\ puedas,\\ llámame\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Cuando puedas, llámame.",
+        "wrong": "Recuerda: Cuando puedas, llámame."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "poder traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex09",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "___ los platos en la mesa. (pretérito yo)",
+      "answer": "Puse",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz pus- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "poner cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex10",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It is necessary that you pay more attention.**",
+      "answer": "Es necesario que pongas más atención.",
+      "accepted": [
+        "re:^Es\\ necesario\\ que\\ pongas\\ más\\ atención\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es necesario que pongas más atención.",
+        "wrong": "Recuerda: Es necesario que pongas más atención."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "poner traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex11",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "___ ayudarte pero llegué tarde. (pretérito yo)",
+      "answer": "Quise",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz quis- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "querer cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex12",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "Nos ___ mucho con esa película. (pretérito nosotros)",
+      "answer": "reímos",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Acento en -í para mantener hiato."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "reír cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex13",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you laugh again soon.**",
+      "answer": "Ojalá rías de nuevo pronto.",
+      "accepted": [
+        "re:^Ojalá\\ rías\\ de\\ nuevo\\ pronto\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Ojalá rías de nuevo pronto.",
+        "wrong": "Recuerda: Ojalá rías de nuevo pronto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "reír traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex14",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "___ la verdad demasiado tarde. (pretérito yo)",
+      "answer": "Supe",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz sup- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "saber cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex15",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "___ temprano para evitar el tráfico. (pretérito yo)",
+      "answer": "Salí",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Pretérito regular; atención a acento en -í."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "salir cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex16",
+      "lessonId": "iv-m-s",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s better that you leave before five.**",
+      "answer": "Es mejor que salgas antes de las cinco.",
+      "accepted": [
+        "re:^Es\\ mejor\\ que\\ salgas\\ antes\\ de\\ las\\ cinco\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es mejor que salgas antes de las cinco.",
+        "wrong": "Recuerda: Es mejor que salgas antes de las cinco."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "salir traducción"
+      }
+    },
+    {
+      "id": "iv-m-s-ex17",
+      "lessonId": "iv-m-s",
+      "type": "cloze",
+      "promptMd": "___ responsables de nuestras decisiones. (presente nosotros)",
+      "answer": "Somos",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Nosotros mantiene forma irregular propia."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ser cloze"
+      }
+    },
+    {
+      "id": "iv-m-s-ex18",
+      "lessonId": "iv-m-s",
+      "type": "conjugate",
+      "promptMd": "Conjuga **querer** en pretérito indefinido.",
+      "answer": [
+        "quise",
+        "quisiste",
+        "quiso",
+        "quisimos",
+        "quisisteis",
+        "quisieron"
+      ],
+      "feedback": {
+        "correct": "Perfecto: Pretérito indefinido de *querer* sigue Cambio e→ie; pretérito quis-; futuro querr-..",
+        "wrong": "Revisa la irregularidad: Cambio e→ie; pretérito quis-; futuro querr-.."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "quis- pretérito"
+      }
+    },
+    {
+      "id": "iv-m-s-ex19",
+      "lessonId": "iv-m-s",
+      "type": "mcq",
+      "promptMd": "Traduce al español: *I want you to know that I trust you.*",
+      "options": [
+        "Quiero que sepas que confío en ti.",
+        "Quiero que sabes que confío en ti.",
+        "Quiero que sepas que confías en mí.",
+        "Quise que supieras que confío en ti."
+      ],
+      "answer": "Quiero que sepas que confío en ti.",
+      "feedback": {
+        "correct": "Perfecto: *Quiero que sepas que confío en ti* usa subjuntivo presente tras querer.",
+        "wrong": "Necesitas subjuntivo: **sepas** + *confío en ti*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "querer + subjuntivo"
+      }
+    },
+    {
+      "id": "iv-m-s-ex20",
+      "lessonId": "iv-m-s",
+      "type": "multi",
+      "promptMd": "Selecciona las oraciones que requieren el subjuntivo de **ser**.",
+      "options": [
+        "Quería que fueras sincero conmigo.",
+        "Sé que eres sincero conmigo.",
+        "Necesitan que seamos puntuales.",
+        "Ellos son sinceros cuando hablan."
+      ],
+      "answer": [
+        "Quería que fueras sincero conmigo.",
+        "Necesitan que seamos puntuales."
+      ],
+      "feedback": {
+        "correct": "Exacto: *quería que fueras* y *necesitan que seamos* activan subjuntivo.",
+        "wrong": "Recuerda: verbos de deseo o necesidad → subjuntivo (fueras, seamos)."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "subjuntivo ser"
+      }
+    },
+    {
+      "id": "iv-t-z-ex01",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "___ que salir antes de la reunión. (pretérito yo)",
+      "answer": "Tuve",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz tuv- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "tener cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex02",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s vital that you have patience.**",
+      "answer": "Es vital que tengas paciencia.",
+      "accepted": [
+        "re:^Es\\ vital\\ que\\ tengas\\ paciencia\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es vital que tengas paciencia.",
+        "wrong": "Recuerda: Es vital que tengas paciencia."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "tener traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex03",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "___ los documentos firmados. (pretérito yo)",
+      "answer": "Traje",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz traj- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "traer cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex04",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I want you to bring bread for dinner.**",
+      "answer": "Quiero que traigas pan para la cena.",
+      "accepted": [
+        "re:^Quiero\\ que\\ traigas\\ pan\\ para\\ la\\ cena\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Quiero que traigas pan para la cena.",
+        "wrong": "Recuerda: Quiero que traigas pan para la cena."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "traer traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex05",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "___ el artículo al español. (pretérito nosotros)",
+      "answer": "Tradujimos",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz traduj- + -imos sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "traducir cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex06",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s necessary that you translate the nuances well.**",
+      "answer": "Es necesario que traduzcas bien los matices.",
+      "accepted": [
+        "re:^Es\\ necesario\\ que\\ traduzcas\\ bien\\ los\\ matices\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es necesario que traduzcas bien los matices.",
+        "wrong": "Recuerda: Es necesario que traduzcas bien los matices."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "traducir traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex07",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "Ese cuadro ___ millones en la subasta. (pretérito él)",
+      "answer": "valió",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Pretérito regular: atención al acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "valer cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex08",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **Do you think it is worth continuing to try?**",
+      "answer": "¿Crees que valga la pena seguir intentándolo?",
+      "accepted": [
+        "re:^¿Crees\\ que\\ valga\\ la\\ pena\\ seguir\\ intentándolo\\?$"
+      ],
+      "feedback": {
+        "correct": "Bien: ¿Crees que valga la pena seguir intentándolo?",
+        "wrong": "Recuerda: ¿Crees que valga la pena seguir intentándolo?"
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "valer traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex09",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "___ a ayudarte con la mudanza. (pretérito yo)",
+      "answer": "Vine",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Raíz vin- + terminaciones sin acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "venir cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex10",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I hope you come early tomorrow.**",
+      "answer": "Espero que vengas temprano mañana.",
+      "accepted": [
+        "re:^Espero\\ que\\ vengas\\ temprano\\ mañana\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Espero que vengas temprano mañana.",
+        "wrong": "Recuerda: Espero que vengas temprano mañana."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "venir traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex11",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "He ___ esa película tres veces. (participio)",
+      "answer": "visto",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Participio irregular con -sto."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ver cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex12",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **I wish you could see what I see.**",
+      "answer": "Ojalá vieras lo que yo veo.",
+      "accepted": [
+        "re:^Ojalá\\ vieras\\ lo\\ que\\ yo\\ veo\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Ojalá vieras lo que yo veo.",
+        "wrong": "Recuerda: Ojalá vieras lo que yo veo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "ver traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex13",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "___ tarde del trabajo. (pretérito yo)",
+      "answer": "Volví",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Pretérito regular; atención a acento."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "volver cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex14",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **When you come back, bring me souvenirs.**",
+      "answer": "Cuando vuelvas, tráeme recuerdos.",
+      "accepted": [
+        "re:^Cuando\\ vuelvas,\\ tráeme\\ recuerdos\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Cuando vuelvas, tráeme recuerdos.",
+        "wrong": "Recuerda: Cuando vuelvas, tráeme recuerdos."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "volver traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex15",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "El guerrero ___ en la tumba de sus ancestros. (presente él)",
+      "answer": "yace",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Yo yazco; 3ª persona mantiene c suave."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "yacer cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex16",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **When you lie exhausted, rest a little.**",
+      "answer": "Cuando yazcas tan cansado, descansa un poco.",
+      "accepted": [
+        "re:^Cuando\\ yazcas\\ tan\\ cansado,\\ descansa\\ un\\ poco\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Cuando yazcas tan cansado, descansa un poco.",
+        "wrong": "Recuerda: Cuando yazcas tan cansado, descansa un poco."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "yacer traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex17",
+      "lessonId": "iv-t-z",
+      "type": "cloze",
+      "promptMd": "___ los calcetines viejos a mano. (presente yo)",
+      "answer": "Zurzo",
+      "feedback": {
+        "correct": "Correcto.",
+        "wrong": "Pista: Yo cambia c→z para mantener el sonido."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "zurcir cloze"
+      }
+    },
+    {
+      "id": "iv-t-z-ex18",
+      "lessonId": "iv-t-z",
+      "type": "translate",
+      "promptMd": "Traduce al español: **It’s necessary that you darn the net before the trip.**",
+      "answer": "Es necesario que zurzas la red antes del viaje.",
+      "accepted": [
+        "re:^Es\\ necesario\\ que\\ zurzas\\ la\\ red\\ antes\\ del\\ viaje\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: Es necesario que zurzas la red antes del viaje.",
+        "wrong": "Recuerda: Es necesario que zurzas la red antes del viaje."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "zurcir traducción"
+      }
+    },
+    {
+      "id": "iv-t-z-ex19",
+      "lessonId": "iv-t-z",
+      "type": "conjugate",
+      "promptMd": "Conjuga **tener** en pretérito indefinido.",
+      "answer": [
+        "tuve",
+        "tuviste",
+        "tuvo",
+        "tuvimos",
+        "tuvisteis",
+        "tuvieron"
+      ],
+      "feedback": {
+        "correct": "Perfecto: Pretérito indefinido de *tener* sigue Yo tengo; pretérito tuve; futuro tendré; subjuntivo tenga..",
+        "wrong": "Revisa la irregularidad: Yo tengo; pretérito tuve; futuro tendré; subjuntivo tenga.."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "tuv- pretérito"
+      }
+    },
+    {
+      "id": "iv-t-z-ex20",
+      "lessonId": "iv-t-z",
+      "type": "mcq",
+      "promptMd": "¿Cuál es la forma de futuro simple (yo) de **valer**?",
+      "options": [
+        "valdré",
+        "valeré",
+        "valré",
+        "valdría"
+      ],
+      "answer": "valdré",
+      "feedback": {
+        "correct": "Correcto: futuro irregular **valdré** (raíz valdr-).",
+        "wrong": "La raíz de futuro es **valdr-**: yo **valdré**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "futuro valdr-"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "iv-a-abrir",
+      "front": "abrir — formas clave",
+      "back": "yo abro; pret. yo abrí; subj. yo abra; participio abierto. Nota: Participio irregular abierto; resto regular.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-a-andar",
+      "front": "andar — formas clave",
+      "back": "yo ando; pret. yo anduve; subj. yo ande; participio andado. Nota: Pretérito con raíz anduv- y subjuntivo pretérito anduviera.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-b-bendecir",
+      "front": "bendecir — formas clave",
+      "back": "yo bendigo; pret. yo bendije; subj. yo bendiga; participio bendecido (verbal) / bendito (adjetivo). Nota: Como *decir*: yo bendigo, pretérito bendije, participio verbal *bendecido* (adjetivo *bendito*).",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-c-caber",
+      "front": "caber — formas clave",
+      "back": "yo quepo; pret. yo cupe; subj. yo quepa; participio cabido. Nota: Yo quepo; pretérito cupe; futuro cabré; subjuntivo presente quepa.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-c-caer",
+      "front": "caer — formas clave",
+      "back": "yo caigo; pret. yo caí; subj. yo caiga; participio caído. Nota: Yo caigo; pretérito con y (cayó, cayeron); participio caído.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-c-conducir",
+      "front": "conducir — formas clave",
+      "back": "yo conduzco; pret. yo conduje; subj. yo conduzca; participio conducido. Nota: Yo conduzco; pretérito conduje con 3ª plural -eron.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-c-cerrar",
+      "front": "cerrar — formas clave",
+      "back": "yo cierro; pret. yo cerré; subj. yo cierre; participio cerrado. Nota: Cambio vocálico e→ie excepto en nosotros/vosotros.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-c-construir",
+      "front": "construir — formas clave",
+      "back": "yo construyo; pret. yo construí; subj. yo construya; participio construido. Nota: Cambio i→y en presente, pretérito y subjuntivo; nosotros conservan i.",
+      "tag": "iv-atlas>a–c",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-d-decir",
+      "front": "decir — formas clave",
+      "back": "yo digo; pret. yo dije; subj. yo diga; participio dicho. Nota: Yo digo; pretérito dije; participio dicho.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-d-dormir",
+      "front": "dormir — formas clave",
+      "back": "yo duermo; pret. yo dormí; subj. yo duerma; participio dormido. Nota: Cambio o→ue/e→u; pretérito 3ª persona durmió/durmieron.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-e-estar",
+      "front": "estar — formas clave",
+      "back": "yo estoy; pret. yo estuve; subj. yo esté; participio estado. Nota: Yo estoy; pretérito estuve; subjuntivo esté.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-f-freir",
+      "front": "freír — formas clave",
+      "back": "yo frío; pret. yo freí; subj. yo fría; participio freído / frito. Nota: Acentos en presente (frío); participio doble *freído/frito*.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-h-haber",
+      "front": "haber — formas clave",
+      "back": "yo he; pret. yo hube; subj. yo haya; participio habido (raro). Nota: Auxiliar: he, has, ha; pretérito hube; subjuntivo haya.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-h-hacer",
+      "front": "hacer — formas clave",
+      "back": "yo hago; pret. yo hice; subj. yo haga; participio hecho. Nota: Yo hago; pretérito hice (3ª hizo); futuro haré.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-i-ir",
+      "front": "ir — formas clave",
+      "back": "yo voy; pret. yo fui; subj. yo vaya; participio ido. Nota: Suplétivo: presente voy, pretérito fui, subjuntivo vaya.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-j-jugar",
+      "front": "jugar — formas clave",
+      "back": "yo juego; pret. yo jugué; subj. yo juegue; participio jugado. Nota: Cambio u→ue; pretérito yo jugué con g; subjuntivo juegue.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-l-leer",
+      "front": "leer — formas clave",
+      "back": "yo leo; pret. yo leí; subj. yo lea; participio leído. Nota: Pretérito con y (leyó, leyeron); gerundio leyendo.",
+      "tag": "iv-atlas>d–l",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-m-morir",
+      "front": "morir — formas clave",
+      "back": "yo muero; pret. yo morí; subj. yo muera; participio muerto. Nota: Cambio o→ue/e→u; participio irregular muerto.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-o-oir",
+      "front": "oír — formas clave",
+      "back": "yo oigo; pret. yo oí; subj. yo oiga; participio oído. Nota: Formas con y (oigo, oyes); pretérito oyó, oyeron.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-p-pedir",
+      "front": "pedir — formas clave",
+      "back": "yo pido; pret. yo pedí; subj. yo pida; participio pedido. Nota: Cambio e→i; pretérito 3ª persona pidió/pidieron.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-p-poder",
+      "front": "poder — formas clave",
+      "back": "yo puedo; pret. yo pude; subj. yo pueda; participio podido. Nota: Raíz irregular: presente pued-, pretérito pud-, futuro podr-.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-p-poner",
+      "front": "poner — formas clave",
+      "back": "yo pongo; pret. yo puse; subj. yo ponga; participio puesto. Nota: Yo pongo; pretérito puse; futuro pondré; participio puesto.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-q-querer",
+      "front": "querer — formas clave",
+      "back": "yo quiero; pret. yo quise; subj. yo quiera; participio querido. Nota: Cambio e→ie; pretérito quis-; futuro querr-.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-r-reir",
+      "front": "reír — formas clave",
+      "back": "yo río; pret. yo reí; subj. yo ría; participio reído. Nota: Acentos en presente (río); pretérito rió, rieron; gerundio riendo.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-s-saber",
+      "front": "saber — formas clave",
+      "back": "yo sé; pret. yo supe; subj. yo sepa; participio sabido. Nota: Yo sé; pretérito supe; subjuntivo presente sepa.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-s-salir",
+      "front": "salir — formas clave",
+      "back": "yo salgo; pret. yo salí; subj. yo salga; participio salido. Nota: Yo salgo; futuro saldré; subjuntivo presente salga.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-s-ser",
+      "front": "ser — formas clave",
+      "back": "yo soy; pret. yo fui; subj. yo sea; participio sido. Nota: Presente soy, eres; pretérito fui; imperfecto era; subjuntivo sea/fuera.",
+      "tag": "iv-atlas>m–s",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-t-tener",
+      "front": "tener — formas clave",
+      "back": "yo tengo; pret. yo tuve; subj. yo tenga; participio tenido. Nota: Yo tengo; pretérito tuve; futuro tendré; subjuntivo tenga.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-t-traer",
+      "front": "traer — formas clave",
+      "back": "yo traigo; pret. yo traje; subj. yo traiga; participio traído. Nota: Yo traigo; pretérito traje (3ª trajeron); gerundio trayendo.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-t-traducir",
+      "front": "traducir — formas clave",
+      "back": "yo traduzco; pret. yo traduje; subj. yo traduzca; participio traducido. Nota: Yo traduzco; pretérito traduje (3ª tradujeron); subjuntivo traduzca.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-v-valer",
+      "front": "valer — formas clave",
+      "back": "yo valgo; pret. yo valí; subj. yo valga; participio valido. Nota: Yo valgo; futuro valdré; subjuntivo valga.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-v-venir",
+      "front": "venir — formas clave",
+      "back": "yo vengo; pret. yo vine; subj. yo venga; participio venido. Nota: Yo vengo; presente vien-; pretérito vine; futuro vendré.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-v-ver",
+      "front": "ver — formas clave",
+      "back": "yo veo; pret. yo vi; subj. yo vea; participio visto. Nota: Yo veo; pretérito vi, viste, vio sin acentos; participio visto.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-v-volver",
+      "front": "volver — formas clave",
+      "back": "yo vuelvo; pret. yo volví; subj. yo vuelva; participio vuelto. Nota: Cambio o→ue; participio irregular vuelto; futuro volveré.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-y-yacer",
+      "front": "yacer — formas clave",
+      "back": "yo yazco; pret. yo yací; subj. yo yazca; participio yacido. Nota: Yo yazco (también *yago*); pretérito yací/yació; subjuntivo yazca.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    },
+    {
+      "id": "iv-z-zurcir",
+      "front": "zurcir — formas clave",
+      "back": "yo zurzo; pret. yo zurcí; subj. yo zurza; participio zurcido. Nota: Yo zurzo; subjuntivo zurza; 2ª pl. imperativo zurcid.",
+      "tag": "iv-atlas>t–z",
+      "deck": "verbs"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add IV-A through IV-D irregular verb atlas lessons with detailed paradigms and usage examples
- provide 80 mixed exercises (cloze, translation, conjugation, MCQ, multi-select) tied to each atlas lesson
- export 36 verb flashcards with stable IDs for the atlas chunks

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd979a1d9c832489c10638d855cb01