### PR TITLE
Add D-series drills, flashcards export, and cheat sheet

### DIFF
--- a/docs/d2-anki-guide.md
+++ b/docs/d2-anki-guide.md
@@ -1,0 +1,33 @@
+# D2 — Consolidated Anki Export & Mobile Guide
+
+## 1. Archivo listo para importar
+- **Ruta:** `exports/d2-anki-export.csv`
+- **Formato:** columnas `front, back, tag` compatibles con Anki.
+- **Contenido:** combina todas las barajas (`grammar`, `verbs`, `vocab`, etc.) sin duplicados.
+
+> 📌 Sugerencia: crea una nota de respaldo del CSV en tu gestor de archivos o nube antes de importarlo.
+
+## 2. Importación en AnkiWeb (gratuito)
+1. Abre [AnkiWeb](https://ankiweb.net) y regístrate (gratuito).
+2. Ve a **Decks → Import File**.
+3. Selecciona `d2-anki-export.csv`.
+4. Configura:
+   - **Type:** *Basic* (front/back).
+   - **Field Mapping:** `Front` → *Front*, `Back` → *Back*, `Tags` → *Tags*.
+   - Activa "Allow HTML in fields" para conservar cursivas/acentos.
+5. Pulsa **Import** y verifica que aparecen las notas y etiquetas.
+
+## 3. Sincronizar con AnkiMobile (iPhone/iPad)
+1. Descarga la app **AnkiMobile Flashcards** (pago único, recomendable para estudio serio).
+2. Inicia sesión con la misma cuenta de AnkiWeb.
+3. Toca **Sync** (icono circular) para traer las tarjetas.
+4. Ajusta las opciones de estudio: `Deck Options → New Cards/day` según tu carga (p.ej. 20) y `Steps` para intervalos cortos (1m → 10m → 1d).
+
+> 💡 Truco móvil: añade el widget de AnkiMobile para repasos rápidos y usa los gestos (swipe) para clasificar respuestas sin mirar la pantalla completa.
+
+## 4. Buenas prácticas de repaso
+- Etiquetas como `d1>por-para` permiten filtros rápidos en "Browse" → `tag:d1>por-para`.
+- Crea una baraja filtrada semanal con `tag:d1*` para enfocarte en trampas del simulacro.
+- Activa "Bury related new cards" para espaciar tarjetas con respuestas similares.
+
+Con esto tienes el ecosistema listo: exporto consolidado, importación web gratuita y sincronización móvil para estudiar en cualquier pausa.

--- a/docs/d3-exam-cheatsheet.md
+++ b/docs/d3-exam-cheatsheet.md
@@ -1,0 +1,174 @@
+# D3 — Exam-day Cheatsheet (Printable)
+
+> **Uso recomendado:** imprime a doble cara o exporta a PDF. Resalta con colores tus zonas de riesgo y coloca post-its en las tablas de decisión.
+
+---
+
+## 1. Tiempos perfectos vs indefinido (⚡ Narrativa y reporte)
+
+### 1.1 Árbol de decisión rápido
+1. **¿El marco temporal sigue conectado al presente?**
+   - Sí → **Pretérito perfecto compuesto** (he/has/ha + participio).
+   - No → ve a 2.
+2. **¿La acción es única y cerrada?**
+   - Sí → **Pretérito indefinido** (terminé, llegó).
+   - No → ¿Describe trasfondo? → pasa a imperfecto (ver sección 2).
+
+### 1.2 Tabla de marcadores
+| Marcador | Tiempo preferido | Ejemplo | Comentario |
+|---|---|---|---|
+| hoy, esta semana, este invierno | Perfecto | *Esta semana **he enviado** tres CV.* | Península; enlaza con el presente. |
+| ya, todavía no | Perfecto | *¿Ya **has visto** la expo?* | Experiencia reciente. |
+| ayer, en 2019, el lunes pasado | Indefinido | *Ayer **firmé** el contrato.* | Marco cerrado. |
+| hace X años, aquella vez | Indefinido | *Hace cinco años **viajé** a Lima.* | Pasado terminado. |
+
+### 1.3 Pares mínimos de intención
+- *Ya **he acabado*** (el día sigue) vs *Ya **acabé*** (marco cerrado).
+- *Nunca **he probado*** escargots (experiencia) vs *Nunca **probé*** ... (relato puntual).
+
+---
+
+## 2. Imperfecto vs indefinido (🎬 Fondo vs acción)
+
+### 2.1 Patrón narrativo S.E.A.
+1. **S**cena → imperfecto: *Hacía frío*.
+2. **E**vento → indefinido: *Sonó el teléfono*.
+3. **A**cción prolongada → imperfecto: *Mientras hablábamos...*.
+
+### 2.2 Matriz de uso
+| Uso | Imperfecto | Indefinido | Pistas |
+|---|---|---|---|
+| Descripción | *La casa **era** luminosa.* | — | Adjetivos, edad, clima. |
+| Hábito | *Cada verano **íbamos*** | — | Siempre, normalmente. |
+| Acción en curso | *Mientras **cocinaba*** | — | Mientras, cuando + fondo. |
+| Evento puntual | — | *De repente **entró*** | Entonces, de pronto. |
+| Secuencia | — | *Llegó, vio, venció* | Verbs encadenados. |
+
+### 2.3 Señales para cambiar de tiempo
+- **Cuando + pasado** → decide quién es fondo y quién evento: *Cuando **llegué** (evento), ella **estaba** leyendo (fondo).* 
+- Verbos con cambio de significado:
+  - *Conocer*: **conocí** = conocí por primera vez; **conocía** = sabía quién era.
+  - *Querer*: **quise** = intenté; **quería** = deseaba.
+
+---
+
+## 3. Indicativo vs subjuntivo (🎯 Modalidad)
+
+### 3.1 Tabla de disparadores
+| Categoría | Indicativo | Subjuntivo | Ejemplo clave |
+|---|---|---|---|
+| Creencia | *Creo que **es*** | *No creo que **sea*** | Negación cambia el modo. |
+| Evidencia | *Es evidente que **tiene*** | — | Certeza → indicativo. |
+| Deseo / influencia | — | *Quiero que **vengas*** | Verbos volitivos + que. |
+| Recomendación | — | *Es importante que **estudies*** | Valor subjetivo. |
+| Concesión | — | *Aunque **sea** caro* | Hipótesis / posibilidad. |
+| Futuro tras "cuando" | *Cuando **llegó*** (pasado real) | *Cuando **llegue*** (futuro) | Mira la referencia temporal. |
+
+### 3.2 Checklist relámpago
+1. ¿Hay cambio de sujeto tras "que"?
+2. ¿Expresa valoración, duda o emoción? → Subjuntivo.
+3. ¿Expresa certeza, reporte o percepción objetiva? → Indicativo.
+
+### 3.3 Pseudocódigo mental
+```
+if trigger in {duda, deseo, mandato, emoción, negación de creencia}:
+    usar_subjuntivo()
+elif antecedente_indefinido:
+    usar_subjuntivo()
+else:
+    usar_indicativo()
+```
+
+---
+
+## 4. Clíticos y `se` (🧩 Pronombres)
+
+### 4.1 Tabla de colocación
+| Contexto | Orden | Ejemplo |
+|---|---|---|
+| Verbo conjugado afirmativo | antes | *Se lo digo.* |
+| Verbo conjugado negativo | antes | *No te lo doy.* |
+| Infinitivo | pospuesto | *Quiero **dártelo***. |
+| Gerundio | pospuesto | *Estoy **pidiéndoselo***. |
+| Imperativo afirmativo | pospuesto + tilde | *¡Explícamelo!* |
+| Imperativo negativo | antes | *No me lo expliques.* |
+
+### 4.2 Reglas esenciales
+- **Le/les + lo/la/los/las → se lo/se la...**
+- Añade tilde al imperativo con dos pronombres: *dímelo, tráemelas*.
+- Dobla el clítico con objeto indirecto explícito: *A Ana **se la** envié.*
+
+### 4.3 Mini-matriz de `se`
+| Tipo de `se` | Pista | Ejemplo |
+|---|---|---|
+| Reflexivo | Sujeto = objeto | *Se peina.* |
+| Recíproco | Acción mutua | *Se miran.* |
+| Datívo | sustituto de le/les | *Se lo di.* |
+| Pasiva refleja | Verbo 3.ª persona | *Se venden pisos.* |
+
+---
+
+## 5. Por vs para (🧭 Rutas y motivos)
+
+### 5.1 Tabla comparativa
+| Función | `por` | `para` | Ejemplo |
+|---|---|---|---|
+| Causa / motivo | ✅ | — | *Lo hice **por** ti.* |
+| Intercambio / precio | ✅ | — | *Pagué 20€ **por** la guía.* |
+| Medio / vía | ✅ | — | *Mandé la carta **por** email.* |
+| Duración | ✅ | — | *Viajamos **por** dos semanas.* |
+| Destino final | — | ✅ | *Salimos **para** Madrid.* |
+| Propósito | — | ✅ | *Estudio **para** aprobar.* |
+| Destinatario | — | ✅ | *Esto es **para** Ana.* |
+| Fecha límite | — | ✅ | *Entregaré el informe **para** el lunes.* |
+
+### 5.2 Trucos mnemónicos
+- **POR = P**recio, **O**rigen del motivo, **R**uta.
+- **PARA = P**ropósito, **A**nte destinatario, **R**umboa meta, **A**l plazo.
+
+### 5.3 Errores frecuentes
+- ❌ *Gracias para la ayuda* → ✅ *Gracias **por** la ayuda*.
+- ❌ *Trabajo por una ONG* (si es empleador) → ✅ *Trabajo **para** una ONG*.
+
+---
+
+## 6. Francophone error clinic (🩺)
+
+### 6.1 Falsos amigos críticos
+| Francés | Español correcto | Evita |
+|---|---|---|
+| *actuellement* | **actualmente** = actualmente | *actually* = **en realidad**. |
+| *assister à* | **asistir a** | ❌ *asistir la*. |
+| *demander* (preguntar) | **preguntar** | **solicitar** = pedir formalmente. |
+| *eventuellement* | **quizá / tal vez** | ❌ *eventualmente* (= de forma eventual). |
+| *réaliser* | **darse cuenta** / **realizar** (ejecutar) | Usa contexto correcto. |
+
+### 6.2 Preposiciones trampas
+- *Depender **de*** (no *depender en*).
+- *Pensar **en*** alguien / *pensar **de*** algo (opinión).
+- *Soñar **con***, *insistir **en***, *enamorarse **de***.
+
+### 6.3 Tildes salvavidas
+| Palabra | Uso examen |
+|---|---|
+| **sí** (afirmación) vs **si** (condicional) | *Sí, quiero* / *Si vienes...* |
+| **más** (cantidad) vs **mas** (pero) | Usa tilde salvo en *mas*. |
+| **aún** (todavía) vs **aun** (incluso) | *Aún no llega* / *Aun cansado...* |
+| **qué/cuál/cómo** interrogativos | Siempre con tilde en preguntas directas e indirectas. |
+
+### 6.4 Checklist final de revisión
+1. Barrido de concordancia sujeto-verbo.
+2. Verifica preposiciones con tu lista personal.
+3. Busca calcos directos del francés y reemplázalos.
+4. Lee en voz alta: ¿suena español o traducción literal?
+5. Escanea tildes diacríticas en interrogativos y demostrativos.
+
+---
+
+## 7. Estrategia express pre-examen
+- **5 min:** repasa tabla de tiempos (secciones 1 y 2).
+- **5 min:** recorre disparadores del subjuntivo y la tabla de clíticos.
+- **5 min:** memoriza los falsos amigos prioritarios.
+- **5 min:** planifica ejemplos de producción escrita (usa los pares mínimos).
+
+> ✅ Lleva este esquema doblado dentro del cuaderno. Úsalo como control de calidad antes de entregar: tiempos, modo, pronombres, preposiciones, tildes.

--- a/exports/d2-anki-export.csv
+++ b/exports/d2-anki-export.csv
@@ -1,0 +1,639 @@
+front,back,tag
+Imperativo afirmativo + pronombres,Pega clíticos al final y añade tilde (dámelo),d1>cliticos-se
+Imperativo negativo + pronombres,Pronombres antes del verbo (no te lo lleves),d1>cliticos-se
+Actually ≠ actualmente,Traduce 'actually' como 'en realidad' o 'de hecho',d1>francophone-errors
+Asistir a,El verbo necesita preposición: asistir a la reunión,d1>francophone-errors
+De repente + verbo,Indefinido para evento puntual (de repente sonó),d1>imperfecto-vs-indefinido
+Mientras + verbo,Imperfecto para acción en curso (mientras estudiaba),d1>imperfecto-vs-indefinido
+Es evidente que...,Mantén indicativo (es evidente que tiene),d1>indicativo-vs-subjuntivo
+No creo que...,Activa subjuntivo (no creo que sea),d1>indicativo-vs-subjuntivo
+Marcador 'esta semana',Usa pretérito perfecto: he/has/ha + participio,d1>perfecto-vs-indefinido
+abrir — formas clave,yo abro; pret. yo abrí; subj. yo abra; participio abierto. Nota: Participio irregular abierto; resto regular.,iv-atlas>a–c
+andar — formas clave,yo ando; pret. yo anduve; subj. yo ande; participio andado. Nota: Pretérito con raíz anduv- y subjuntivo pretérito anduviera.,iv-atlas>a–c
+bendecir — formas clave,"yo bendigo; pret. yo bendije; subj. yo bendiga; participio bendecido (verbal) / bendito (adjetivo). Nota: Como *decir*: yo bendigo, pretérito bendije, participio verbal *bendecido* (adjetivo *bendito*).",iv-atlas>a–c
+caber — formas clave,yo quepo; pret. yo cupe; subj. yo quepa; participio cabido. Nota: Yo quepo; pretérito cupe; futuro cabré; subjuntivo presente quepa.,iv-atlas>a–c
+caer — formas clave,"yo caigo; pret. yo caí; subj. yo caiga; participio caído. Nota: Yo caigo; pretérito con y (cayó, cayeron); participio caído.",iv-atlas>a–c
+cerrar — formas clave,yo cierro; pret. yo cerré; subj. yo cierre; participio cerrado. Nota: Cambio vocálico e→ie excepto en nosotros/vosotros.,iv-atlas>a–c
+conducir — formas clave,yo conduzco; pret. yo conduje; subj. yo conduzca; participio conducido. Nota: Yo conduzco; pretérito conduje con 3ª plural -eron.,iv-atlas>a–c
+construir — formas clave,"yo construyo; pret. yo construí; subj. yo construya; participio construido. Nota: Cambio i→y en presente, pretérito y subjuntivo; nosotros conservan i.",iv-atlas>a–c
+decir — formas clave,yo digo; pret. yo dije; subj. yo diga; participio dicho. Nota: Yo digo; pretérito dije; participio dicho.,iv-atlas>d–l
+dormir — formas clave,yo duermo; pret. yo dormí; subj. yo duerma; participio dormido. Nota: Cambio o→ue/e→u; pretérito 3ª persona durmió/durmieron.,iv-atlas>d–l
+estar — formas clave,yo estoy; pret. yo estuve; subj. yo esté; participio estado. Nota: Yo estoy; pretérito estuve; subjuntivo esté.,iv-atlas>d–l
+freír — formas clave,yo frío; pret. yo freí; subj. yo fría; participio freído / frito. Nota: Acentos en presente (frío); participio doble *freído/frito*.,iv-atlas>d–l
+haber — formas clave,"yo he; pret. yo hube; subj. yo haya; participio habido (raro). Nota: Auxiliar: he, has, ha; pretérito hube; subjuntivo haya.",iv-atlas>d–l
+hacer — formas clave,yo hago; pret. yo hice; subj. yo haga; participio hecho. Nota: Yo hago; pretérito hice (3ª hizo); futuro haré.,iv-atlas>d–l
+ir — formas clave,"yo voy; pret. yo fui; subj. yo vaya; participio ido. Nota: Suplétivo: presente voy, pretérito fui, subjuntivo vaya.",iv-atlas>d–l
+jugar — formas clave,yo juego; pret. yo jugué; subj. yo juegue; participio jugado. Nota: Cambio u→ue; pretérito yo jugué con g; subjuntivo juegue.,iv-atlas>d–l
+leer — formas clave,"yo leo; pret. yo leí; subj. yo lea; participio leído. Nota: Pretérito con y (leyó, leyeron); gerundio leyendo.",iv-atlas>d–l
+morir — formas clave,yo muero; pret. yo morí; subj. yo muera; participio muerto. Nota: Cambio o→ue/e→u; participio irregular muerto.,iv-atlas>m–s
+oír — formas clave,"yo oigo; pret. yo oí; subj. yo oiga; participio oído. Nota: Formas con y (oigo, oyes); pretérito oyó, oyeron.",iv-atlas>m–s
+pedir — formas clave,yo pido; pret. yo pedí; subj. yo pida; participio pedido. Nota: Cambio e→i; pretérito 3ª persona pidió/pidieron.,iv-atlas>m–s
+poder — formas clave,"yo puedo; pret. yo pude; subj. yo pueda; participio podido. Nota: Raíz irregular: presente pued-, pretérito pud-, futuro podr-.",iv-atlas>m–s
+poner — formas clave,yo pongo; pret. yo puse; subj. yo ponga; participio puesto. Nota: Yo pongo; pretérito puse; futuro pondré; participio puesto.,iv-atlas>m–s
+querer — formas clave,yo quiero; pret. yo quise; subj. yo quiera; participio querido. Nota: Cambio e→ie; pretérito quis-; futuro querr-.,iv-atlas>m–s
+reír — formas clave,"yo río; pret. yo reí; subj. yo ría; participio reído. Nota: Acentos en presente (río); pretérito rió, rieron; gerundio riendo.",iv-atlas>m–s
+saber — formas clave,yo sé; pret. yo supe; subj. yo sepa; participio sabido. Nota: Yo sé; pretérito supe; subjuntivo presente sepa.,iv-atlas>m–s
+salir — formas clave,yo salgo; pret. yo salí; subj. yo salga; participio salido. Nota: Yo salgo; futuro saldré; subjuntivo presente salga.,iv-atlas>m–s
+ser — formas clave,"yo soy; pret. yo fui; subj. yo sea; participio sido. Nota: Presente soy, eres; pretérito fui; imperfecto era; subjuntivo sea/fuera.",iv-atlas>m–s
+tener — formas clave,yo tengo; pret. yo tuve; subj. yo tenga; participio tenido. Nota: Yo tengo; pretérito tuve; futuro tendré; subjuntivo tenga.,iv-atlas>t–z
+traducir — formas clave,yo traduzco; pret. yo traduje; subj. yo traduzca; participio traducido. Nota: Yo traduzco; pretérito traduje (3ª tradujeron); subjuntivo traduzca.,iv-atlas>t–z
+traer — formas clave,yo traigo; pret. yo traje; subj. yo traiga; participio traído. Nota: Yo traigo; pretérito traje (3ª trajeron); gerundio trayendo.,iv-atlas>t–z
+valer — formas clave,yo valgo; pret. yo valí; subj. yo valga; participio valido. Nota: Yo valgo; futuro valdré; subjuntivo valga.,iv-atlas>t–z
+venir — formas clave,yo vengo; pret. yo vine; subj. yo venga; participio venido. Nota: Yo vengo; presente vien-; pretérito vine; futuro vendré.,iv-atlas>t–z
+ver — formas clave,"yo veo; pret. yo vi; subj. yo vea; participio visto. Nota: Yo veo; pretérito vi, viste, vio sin acentos; participio visto.",iv-atlas>t–z
+volver — formas clave,yo vuelvo; pret. yo volví; subj. yo vuelva; participio vuelto. Nota: Cambio o→ue; participio irregular vuelto; futuro volveré.,iv-atlas>t–z
+yacer — formas clave,yo yazco; pret. yo yací; subj. yo yazca; participio yacido. Nota: Yo yazco (también *yago*); pretérito yací/yació; subjuntivo yazca.,iv-atlas>t–z
+zurcir — formas clave,yo zurzo; pret. yo zurcí; subj. yo zurza; participio zurcido. Nota: Yo zurzo; subjuntivo zurza; 2ª pl. imperativo zurcid.,iv-atlas>t–z
+Marcador 'ayer',Usa pretérito indefinido (terminé,llegamos)
+Por = causa / intercambio,Gracias por...,pagar por
+Para = meta / destinatario,Salgo para Madrid,regalo para Ana
+abandonar,abandon,verbs>regular500
+abarcar,cross,verbs>regular500
+abastecer,provide,verbs>regular500
+abatir,down,verbs>regular500
+abdicar,abnegate,verbs>regular500
+ablandar,soft-pedal,verbs>regular500
+abogar,advocate,verbs>regular500
+abolir,abolish,verbs>regular500
+abonar,pay,verbs>regular500
+abordar,address,verbs>regular500
+abrazar,adopt,verbs>regular500
+abreviar,abbreviate,verbs>regular500
+abrir,open,verbs>regular500
+absolver,free,verbs>regular500
+absorber,take up,verbs>regular500
+abundar,abound,verbs>regular500
+aburrir,tire,verbs>regular500
+abusar,abuse,verbs>regular500
+acabar,finish,verbs>regular500
+acallar,hush up,verbs>regular500
+acampar,camp,verbs>regular500
+acariciar,stroke,verbs>regular500
+acarrear,haul,verbs>regular500
+acceder,agree,verbs>regular500
+acechar,spot,verbs>regular500
+acelerar,get going,verbs>regular500
+acentuar,point up,verbs>regular500
+aceptar,accept,verbs>regular500
+acertar,hit,verbs>regular500
+achicar,dwarf,verbs>regular500
+aclarar,light up,verbs>regular500
+acoger,take in,verbs>regular500
+acometer,undertake,verbs>regular500
+acomodar,accommodate,verbs>regular500
+aconsejar,recommend,verbs>regular500
+acontecer,go on,verbs>regular500
+acoplar,couple,verbs>regular500
+acordar,square up,verbs>regular500
+acorralar,set up,verbs>regular500
+acosar,harass,verbs>regular500
+acostar,bed,verbs>regular500
+acostumbrar,accustom,verbs>regular500
+acrecentar,run up,verbs>regular500
+acreditar,credit,verbs>regular500
+activar,root on,verbs>regular500
+actuar,act,verbs>regular500
+acudir,proceed,verbs>regular500
+acumular,take in,verbs>regular500
+acusar,charge,verbs>regular500
+adaptar,adapt,verbs>regular500
+adecuar,fit,verbs>regular500
+adelantar,advance,verbs>regular500
+adelgazar,lose weight,verbs>regular500
+adherir,adhere,verbs>regular500
+adicionar,add,verbs>regular500
+adivinar,guess,verbs>regular500
+adjudicar,lot,verbs>regular500
+adjuntar,attach,verbs>regular500
+administrar,administer,verbs>regular500
+admirar,look up to,verbs>regular500
+admitir,admit,verbs>regular500
+adoptar,take up,verbs>regular500
+adorar,love,verbs>regular500
+adornar,grace,verbs>regular500
+adquirir,take on,verbs>regular500
+adulterar,fake,verbs>regular500
+advertir,name,verbs>regular500
+afectar,affect,verbs>regular500
+afianzar,buttress,verbs>regular500
+afilar,point,verbs>regular500
+afinar,down,verbs>regular500
+afirmar,say,verbs>regular500
+aflojar,loose,verbs>regular500
+aflorar,crop out,verbs>regular500
+afrontar,face,verbs>regular500
+agarrar,grab,verbs>regular500
+agitar,call down,verbs>regular500
+agotar,play out,verbs>regular500
+agradar,like,verbs>regular500
+agradecer,thank,verbs>regular500
+agravar,decline,verbs>regular500
+agrupar,group,verbs>regular500
+aguantar,last out,verbs>regular500
+aguardar,look,verbs>regular500
+agudizar,point,verbs>regular500
+ahondar,deepen,verbs>regular500
+ahorcar,halter,verbs>regular500
+ahorrar,save,verbs>regular500
+ahuyentar,shoo,verbs>regular500
+aislar,isolate,verbs>regular500
+ajustar,line up,verbs>regular500
+alardear,gas,verbs>regular500
+alargar,draw out,verbs>regular500
+alarmar,alarm,verbs>regular500
+albergar,house,verbs>regular500
+alegar,say,verbs>regular500
+alegrar,joy,verbs>regular500
+alejar,move away,verbs>regular500
+alentar,encourage,verbs>regular500
+alertar,alert,verbs>regular500
+alimentar,feed,verbs>regular500
+aliviar,still,verbs>regular500
+almacenar,store,verbs>regular500
+alojar,house,verbs>regular500
+alquilar,let,verbs>regular500
+alterar,alter,verbs>regular500
+alternar,alternate,verbs>regular500
+aludir,name,verbs>regular500
+alumbrar,light,verbs>regular500
+alzar,put up,verbs>regular500
+amamantar,suck,verbs>regular500
+amarrar,catch,verbs>regular500
+amasar,knead,verbs>regular500
+amortiguar,buffer,verbs>regular500
+amortizar,amortize,verbs>regular500
+amparar,shelter,verbs>regular500
+ampliar,amplify,verbs>regular500
+anexar,annex,verbs>regular500
+anhelar,long,verbs>regular500
+animar,fan,verbs>regular500
+aniquilar,nuke,verbs>regular500
+anochecer,benight,verbs>regular500
+anotar,set down,verbs>regular500
+anticipar,anticipate,verbs>regular500
+anular,set off,verbs>regular500
+anunciar,announce,verbs>regular500
+apaciguar,still,verbs>regular500
+aparecer,appear,verbs>regular500
+aparentar,look,verbs>regular500
+apartar,come off,verbs>regular500
+apelar,appeal,verbs>regular500
+aplastar,press out,verbs>regular500
+aplaudir,applaud,verbs>regular500
+aplazar,put over,verbs>regular500
+aportar,put up,verbs>regular500
+apostar,place,verbs>regular500
+apoyar,support,verbs>regular500
+apreciar,care for,verbs>regular500
+aprender,learn,verbs>regular500
+apresurar,speed,verbs>regular500
+apretar,force,verbs>regular500
+aprobar,make it,verbs>regular500
+aprovechar,capitalize on,verbs>regular500
+apuntalar,land,verbs>regular500
+apuntar,show,verbs>regular500
+apurar,worry,verbs>regular500
+arbitrar,arbitrate,verbs>regular500
+arder,fire,verbs>regular500
+argumentar,argue,verbs>regular500
+armar,arm,verbs>regular500
+armonizar,proportion,verbs>regular500
+arrancar,start,verbs>regular500
+arrasar,level,verbs>regular500
+arrastrar,drag,verbs>regular500
+arrebatar,transport,verbs>regular500
+arreglar,fix,verbs>regular500
+arrestar,arrest,verbs>regular500
+arribar,get in,verbs>regular500
+arriesgar,game,verbs>regular500
+arrojar,throw,verbs>regular500
+arruinar,fuck up,verbs>regular500
+articular,articulate,verbs>regular500
+asaltar,set on,verbs>regular500
+ascender,move up,verbs>regular500
+asegurar,ensure,verbs>regular500
+asentar,set down,verbs>regular500
+asentir,allow,verbs>regular500
+asesinar,off,verbs>regular500
+asfixiar,put out,verbs>regular500
+asignar,assign,verbs>regular500
+asimilar,take in,verbs>regular500
+asistir,attend,verbs>regular500
+asociar,link,verbs>regular500
+asomar,appear,verbs>regular500
+asombrar,surprise,verbs>regular500
+aspirar,aspire,verbs>regular500
+asumir,assume,verbs>regular500
+asustar,scare,verbs>regular500
+atacar,attack,verbs>regular500
+atajar,block,verbs>regular500
+atender,attend,verbs>regular500
+atenuar,break,verbs>regular500
+aterrorizar,awe,verbs>regular500
+atesorar,value,verbs>regular500
+atormentar,torture,verbs>regular500
+atracar,dock,verbs>regular500
+atrapar,set up,verbs>regular500
+atravesar,get over,verbs>regular500
+atribuir,credit,verbs>regular500
+atropellar,run over,verbs>regular500
+aullar,bay,verbs>regular500
+aumentar,increase,verbs>regular500
+avalar,underwrite,verbs>regular500
+aventar,winnow,verbs>regular500
+aventurar,game,verbs>regular500
+avergonzar,shame,verbs>regular500
+avisar,send word,verbs>regular500
+avivar,get going,verbs>regular500
+ayudar,help,verbs>regular500
+azotar,worst,verbs>regular500
+bailar,dance,verbs>regular500
+bajar,lower,verbs>regular500
+balancear,balance,verbs>regular500
+barrer,brush,verbs>regular500
+basar,base,verbs>regular500
+bastar,answer,verbs>regular500
+batear,bat,verbs>regular500
+batir,beat,verbs>regular500
+beber,drink,verbs>regular500
+bendecir,sign,verbs>regular500
+beneficiar,benefit,verbs>regular500
+besar,kiss,verbs>regular500
+bloquear,block,verbs>regular500
+boicotear,boycott,verbs>regular500
+bombardear,beat,verbs>regular500
+bombear,pump,verbs>regular500
+bordar,embroider,verbs>regular500
+borrar,off,verbs>regular500
+botar,launch,verbs>regular500
+brillar,shine,verbs>regular500
+brincar,bound off,verbs>regular500
+brindar,put up,verbs>regular500
+bromear,kid,verbs>regular500
+brotar,well,verbs>regular500
+bucear,skin-dive,verbs>regular500
+burlar,beat,verbs>regular500
+calar,stall,verbs>regular500
+calcular,calculate,verbs>regular500
+calentar,sex,verbs>regular500
+calificar,mark,verbs>regular500
+callar,close up,verbs>regular500
+calmar,still,verbs>regular500
+cambiar,change,verbs>regular500
+caminar,walk,verbs>regular500
+canalizar,channel,verbs>regular500
+cancelar,cancel,verbs>regular500
+cansar,try,verbs>regular500
+cantar,sing,verbs>regular500
+capacitar,enable,verbs>regular500
+capitalizar,capitalize,verbs>regular500
+captar,capture,verbs>regular500
+capturar,capture,verbs>regular500
+caracterizar,qualify,verbs>regular500
+carecer,want,verbs>regular500
+cargar,charge,verbs>regular500
+casar,couple,verbs>regular500
+castigar,correct,verbs>regular500
+castrar,fix,verbs>regular500
+catalogar,catalogue,verbs>regular500
+catar,try,verbs>regular500
+categorizar,categorize,verbs>regular500
+causar,cause,verbs>regular500
+cautivar,transport,verbs>regular500
+cavar,dig,verbs>regular500
+cebar,fat,verbs>regular500
+ceder,give way,verbs>regular500
+cegar,blind,verbs>regular500
+celebrar,celebrate,verbs>regular500
+cenar,dine,verbs>regular500
+censurar,call down,verbs>regular500
+centrar,center,verbs>regular500
+cepillar,brush,verbs>regular500
+cercar,wall,verbs>regular500
+certificar,certify,verbs>regular500
+cesar,end,verbs>regular500
+charlar,chat,verbs>regular500
+chillar,bitch,verbs>regular500
+chocar,hit,verbs>regular500
+chupar,take up,verbs>regular500
+cifrar,code,verbs>regular500
+circular,circle,verbs>regular500
+citar,cite,verbs>regular500
+clasificar,class,verbs>regular500
+claudicar,give in,verbs>regular500
+clausurar,close up,verbs>regular500
+clavar,center,verbs>regular500
+cobrar,take home,verbs>regular500
+cocinar,ready,verbs>regular500
+codificar,work out,verbs>regular500
+coexistir,coexist,verbs>regular500
+coincidir,check,verbs>regular500
+colaborar,get together,verbs>regular500
+colapsar,collapse,verbs>regular500
+colar,separate out,verbs>regular500
+coleccionar,collect,verbs>regular500
+colgar,post,verbs>regular500
+colisionar,hit,verbs>regular500
+colmar,fill,verbs>regular500
+colocar,place,verbs>regular500
+colonizar,colonize,verbs>regular500
+combatir,combat,verbs>regular500
+combinar,combine,verbs>regular500
+comentar,comment,verbs>regular500
+comer,eat,verbs>regular500
+comercializar,trade,verbs>regular500
+comerciar,trade,verbs>regular500
+cometer,commit,verbs>regular500
+comparar,compare,verbs>regular500
+comparecer,appear,verbs>regular500
+compartir,share,verbs>regular500
+compensar,compensate,verbs>regular500
+competir,compete,verbs>regular500
+complacer,please,verbs>regular500
+complementar,supplement,verbs>regular500
+completar,complete,verbs>regular500
+complicar,complicate,verbs>regular500
+comportar,mean,verbs>regular500
+comprar,buy,verbs>regular500
+comprender,understand,verbs>regular500
+comprimir,contract,verbs>regular500
+comprobar,control,verbs>regular500
+comprometer,compromise,verbs>regular500
+computar,work out,verbs>regular500
+comunicar,communicate,verbs>regular500
+concebir,imagine,verbs>regular500
+conceder,concede,verbs>regular500
+concentrar,concentrate,verbs>regular500
+concertar,concert,verbs>regular500
+concienciar,sensitize,verbs>regular500
+concluir,conclude,verbs>regular500
+concordar,concord,verbs>regular500
+concretar,finalize,verbs>regular500
+concurrir,go with,verbs>regular500
+condenar,condemn,verbs>regular500
+condensar,sum up,verbs>regular500
+condicionar,condition,verbs>regular500
+condimentar,season,verbs>regular500
+conectar,connect,verbs>regular500
+confeccionar,confection,verbs>regular500
+conferir,confer,verbs>regular500
+confesar,confess,verbs>regular500
+confiar,trust,verbs>regular500
+configurar,configure,verbs>regular500
+confirmar,confirm,verbs>regular500
+confiscar,confiscate,verbs>regular500
+confluir,converge,verbs>regular500
+conformar,conform to,verbs>regular500
+confrontar,confront,verbs>regular500
+confundir,take in,verbs>regular500
+congelar,cool,verbs>regular500
+conjurar,call down,verbs>regular500
+conmemorar,remember,verbs>regular500
+conmover,impact,verbs>regular500
+conquistar,conquer,verbs>regular500
+consagrar,order,verbs>regular500
+consentir,give in,verbs>regular500
+conservar,keep up,verbs>regular500
+considerar,consider,verbs>regular500
+consignar,record,verbs>regular500
+consistir,consist,verbs>regular500
+consolar,console,verbs>regular500
+consolidar,consolidate,verbs>regular500
+conspirar,conspire,verbs>regular500
+constar,consist,verbs>regular500
+constatar,check,verbs>regular500
+constituir,constitute,verbs>regular500
+consultar,consult,verbs>regular500
+consumar,consummate,verbs>regular500
+consumir,consume,verbs>regular500
+contabilizar,factor,verbs>regular500
+contactar,touch,verbs>regular500
+contagiar,communicate,verbs>regular500
+contaminar,contaminate,verbs>regular500
+contemplar,contemplate,verbs>regular500
+contender,contend,verbs>regular500
+contener,contain,verbs>regular500
+contestar,answer,verbs>regular500
+contraatacar,counterattack,verbs>regular500
+contradecir,misrepresent,verbs>regular500
+contraer,contract,verbs>regular500
+contrarrestar,set off,verbs>regular500
+contrastar,contrast,verbs>regular500
+contratar,contract,verbs>regular500
+contribuir,contribute,verbs>regular500
+controlar,control,verbs>regular500
+converger,converge,verbs>regular500
+conversar,converse,verbs>regular500
+convertir,convert,verbs>regular500
+convivir,live together,verbs>regular500
+convocar,call,verbs>regular500
+copiar,copy,verbs>regular500
+coronar,top,verbs>regular500
+corregir,correct,verbs>regular500
+correr,run,verbs>regular500
+corresponder,correspond,verbs>regular500
+corroborar,corroborate,verbs>regular500
+corromper,corrupt,verbs>regular500
+cortar,cut,verbs>regular500
+cortejar,court,verbs>regular500
+cosechar,harvest,verbs>regular500
+coser,run up,verbs>regular500
+costear,pick,verbs>regular500
+cotejar,collate,verbs>regular500
+crear,create,verbs>regular500
+criar,cover,verbs>regular500
+cristalizar,crystallize,verbs>regular500
+criticar,call down,verbs>regular500
+crucificar,crucify,verbs>regular500
+crujir,crunch,verbs>regular500
+cruzar,get over,verbs>regular500
+cuadrar,even up,verbs>regular500
+cuajar,clot,verbs>regular500
+cubrir,cover,verbs>regular500
+cuestionar,question,verbs>regular500
+cuidar,care,verbs>regular500
+culminar,culminate,verbs>regular500
+culpar,charge,verbs>regular500
+cultivar,cultivate,verbs>regular500
+cumplimentar,call,verbs>regular500
+cumplir,fulfill,verbs>regular500
+curar,cure,verbs>regular500
+curiosear,rubberneck,verbs>regular500
+cursar,study,verbs>regular500
+danzar,dance,verbs>regular500
+deambular,range,verbs>regular500
+debatir,debate,verbs>regular500
+deber,owe,verbs>regular500
+debilitar,drain,verbs>regular500
+debutar,debut,verbs>regular500
+decaer,decay,verbs>regular500
+decapitar,decapitate,verbs>regular500
+decepcionar,fall short of,verbs>regular500
+decidir,decide,verbs>regular500
+declarar,say,verbs>regular500
+declinar,decline,verbs>regular500
+decorar,deck,verbs>regular500
+decretar,decree,verbs>regular500
+dedicar,pay,verbs>regular500
+deducir,work out,verbs>regular500
+defender,defend,verbs>regular500
+definir,define,verbs>regular500
+deformar,deform,verbs>regular500
+defraudar,defraud,verbs>regular500
+degradar,degrade,verbs>regular500
+degustar,try,verbs>regular500
+dejar,let,verbs>regular500
+delatar,shit,verbs>regular500
+delegar,delegate,verbs>regular500
+deleitar,enjoy,verbs>regular500
+deletrear,write,verbs>regular500
+delimitar,define,verbs>regular500
+delinear,streamline,verbs>regular500
+demandar,demand,verbs>regular500
+demoler,destroy,verbs>regular500
+demorar,hold up,verbs>regular500
+demostrar,show,verbs>regular500
+denegar,deny,verbs>regular500
+denominar,name,verbs>regular500
+denotar,mean,verbs>regular500
+denunciar,report,verbs>regular500
+depender,depend,verbs>regular500
+depositar,deposit,verbs>regular500
+deprimir,cast down,verbs>regular500
+depurar,rack,verbs>regular500
+derivar,draw,verbs>regular500
+derogar,strike down,verbs>regular500
+derramar,run out,verbs>regular500
+derribar,down,verbs>regular500
+derrocar,overthrow,verbs>regular500
+derrochar,run off,verbs>regular500
+derrotar,get the better of,verbs>regular500
+derrumbar,demolish,verbs>regular500
+desacreditar,disgrace,verbs>regular500
+desafiar,front,verbs>regular500
+desalentar,put off,verbs>regular500
+desaparecer,disappear,verbs>regular500
+desaprobar,forbid,verbs>regular500
+desarmar,disarm,verbs>regular500
+desarrollar,develop,verbs>regular500
+desatar,come off,verbs>regular500
+desayunar,breakfast,verbs>regular500
+desbloquear,free,verbs>regular500
+desbordar,crowd,verbs>regular500
+descalificar,disqualify,verbs>regular500
+descansar,rest on,verbs>regular500
+descargar,go off,verbs>regular500
+descarrilar,reel off,verbs>regular500
+descartar,rule out,verbs>regular500
+descender,come,verbs>regular500
+descifrar,decipher,verbs>regular500
+descomponer,break up,verbs>regular500
+desconectar,disconnect,verbs>regular500
+desconfiar,suspect,verbs>regular500
+descongelar,free,verbs>regular500
+desconocer,ignore,verbs>regular500
+descontar,allow,verbs>regular500
+describir,describe,verbs>regular500
+descubrir,discover,verbs>regular500
+descuidar,neglect,verbs>regular500
+desear,want,verbs>regular500
+desechar,throw out,verbs>regular500
+desembarcar,land,verbs>regular500
+desembocar,flow off,verbs>regular500
+desencadenar,set off,verbs>regular500
+desenmascarar,unmask,verbs>regular500
+desenredar,comb,verbs>regular500
+desenterrar,exhume,verbs>regular500
+desesperar,despair,verbs>regular500
+desestabilizar,destabilize,verbs>regular500
+desfilar,parade,verbs>regular500
+aerotermia,air-source heat pump technology,vocab>arquitectura-sostenible
+aislamiento térmico,thermal insulation,vocab>arquitectura-sostenible
+análisis de ciclo de vida,life cycle assessment,vocab>arquitectura-sostenible
+arquitectura bioclimática,bioclimatic architecture,vocab>arquitectura-sostenible
+certificación energética,energy certification,vocab>arquitectura-sostenible
+corredor verde,green corridor,vocab>arquitectura-sostenible
+cubierta verde,green roof,vocab>arquitectura-sostenible
+densidad residencial,residential density,vocab>arquitectura-sostenible
+eficiencia energética,energy efficiency,vocab>arquitectura-sostenible
+fachada ventilada,ventilated façade,vocab>arquitectura-sostenible
+gentrificación,gentrification,vocab>arquitectura-sostenible
+geotermia,geothermal system,vocab>arquitectura-sostenible
+hormigón reciclado,recycled concrete,vocab>arquitectura-sostenible
+huella de carbono,carbon footprint,vocab>arquitectura-sostenible
+madera laminada cruzada,cross-laminated timber,vocab>arquitectura-sostenible
+mobiliario urbano,street furniture,vocab>arquitectura-sostenible
+normativa urbanística,zoning regulation,vocab>arquitectura-sostenible
+orientación solar,solar orientation,vocab>arquitectura-sostenible
+panel solar fotovoltaico,photovoltaic solar panel,vocab>arquitectura-sostenible
+participación vecinal,community participation,vocab>arquitectura-sostenible
+plan maestro,master plan,vocab>arquitectura-sostenible
+recuperación de aguas grises,greywater recovery,vocab>arquitectura-sostenible
+rehabilitación integral,full refurbishment,vocab>arquitectura-sostenible
+resiliencia urbana,urban resilience,vocab>arquitectura-sostenible
+sombreado pasivo,passive shading,vocab>arquitectura-sostenible
+transporte multimodal,multimodal transport,vocab>arquitectura-sostenible
+urbanismo táctico,tactical urbanism,vocab>arquitectura-sostenible
+uso mixto,mixed-use zoning,vocab>arquitectura-sostenible
+ventilación cruzada,cross ventilation,vocab>arquitectura-sostenible
+vivienda asequible,affordable housing,vocab>arquitectura-sostenible
+algoritmo de estratificación,stratification algorithm,vocab>biotecnologia-salud
+anticuerpo monoclonal,monoclonal antibody,vocab>biotecnologia-salud
+biobanco,biobank,vocab>biotecnologia-salud
+biosensor,biosensor,vocab>biotecnologia-salud
+brote zoonótico,zoonotic outbreak,vocab>biotecnologia-salud
+consentimiento informado,informed consent,vocab>biotecnologia-salud
+cribado neonatal,newborn screening,vocab>biotecnologia-salud
+cultivo celular,cell culture,vocab>biotecnologia-salud
+célula madre pluripotente,pluripotent stem cell,vocab>biotecnologia-salud
+datos de cohortes,cohort data,vocab>biotecnologia-salud
+doble ciego,double-blind design,vocab>biotecnologia-salud
+dosis de refuerzo,booster dose,vocab>biotecnologia-salud
+edición genética,gene editing,vocab>biotecnologia-salud
+ensayo clínico controlado,controlled clinical trial,vocab>biotecnologia-salud
+epidemiología genómica,genomic epidemiology,vocab>biotecnologia-salud
+farmacovigilancia,pharmacovigilance,vocab>biotecnologia-salud
+inmunoterapia,immunotherapy,vocab>biotecnologia-salud
+modelo predictivo,predictive model,vocab>biotecnologia-salud
+neutralización viral,viral neutralization,vocab>biotecnologia-salud
+nivel de anticuerpos,antibody level,vocab>biotecnologia-salud
+plataforma diagnóstica,diagnostic platform,vocab>biotecnologia-salud
+resistencia antimicrobiana,antimicrobial resistance,vocab>biotecnologia-salud
+secuenciación masiva,next-generation sequencing,vocab>biotecnologia-salud
+terapia génica,gene therapy,vocab>biotecnologia-salud
+transferencia tecnológica,technology transfer,vocab>biotecnologia-salud
+trazabilidad,traceability,vocab>biotecnologia-salud
+vacuna de ARNm,mRNA vaccine,vocab>biotecnologia-salud
+vector viral,viral vector,vocab>biotecnologia-salud
+ventana inmunológica,immunologic window,vocab>biotecnologia-salud
+vigilancia sindrómica,syndromic surveillance,vocab>biotecnologia-salud
+acuerdo de nivel de servicio,service-level agreement,vocab>ciberseguridad-digital
+algoritmo de recomendación,recommendation algorithm,vocab>ciberseguridad-digital
+análisis de amenazas,threat analysis,vocab>ciberseguridad-digital
+aprendizaje automático,machine learning,vocab>ciberseguridad-digital
+arquitectura sin servidor,serverless architecture,vocab>ciberseguridad-digital
+auditoría forense,forensic audit,vocab>ciberseguridad-digital
+autenticación multifactor,multi-factor authentication,vocab>ciberseguridad-digital
+automatización robótica de procesos,robotic process automation,vocab>ciberseguridad-digital
+cifrado de extremo a extremo,end-to-end encryption,vocab>ciberseguridad-digital
+continuidad de negocio,business continuity,vocab>ciberseguridad-digital
+cortafuegos,firewall,vocab>ciberseguridad-digital
+cumplimiento normativo,regulatory compliance,vocab>ciberseguridad-digital
+escalabilidad elástica,elastic scalability,vocab>ciberseguridad-digital
+formación de concienciación,awareness training,vocab>ciberseguridad-digital
+fuga de datos,data breach,vocab>ciberseguridad-digital
+gestión de identidades,identity management,vocab>ciberseguridad-digital
+gobernanza de datos,data governance,vocab>ciberseguridad-digital
+hoja de ruta digital,digital roadmap,vocab>ciberseguridad-digital
+infraestructura crítica,critical infrastructure,vocab>ciberseguridad-digital
+nube híbrida,hybrid cloud,vocab>ciberseguridad-digital
+orquestación de contenedores,container orchestration,vocab>ciberseguridad-digital
+parche de seguridad,security patch,vocab>ciberseguridad-digital
+plan de recuperación,recovery plan,vocab>ciberseguridad-digital
+privacidad diferencial,differential privacy,vocab>ciberseguridad-digital
+registro de auditoría,audit log,vocab>ciberseguridad-digital
+respuesta a incidentes,incident response,vocab>ciberseguridad-digital
+simulacro de phishing,phishing drill,vocab>ciberseguridad-digital
+superficie de exposición,attack surface,vocab>ciberseguridad-digital
+vector de ataque,attack vector,vocab>ciberseguridad-digital
+vulnerabilidad de día cero,zero-day vulnerability,vocab>ciberseguridad-digital

--- a/scripts/merge_flashcards.py
+++ b/scripts/merge_flashcards.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Merge all flashcard CSV files into a consolidated Anki export."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_PATTERN = "src/seed/**/*-flashcards.csv"
+OUTPUT = ROOT / "exports" / "d2-anki-export.csv"
+
+
+def gather_rows() -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for csv_path in sorted(ROOT.glob(SRC_PATTERN)):
+        with csv_path.open(newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for record in reader:
+                front = (record.get("front") or "").strip()
+                back = (record.get("back") or "").strip()
+                tag = (record.get("tag") or "").strip()
+                if not front or not back:
+                    continue
+                key = (front, back, tag)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rows.append(key)
+    rows.sort(key=lambda item: (item[2], item[0]))
+    return rows
+
+
+def write_output(rows: list[tuple[str, str, str]]) -> None:
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["front", "back", "tag"])
+        writer.writerows(rows)
+
+
+if __name__ == "__main__":
+    write_output(gather_rows())

--- a/src/seed/d1-cumulative-drills.json
+++ b/src/seed/d1-cumulative-drills.json
@@ -1,0 +1,768 @@
+{
+  "lessons": [
+    {
+      "id": "d1-cumulative-drills",
+      "level": "C1",
+      "title": "D1 — Cumulative Drills & Analytics Hooks",
+      "slug": "d1-cumulative-drills",
+      "tags": [
+        "drills",
+        "analytics",
+        "mixed",
+        "c1"
+      ],
+      "markdown": "# 📊 D1 — Cumulative Drills & Analytics Hooks\\n\\n**Objetivo:** detectar lagunas en contrastes claves y redirigir a la lección de refuerzo adecuada. Cada ejercicio lleva su lessonId de origen para que el panel analítico pueda sugerir la lectura correspondiente.\\n\\n---\\n\\n## Cómo usar este set\\n1. Responde cada item sin mirar apuntes.\\n2. Consulta la retroalimentación y anota los temas que requieren repaso.\\n3. Usa el lessonId vinculado para saltar a la explicación.\\n\\n| Bloque | Qué destapa | Lección de repaso |\\n|---|---|---|\\n| Perfecto vs indefinido | Alcance temporal y marcadores | b1-preterito-perfecto |\\n| Imperfecto vs indefinido | Fondo vs evento | b1-imperfecto-vs-indefinido |\\n| Indicativo vs subjuntivo | Valor epistémico vs modal | a28-subjunctive-sequence |\\n| Clíticos y se | Orden pronominal y duplicaciones | a25-clitics-se |\\n| Por / para | Meta vs causa | a32-por-para-advanced |\\n| Errores francófonos | Falsos amigos y preposiciones | a37-error-bank |\\n\\n> 💡 **Analytics hook:** usa `meta.topic` para filtrar por bloque (`d1:perfecto-vs-indefinido`, etc.) y agrupa respuestas erradas por lessonId para disparar micro-remediaciones.",
+      "references": [
+        "b1-preterito-perfecto",
+        "b1-imperfecto-vs-indefinido",
+        "a28-subjunctive-sequence",
+        "a25-clitics-se",
+        "a32-por-para-advanced",
+        "a37-error-bank"
+      ]
+    }
+  ],
+  "exercises": [
+    {
+      "id": "d1-perfecto-indefinido-ex1",
+      "lessonId": "b1-preterito-perfecto",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Esta mañana ___ (terminar, yo) el informe.",
+      "answer": "he terminado",
+      "accepted": [
+        "re:^he terminado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: periodo aún vigente en el día → pretérito perfecto compuesto.",
+        "wrong": "Cuando el marco temporal sigue abierto (\"esta mañana\"), usa **he terminado** en variedad peninsular."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:perfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-perfecto-indefinido-ex2",
+      "lessonId": "b1-preterito-perfecto",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Selecciona la forma natural en España: *¿___ ya la nueva serie?*",
+      "options": [
+        "Has visto",
+        "Viste",
+        "Veías"
+      ],
+      "answer": "Has visto",
+      "feedback": {
+        "correct": "Correcto: la pregunta sobre experiencia reciente usa pretérito perfecto.",
+        "wrong": "Para una experiencia aún conectada al presente, elige **Has visto**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:perfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-perfecto-indefinido-ex3",
+      "lessonId": "b1-preterito-perfecto",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Ayer ___ (cerrar, nosotros) la campaña con un acto final.",
+      "answer": "cerramos",
+      "accepted": [
+        "re:^cerramos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: \"ayer\" cierra el marco temporal → indefinido.",
+        "wrong": "Los marcadores terminados como *ayer* exigen indefinido: **cerramos**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:perfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-perfecto-indefinido-ex4",
+      "lessonId": "b1-preterito-perfecto",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Nunca ___ (probar, yo) la carne de reno.",
+      "answer": "he probado",
+      "accepted": [
+        "re:^he probado$"
+      ],
+      "feedback": {
+        "correct": "Correcto: \"nunca\" señala experiencia vital → pretérito perfecto.",
+        "wrong": "Para experiencias sin tiempo concreto usa **he probado** (aunque la respuesta sea negativa)."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:perfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-perfecto-indefinido-ex5",
+      "lessonId": "b1-preterito-perfecto",
+      "type": "mcq",
+      "promptMd": "D1 Drill — ¿Qué marcador favorece el pretérito perfecto compuesto?",
+      "options": [
+        "esta semana",
+        "ayer",
+        "el año pasado"
+      ],
+      "answer": "esta semana",
+      "feedback": {
+        "correct": "Correcto: marco vigente → perfecto.",
+        "wrong": "Los marcos abiertos como *esta semana* activan **he/has/ha**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:perfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-imperfecto-indefinido-ex1",
+      "lessonId": "b1-imperfecto-vs-indefinido",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Cuando ___ (ser, ella) niña, veraneaba en Bretaña.",
+      "answer": "era",
+      "accepted": [
+        "re:^era$"
+      ],
+      "feedback": {
+        "correct": "Correcto: descripción de fondo → imperfecto.",
+        "wrong": "Las descripciones de edad y contexto usan **era**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:imperfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-imperfecto-indefinido-ex2",
+      "lessonId": "b1-imperfecto-vs-indefinido",
+      "type": "cloze",
+      "promptMd": "D1 Drill — De repente ___ (sonar) el teléfono y nos sobresaltamos.",
+      "answer": "sonó",
+      "accepted": [
+        "re:^sonó$"
+      ],
+      "feedback": {
+        "correct": "Correcto: evento puntual → indefinido.",
+        "wrong": "Las irrupciones repentinas van en indefinido: **sonó**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:imperfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-imperfecto-indefinido-ex3",
+      "lessonId": "b1-imperfecto-vs-indefinido",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Mientras nosotros ___ (cocinar), ellos llegaron con postre.",
+      "answer": "cocinábamos",
+      "accepted": [
+        "re:^cocinábamos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acción en progreso paralela → imperfecto.",
+        "wrong": "Tras *mientras* usa imperfecto: **cocinábamos**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:imperfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-imperfecto-indefinido-ex4",
+      "lessonId": "b1-imperfecto-vs-indefinido",
+      "type": "mcq",
+      "promptMd": "D1 Drill — ___ una tarde fría cuando salió el sol.",
+      "options": [
+        "Era",
+        "Fue",
+        "Ha sido"
+      ],
+      "answer": "Era",
+      "feedback": {
+        "correct": "Correcto: fondo descriptivo → imperfecto.",
+        "wrong": "Para pintar el telón de fondo usa **Era**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:imperfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-imperfecto-indefinido-ex5",
+      "lessonId": "b1-imperfecto-vs-indefinido",
+      "type": "cloze",
+      "promptMd": "D1 Drill — A las ocho ___ (empezar) la reunión puntualmente.",
+      "answer": "empezó",
+      "accepted": [
+        "re:^empezó$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acción puntual con hora específica → indefinido.",
+        "wrong": "Cuando indicas hora concreta del evento, usa **empezó**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:imperfecto-vs-indefinido"
+      }
+    },
+    {
+      "id": "d1-indicativo-subjuntivo-ex1",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "D1 Drill — No creo que ___ (ser) buena idea.",
+      "answer": "sea",
+      "accepted": [
+        "re:^sea$"
+      ],
+      "feedback": {
+        "correct": "Correcto: verbo de opinión en negativo → subjuntivo.",
+        "wrong": "Tras *no creo que* necesitas subjuntivo: **sea**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:indicativo-vs-subjuntivo"
+      }
+    },
+    {
+      "id": "d1-indicativo-subjuntivo-ex2",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Buscamos a alguien que ___ (hablar) francés con fluidez.",
+      "answer": "hable",
+      "accepted": [
+        "re:^hable$"
+      ],
+      "feedback": {
+        "correct": "Correcto: antecedente indefinido → subjuntivo.",
+        "wrong": "Cuando el antecedente es indefinido o hipotético, usa **hable**."
+      },
+      "meta": {
+        "difficulty": "C1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:indicativo-vs-subjuntivo"
+      }
+    },
+    {
+      "id": "d1-indicativo-subjuntivo-ex3",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Es evidente que ella ___ experiencia en ventas.",
+      "options": [
+        "tiene",
+        "tenga",
+        "tuviera"
+      ],
+      "answer": "tiene",
+      "feedback": {
+        "correct": "Correcto: certeza + \"es evidente que\" → indicativo.",
+        "wrong": "Las expresiones de certeza mantienen indicativo: **tiene**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:indicativo-vs-subjuntivo"
+      }
+    },
+    {
+      "id": "d1-indicativo-subjuntivo-ex4",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Te llamaré cuando ___ (llegar) a casa.",
+      "answer": "llegue",
+      "accepted": [
+        "re:^llegue$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acción futura pendiente tras *cuando* → subjuntivo.",
+        "wrong": "Con acciones futuras tras *cuando*, usa **llegue**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:indicativo-vs-subjuntivo"
+      }
+    },
+    {
+      "id": "d1-indicativo-subjuntivo-ex5",
+      "lessonId": "a28-subjunctive-sequence",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Aunque ___ caro, lo compraré.",
+      "options": [
+        "sea",
+        "es",
+        "fue"
+      ],
+      "answer": "sea",
+      "feedback": {
+        "correct": "Correcto: concesión hipotética → subjuntivo.",
+        "wrong": "Para una concesión con posibilidad, usa **sea**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:indicativo-vs-subjuntivo"
+      }
+    },
+    {
+      "id": "d1-cliticos-se-ex1",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "D1 Drill — ¿Puedes ___ mañana? (dar + se + lo)",
+      "answer": "dárselo",
+      "accepted": [
+        "re:^dárselo$",
+        "re:^darselo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: en infinitivo afirmativo los clíticos se posponen y unen.",
+        "wrong": "En infinitivo, coloca los pronombres detrás: **dárselo**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:cliticos-se"
+      }
+    },
+    {
+      "id": "d1-cliticos-se-ex2",
+      "lessonId": "a25-clitics-se",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Entrega el informe a Marta →",
+      "options": [
+        "Entrégaselo",
+        "Entrégalo",
+        "Se lo entrega"
+      ],
+      "answer": "Entrégaselo",
+      "feedback": {
+        "correct": "Correcto: imperativo afirmativo + doble pronombre = posposición con tilde.",
+        "wrong": "En imperativo afirmativo añade ambos pronombres al final: **Entrégaselo**."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:cliticos-se"
+      }
+    },
+    {
+      "id": "d1-cliticos-se-ex3",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "D1 Drill — No ___ dije porque ya lo sabía.",
+      "answer": "se lo",
+      "accepted": [
+        "re:^se lo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: en negativo, los pronombres van delante del verbo conjugado.",
+        "wrong": "Con estructuras negativas, coloca los clíticos antes: **no se lo dije**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:cliticos-se"
+      }
+    },
+    {
+      "id": "d1-cliticos-se-ex4",
+      "lessonId": "a25-clitics-se",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Les di el libro a mis padres →",
+      "options": [
+        "Se lo di",
+        "Les lo di",
+        "Lo se di"
+      ],
+      "answer": "Se lo di",
+      "feedback": {
+        "correct": "Correcto: \"le/les\" + lo/la se convierte en **se lo**.",
+        "wrong": "Con objetos directo e indirecto de tercera persona usa **se lo di**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:cliticos-se"
+      }
+    },
+    {
+      "id": "d1-cliticos-se-ex5",
+      "lessonId": "a25-clitics-se",
+      "type": "cloze",
+      "promptMd": "D1 Drill — ___ comas todo el pastel. (te + lo + comer)",
+      "answer": "No te lo comas",
+      "accepted": [
+        "re:^No te lo comas$"
+      ],
+      "feedback": {
+        "correct": "Correcto: en negativo el pronombre va antes del verbo conjugado.",
+        "wrong": "En imperativos negativos coloca los clíticos antes: **No te lo comas**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:cliticos-se"
+      }
+    },
+    {
+      "id": "d1-por-para-ex1",
+      "lessonId": "a32-por-para-advanced",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Gracias ___ tu apoyo constante.",
+      "options": [
+        "por",
+        "para",
+        "a"
+      ],
+      "answer": "por",
+      "feedback": {
+        "correct": "Correcto: expresa causa o agradecimiento → por.",
+        "wrong": "El agradecimiento se introduce con **por**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:por-para"
+      }
+    },
+    {
+      "id": "d1-por-para-ex2",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Salgo ___ Madrid mañana por la tarde.",
+      "answer": "para",
+      "accepted": [
+        "re:^para$"
+      ],
+      "feedback": {
+        "correct": "Correcto: destino final → para.",
+        "wrong": "Para señalar destino o meta usa **para**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:por-para"
+      }
+    },
+    {
+      "id": "d1-por-para-ex3",
+      "lessonId": "a32-por-para-advanced",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Lo hago ___ ti (motivo).",
+      "options": [
+        "por",
+        "para",
+        "sobre"
+      ],
+      "answer": "por",
+      "feedback": {
+        "correct": "Correcto: motivo/causa → por.",
+        "wrong": "Cuando se indica causa o motivación, elige **por**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:por-para"
+      }
+    },
+    {
+      "id": "d1-por-para-ex4",
+      "lessonId": "a32-por-para-advanced",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Este regalo es ___ tu hermana.",
+      "answer": "para",
+      "accepted": [
+        "re:^para$"
+      ],
+      "feedback": {
+        "correct": "Correcto: destinatario → para.",
+        "wrong": "Para señalar beneficiario usa **para**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:por-para"
+      }
+    },
+    {
+      "id": "d1-por-para-ex5",
+      "lessonId": "a32-por-para-advanced",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Llevamos aquí dos horas ___ el tráfico.",
+      "options": [
+        "por",
+        "para",
+        "hasta"
+      ],
+      "answer": "por",
+      "feedback": {
+        "correct": "Correcto: causa que prolonga la espera → por.",
+        "wrong": "Cuando la causa explica una duración, usa **por**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:por-para"
+      }
+    },
+    {
+      "id": "d1-francophone-ex1",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Corrige el calco: *asistir la conferencia* → ___",
+      "answer": "asistir a la conferencia",
+      "accepted": [
+        "re:^asistir a la conferencia$"
+      ],
+      "feedback": {
+        "correct": "Correcto: *asistir* exige la preposición **a**.",
+        "wrong": "Recuerda: se dice **asistir a la conferencia**, no *asistir la*."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:francophone-errors"
+      }
+    },
+    {
+      "id": "d1-francophone-ex2",
+      "lessonId": "a37-error-bank",
+      "type": "mcq",
+      "promptMd": "D1 Drill — Elige la opción idiomática:",
+      "options": [
+        "Tomé una decisión",
+        "Realicé una decisión",
+        "Hice una decisión"
+      ],
+      "answer": "Tomé una decisión",
+      "feedback": {
+        "correct": "Correcto: el verbo natural es *tomar* una decisión.",
+        "wrong": "Evita calcos del francés *prendre une décision*: usa **Tomé una decisión**."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:francophone-errors"
+      }
+    },
+    {
+      "id": "d1-francophone-ex3",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Estoy interesado ___ la música barroca.",
+      "answer": "en",
+      "accepted": [
+        "re:^en$"
+      ],
+      "feedback": {
+        "correct": "Correcto: \"interesado\" rige **en**.",
+        "wrong": "Se dice **interesado en**, no *interesado por* en este contexto personal."
+      },
+      "meta": {
+        "difficulty": "A2",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:francophone-errors"
+      }
+    },
+    {
+      "id": "d1-francophone-ex4",
+      "lessonId": "a37-error-bank",
+      "type": "mcq",
+      "promptMd": "D1 Drill — ¿Cómo traduces 'actually' sin caer en el falso amigo?",
+      "options": [
+        "actualmente",
+        "en realidad",
+        "ahora mismo"
+      ],
+      "answer": "en realidad",
+      "feedback": {
+        "correct": "Correcto: *actually* se traduce como **en realidad** o **de hecho**.",
+        "wrong": "No confundas *actually* con *actualmente* (que significa \"at present\")."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "read"
+        ],
+        "topic": "d1:francophone-errors"
+      }
+    },
+    {
+      "id": "d1-francophone-ex5",
+      "lessonId": "a37-error-bank",
+      "type": "cloze",
+      "promptMd": "D1 Drill — Me di cuenta ___ había olvidado el dossier.",
+      "answer": "de que",
+      "accepted": [
+        "re:^de que$"
+      ],
+      "feedback": {
+        "correct": "Correcto: *darse cuenta* exige \"de que\".",
+        "wrong": "Evita el queísmo: di **me di cuenta de que**."
+      },
+      "meta": {
+        "difficulty": "B1",
+        "skills": [
+          "write"
+        ],
+        "topic": "d1:francophone-errors"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "d1-fc-001",
+      "front": "Marcador 'esta semana'",
+      "back": "Usa pretérito perfecto: he/has/ha + participio",
+      "tag": "d1>perfecto-vs-indefinido",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-002",
+      "front": "Marcador 'ayer'",
+      "back": "Usa pretérito indefinido (terminé, llegamos)",
+      "tag": "d1>perfecto-vs-indefinido",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-003",
+      "front": "Mientras + verbo",
+      "back": "Imperfecto para acción en curso (mientras estudiaba)",
+      "tag": "d1>imperfecto-vs-indefinido",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-004",
+      "front": "De repente + verbo",
+      "back": "Indefinido para evento puntual (de repente sonó)",
+      "tag": "d1>imperfecto-vs-indefinido",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-005",
+      "front": "No creo que...",
+      "back": "Activa subjuntivo (no creo que sea)",
+      "tag": "d1>indicativo-vs-subjuntivo",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-006",
+      "front": "Es evidente que...",
+      "back": "Mantén indicativo (es evidente que tiene)",
+      "tag": "d1>indicativo-vs-subjuntivo",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-007",
+      "front": "Imperativo afirmativo + pronombres",
+      "back": "Pega clíticos al final y añade tilde (dámelo)",
+      "tag": "d1>cliticos-se",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-008",
+      "front": "Imperativo negativo + pronombres",
+      "back": "Pronombres antes del verbo (no te lo lleves)",
+      "tag": "d1>cliticos-se",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-009",
+      "front": "Por = causa / intercambio",
+      "back": "Gracias por..., pagar por, esperar por (Am. Lat.)",
+      "tag": "d1>por-para",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-010",
+      "front": "Para = meta / destinatario",
+      "back": "Salgo para Madrid, regalo para Ana",
+      "tag": "d1>por-para",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-011",
+      "front": "Actually ≠ actualmente",
+      "back": "Traduce 'actually' como 'en realidad' o 'de hecho'",
+      "tag": "d1>francophone-errors",
+      "deck": "grammar"
+    },
+    {
+      "id": "d1-fc-012",
+      "front": "Asistir a",
+      "back": "El verbo necesita preposición: asistir **a** la reunión",
+      "tag": "d1>francophone-errors",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/d1-cumulative-key-traps-flashcards.csv
+++ b/src/seed/d1-cumulative-key-traps-flashcards.csv
@@ -1,0 +1,13 @@
+id,front,back,tag,deck
+d1-fc-001,Marcador 'esta semana',Usa pretérito perfecto: he/has/ha + participio,d1>perfecto-vs-indefinido,grammar
+d1-fc-002,Marcador 'ayer',Usa pretérito indefinido (terminé, llegamos),d1>perfecto-vs-indefinido,grammar
+d1-fc-003,Mientras + verbo,Imperfecto para acción en curso (mientras estudiaba),d1>imperfecto-vs-indefinido,grammar
+d1-fc-004,De repente + verbo,Indefinido para evento puntual (de repente sonó),d1>imperfecto-vs-indefinido,grammar
+d1-fc-005,No creo que...,Activa subjuntivo (no creo que sea),d1>indicativo-vs-subjuntivo,grammar
+d1-fc-006,Es evidente que...,Mantén indicativo (es evidente que tiene),d1>indicativo-vs-subjuntivo,grammar
+d1-fc-007,Imperativo afirmativo + pronombres,Pega clíticos al final y añade tilde (dámelo),d1>cliticos-se,grammar
+d1-fc-008,Imperativo negativo + pronombres,Pronombres antes del verbo (no te lo lleves),d1>cliticos-se,grammar
+d1-fc-009,Por = causa / intercambio,Gracias por..., pagar por, esperar por (Am. Lat.),d1>por-para,grammar
+d1-fc-010,Para = meta / destinatario,Salgo para Madrid, regalo para Ana,d1>por-para,grammar
+d1-fc-011,Actually ≠ actualmente,Traduce 'actually' como 'en realidad' o 'de hecho',d1>francophone-errors,grammar
+d1-fc-012,Asistir a,El verbo necesita preposición: asistir a la reunión,d1>francophone-errors,grammar


### PR DESCRIPTION
## Summary
- add a D1 cumulative lesson with analytics-friendly drills that point back to core lessons and include key-trap flashcards
- generate a consolidated flashcard export and helper script to merge every -flashcards.csv into a single Anki-ready file
- document the new export workflow and provide a printable exam-day cheatsheet with decision tables and high-yield reminders

## Testing
- python scripts/merge_flashcards.py

------
https://chatgpt.com/codex/tasks/task_e_68cda36e3e448324b9fdcb57a7dd0008