### PR TITLE
Refine layout and organize content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Study Spanish Coach
+
+A clean, coach-style workspace for organising B1–C1 Spanish practice. The app keeps lessons, analytics, and flashcards in a single place so you can plan focused sessions and keep your speaking skills sharp—even offline.
+
+## Features
+
+- **Overview dashboard** – scan headline stats, lesson groups, and trending tags on the home screen.
+- **Progress analytics** – review mastery, timing, weak tags, and the next five recommended exercises.
+- **Flashcard trainer** – flip with the spacebar and grade your recall with J/K or the arrow keys.
+- **Content manager** – validate JSON bundles, preview diffs, and cache new lessons for offline use.
+
+## Run the app locally
+
+1. Install dependencies (Node.js 18+ recommended):
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   Vite prints a local URL (typically <http://localhost:5173>) that you can open in the browser.
+
+3. Optional scripts:
+
+   ```bash
+   npm run build   # Type-check and build the production bundle
+   npm run test    # Run the Jest test suite
+   ```
+
+## Importing content
+
+Use the **Content manager** page to upload JSON bundles that follow the `SeedBundle` schema (`lessons`, `exercises`, and `flashcards` arrays). The UI validates the structure, previews new/updated records, and updates the offline cache after a successful import.
+
+## Project structure
+
+- `src/components/layout/AppShell.tsx` – shared layout and navigation shell.
+- `src/pages/` – top-level routes for the dashboard, flashcards, content manager, and lessons.
+- `src/components/` – reusable building blocks such as the dashboard, lesson viewer, and exercise engine.
+- `src/lib/` – analytics, spaced-repetition, schemas, and grading utilities.
+
+Happy studying! 🇪🇸

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import HomePage from './pages/Home';
 import DashboardPage from './pages/DashboardPage';
 import LessonPage from './pages/LessonPage';
 import FlashcardsPage from './pages/FlashcardsPage';
 import ContentManagerPage from './pages/ContentManagerPage';
 import { useHighContrast } from './hooks/useHighContrast';
+import AppShell from './components/layout/AppShell';
 
 const App: React.FC = () => {
   const { enabled, toggle } = useHighContrast();
@@ -15,88 +16,23 @@ const App: React.FC = () => {
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>
-      <div className={`min-h-screen bg-white text-gray-900 ${enabled ? 'high-contrast' : ''}`}>
-        <header className="border-b bg-gray-50" aria-label="Primary navigation">
-          <div className="mx-auto flex flex-wrap items-center justify-between gap-4 px-4 py-3">
-            <div>
-              <h1 className="text-xl font-semibold">Study Spanish Coach</h1>
-              <p className="text-sm text-gray-600">B1–C1 skills on demand</p>
-            </div>
-            <nav aria-label="Main">
-              <ul className="flex flex-wrap items-center gap-4" role="list">
-                <li>
-                  <NavLink
-                    to="/"
-                    end
-                    className={({ isActive }) =>
-                      `focus-visible:ring px-2 py-1 rounded ${isActive ? 'font-semibold underline' : ''}`
-                    }
-                  >
-                    Home
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/dashboard"
-                    className={({ isActive }) =>
-                      `focus-visible:ring px-2 py-1 rounded ${isActive ? 'font-semibold underline' : ''}`
-                    }
-                  >
-                    Dashboard
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/flashcards"
-                    className={({ isActive }) =>
-                      `focus-visible:ring px-2 py-1 rounded ${isActive ? 'font-semibold underline' : ''}`
-                    }
-                  >
-                    Flashcards
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/content-manager"
-                    className={({ isActive }) =>
-                      `focus-visible:ring px-2 py-1 rounded ${isActive ? 'font-semibold underline' : ''}`
-                    }
-                  >
-                    Content manager
-                  </NavLink>
-                </li>
-              </ul>
-            </nav>
-            <button
-              type="button"
-              onClick={toggle}
-              aria-pressed={enabled}
-              className="rounded border border-gray-400 px-3 py-1 focus-visible:ring"
-              aria-label="Toggle high-contrast theme"
-            >
-              {enabled ? 'Use standard theme' : 'Enable high contrast'}
-            </button>
-          </div>
-        </header>
-
-        <main id="main-content" tabIndex={-1} className="mx-auto max-w-5xl p-4 space-y-6">
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/flashcards" element={<FlashcardsPage />} />
-            <Route path="/content-manager" element={<ContentManagerPage />} />
-            <Route path="/lessons/:slug" element={<LessonPage />} />
-            <Route
-              path="*"
-              element={
-                <p role="alert" className="text-red-600">
-                  Page not found. Use the navigation links above to continue learning.
-                </p>
-              }
-            />
-          </Routes>
-        </main>
-      </div>
+      <AppShell highContrastEnabled={enabled} onToggleHighContrast={toggle}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/flashcards" element={<FlashcardsPage />} />
+          <Route path="/content-manager" element={<ContentManagerPage />} />
+          <Route path="/lessons/:slug" element={<LessonPage />} />
+          <Route
+            path="*"
+            element={
+              <p role="alert" className="text-red-600">
+                Page not found. Use the navigation links above to continue learning.
+              </p>
+            }
+          />
+        </Routes>
+      </AppShell>
     </BrowserRouter>
   );
 };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -37,93 +37,105 @@ export const Dashboard: React.FC = () => {
   }, []);
 
   if (loading) {
-    return <p role="status">Loading analytics…</p>;
+    return (
+      <p role="status" className="rounded-xl border bg-white p-4 text-sm text-slate-600">
+        Loading analytics…
+      </p>
+    );
   }
 
   if (!snapshot) {
-    return <p role="status">No data yet. Complete a few exercises to populate the dashboard.</p>;
+    return (
+      <p role="status" className="rounded-xl border bg-white p-4 text-sm text-slate-600">
+        No data yet. Complete a few exercises to populate the dashboard.
+      </p>
+    );
   }
 
   return (
     <div className="space-y-6" aria-live="polite">
-      <section className="space-y-2" aria-label="Mastery progress">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Mastery progress</h2>
-          <span className="text-sm text-gray-600">{progress.toFixed(1)}% mastered</span>
+      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Mastery progress">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-xl font-semibold text-slate-900">Mastery progress</h2>
+          <span className="text-sm font-semibold text-emerald-700">{progress.toFixed(1)}% mastered</span>
         </div>
         <div
-          className="bg-gray-200 h-4 rounded"
+          className="h-4 rounded-full bg-slate-200"
           role="progressbar"
           aria-valuenow={progress}
           aria-valuemin={0}
           aria-valuemax={100}
         >
-          <div className="bg-green-500 h-4 rounded" style={{ width: `${progress}%` }} />
+          <div className="h-4 rounded-full bg-emerald-500" style={{ width: `${progress}%` }} />
         </div>
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-slate-600">
           Average attempts to mastery: {snapshot.averageAttemptsToMastery.toFixed(2)}
         </p>
       </section>
 
-      <section className="space-y-2" aria-label="Time on task by lesson">
-        <h3 className="text-lg font-semibold">Time on task (per lesson)</h3>
+      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Time on task by lesson">
+        <h3 className="text-lg font-semibold text-slate-900">Time on task (per lesson)</h3>
         {snapshot.lessonTimes.length === 0 ? (
-          <p className="text-sm">No lesson time logged yet.</p>
+          <p className="text-sm text-slate-600">No lesson time logged yet.</p>
         ) : (
-          <table className="min-w-full border" aria-label="Lesson time summary">
-            <thead>
-              <tr className="bg-gray-100">
-                <th className="border px-3 py-2 text-left">Lesson</th>
-                <th className="border px-3 py-2 text-left">Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {snapshot.lessonTimes.map((lesson) => (
-                <tr key={lesson.lessonId}>
-                  <td className="border px-3 py-1">{lesson.lessonTitle}</td>
-                  <td className="border px-3 py-1">{formatDuration(lesson.totalMs)}</td>
+          <div className="overflow-hidden rounded-lg border border-slate-200">
+            <table className="min-w-full text-sm" aria-label="Lesson time summary">
+              <thead className="bg-slate-50 text-left text-slate-600">
+                <tr>
+                  <th className="px-3 py-2 font-semibold">Lesson</th>
+                  <th className="px-3 py-2 font-semibold">Time</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {snapshot.lessonTimes.map((lesson) => (
+                  <tr key={lesson.lessonId} className="odd:bg-white even:bg-slate-50">
+                    <td className="px-3 py-2 text-slate-700">{lesson.lessonTitle}</td>
+                    <td className="px-3 py-2 text-slate-700">{formatDuration(lesson.totalMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </section>
 
-      <section className="space-y-2" aria-label="Weakest tags">
-        <h3 className="text-lg font-semibold">Weakest tags</h3>
+      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Weakest tags">
+        <h3 className="text-lg font-semibold text-slate-900">Weakest tags</h3>
         {snapshot.weakestTags.length === 0 ? (
-          <p className="text-sm">No accuracy data by tag yet.</p>
+          <p className="text-sm text-slate-600">No accuracy data by tag yet.</p>
         ) : (
-          <table className="min-w-full border" aria-label="Tags with lowest accuracy">
-            <thead>
-              <tr className="bg-gray-100">
-                <th className="border px-3 py-2 text-left">Tag</th>
-                <th className="border px-3 py-2 text-left">Accuracy</th>
-                <th className="border px-3 py-2 text-left">Attempts</th>
-              </tr>
-            </thead>
-            <tbody>
-              {snapshot.weakestTags.map((tag) => (
-                <tr key={tag.tag}>
-                  <td className="border px-3 py-1">{tag.tag}</td>
-                  <td className="border px-3 py-1">{tag.accuracy.toFixed(1)}%</td>
-                  <td className="border px-3 py-1">{tag.total}</td>
+          <div className="overflow-hidden rounded-lg border border-slate-200">
+            <table className="min-w-full text-sm" aria-label="Tags with lowest accuracy">
+              <thead className="bg-slate-50 text-left text-slate-600">
+                <tr>
+                  <th className="px-3 py-2 font-semibold">Tag</th>
+                  <th className="px-3 py-2 font-semibold">Accuracy</th>
+                  <th className="px-3 py-2 font-semibold">Attempts</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {snapshot.weakestTags.map((tag) => (
+                  <tr key={tag.tag} className="odd:bg-white even:bg-slate-50">
+                    <td className="px-3 py-2 text-slate-700">{tag.tag}</td>
+                    <td className="px-3 py-2 text-slate-700">{tag.accuracy.toFixed(1)}%</td>
+                    <td className="px-3 py-2 text-slate-700">{tag.total}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </section>
 
-      <section className="space-y-2" aria-label="Recommended exercises">
-        <h3 className="text-lg font-semibold">Study plan (next five exercises)</h3>
+      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Recommended exercises">
+        <h3 className="text-lg font-semibold text-slate-900">Study plan (next five exercises)</h3>
         {snapshot.studyPlan.length === 0 ? (
-          <p className="text-sm">All caught up! Import new lessons or revisit completed content.</p>
+          <p className="text-sm text-slate-600">All caught up! Import new lessons or revisit completed content.</p>
         ) : (
-          <ol className="list-decimal ml-5 space-y-1 text-sm">
+          <ol className="ml-5 list-decimal space-y-1 text-sm text-slate-700">
             {snapshot.studyPlan.map((item) => (
               <li key={item.exerciseId}>
-                <span className="font-medium">{item.lessonTitle}</span> – {item.reason}
+                <span className="font-semibold text-slate-900">{item.lessonTitle}</span> – {item.reason}
               </li>
             ))}
           </ol>

--- a/src/components/ExerciseEngine.tsx
+++ b/src/components/ExerciseEngine.tsx
@@ -72,7 +72,10 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
     if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
       try {
         const registration = await navigator.serviceWorker.ready;
-        registration.sync?.register('sync-grades').catch(() => undefined);
+        const syncManager = (registration as ServiceWorkerRegistration & {
+          sync?: { register: (tag: string) => Promise<void> };
+        }).sync;
+        syncManager?.register('sync-grades').catch(() => undefined);
         registration.active?.postMessage({ type: 'SYNC_GRADES' });
       } catch (error) {
         console.warn('Background sync unavailable', error);

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Link, NavLink } from 'react-router-dom';
+
+interface AppShellProps {
+  highContrastEnabled: boolean;
+  onToggleHighContrast: () => void;
+  children: React.ReactNode;
+}
+
+const navigation = [
+  {
+    to: '/',
+    label: 'Overview',
+    description: 'Plan the next study block at a glance.',
+    exact: true,
+  },
+  {
+    to: '/dashboard',
+    label: 'Dashboard',
+    description: 'Progress analytics and weak spots.',
+  },
+  {
+    to: '/flashcards',
+    label: 'Flashcards',
+    description: 'Spaced repetition trainer.',
+  },
+  {
+    to: '/content-manager',
+    label: 'Content manager',
+    description: 'Import JSON lesson bundles.',
+  },
+];
+
+export const AppShell: React.FC<AppShellProps> = ({
+  highContrastEnabled,
+  onToggleHighContrast,
+  children,
+}) => {
+  return (
+    <div
+      className={`min-h-screen bg-slate-50 text-slate-900 ${
+        highContrastEnabled ? 'high-contrast' : ''
+      }`}
+    >
+      <header className="border-b bg-white/90 backdrop-blur" aria-label="Primary navigation">
+        <div className="mx-auto flex flex-wrap items-center justify-between gap-4 px-4 py-4">
+          <div className="space-y-1">
+            <Link to="/" className="text-2xl font-semibold text-slate-900 focus-visible:ring">
+              Study Spanish Coach
+            </Link>
+            <p className="text-sm text-slate-600">
+              Organise B1–C1 lessons, practice and flashcards in one coach-like workspace.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onToggleHighContrast}
+            aria-pressed={highContrastEnabled}
+            className="rounded border border-slate-400 px-3 py-1 text-sm font-medium focus-visible:ring"
+            aria-label="Toggle high-contrast theme"
+          >
+            {highContrastEnabled ? 'Use standard theme' : 'Enable high contrast'}
+          </button>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_260px]">
+          <aside className="order-1 space-y-4" aria-label="Site navigation">
+            <nav className="rounded-xl border bg-white p-4 shadow-sm" aria-label="Main navigation">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Navigate</h2>
+              <ul className="mt-3 space-y-1" role="list">
+                {navigation.map(({ to, label, description, exact }) => (
+                  <li key={to}>
+                    <NavLink
+                      to={to}
+                      end={exact}
+                      className={({ isActive }) =>
+                        `block rounded-lg border px-3 py-2 transition focus-visible:ring ${
+                          isActive
+                            ? 'border-blue-500 bg-blue-50 text-blue-800'
+                            : 'border-transparent hover:border-blue-200 hover:bg-slate-50'
+                        }`
+                      }
+                    >
+                      <span className="block text-sm font-semibold">{label}</span>
+                      <span className="block text-xs text-slate-500">{description}</span>
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </aside>
+
+          <main id="main-content" tabIndex={-1} className="order-2 min-w-0 space-y-8 focus:outline-none">
+            {children}
+          </main>
+
+          <aside className="order-3 space-y-4" aria-label="Study tips">
+            <section className="rounded-xl border bg-white p-4 shadow-sm">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+                Session checklist
+              </h2>
+              <ol className="mt-3 space-y-2 text-sm text-slate-600">
+                <li>
+                  <span className="font-medium">1. Review metrics.</span>{' '}
+                  <Link to="/dashboard" className="text-blue-700 underline focus-visible:ring">
+                    Open the dashboard
+                  </Link>{' '}
+                  to choose a focus tag.
+                </li>
+                <li>
+                  <span className="font-medium">2. Work through one lesson.</span>{' '}
+                  Skim the overview below and pick the next item in your queue.
+                </li>
+                <li>
+                  <span className="font-medium">3. Reinforce with flashcards.</span>{' '}
+                  <Link to="/flashcards" className="text-blue-700 underline focus-visible:ring">
+                    Run the due deck
+                  </Link>{' '}
+                  to lock it in.
+                </li>
+              </ol>
+            </section>
+
+            <section className="rounded-xl border bg-white p-4 shadow-sm">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+                Keep content fresh
+              </h2>
+              <p className="mt-3 text-sm text-slate-600">
+                Import JSON bundles in the Content manager to refresh lessons and practise sets. Once loaded,
+                everything is cached for offline work.
+              </p>
+              <Link to="/content-manager" className="mt-3 inline-flex text-sm font-medium text-blue-700 underline focus-visible:ring">
+                Go to Content manager
+              </Link>
+            </section>
+          </aside>
+        </div>
+      </div>
+
+      <footer className="border-t bg-white" aria-label="Site footer">
+        <div className="mx-auto max-w-6xl px-4 py-4 text-sm text-slate-500">
+          Launch locally with <code>npm install</code> then <code>npm run dev</code>.
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/src/pages/ContentManagerPage.tsx
+++ b/src/pages/ContentManagerPage.tsx
@@ -139,125 +139,175 @@ const ContentManagerPage: React.FC = () => {
   };
 
   return (
-    <section className="space-y-5" aria-labelledby="content-manager-heading">
-      <header className="space-y-2">
-        <h1 id="content-manager-heading" className="text-2xl font-bold">
-          Content Manager
+    <section className="space-y-6" aria-labelledby="content-manager-heading">
+      <header className="space-y-3 rounded-xl border bg-white p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-widest text-blue-600">Content pipeline</p>
+        <h1 id="content-manager-heading" className="text-3xl font-bold text-slate-900">
+          Content manager
         </h1>
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-slate-600">
           Import vetted JSON content drops, preview the diff, and keep the learner database indexed for offline use.
         </p>
       </header>
 
-      <div className="space-y-3">
-        <label htmlFor="content-upload" className="font-medium">
-          Upload JSON bundle
-        </label>
-        <input
-          id="content-upload"
-          type="file"
-          accept="application/json"
-          onChange={handleFileChange}
-          aria-describedby="content-upload-help"
-        />
-        <p id="content-upload-help" className="text-sm text-gray-600">
-          The file should follow the SeedBundle schema with lessons, exercises, and flashcards arrays.
-        </p>
-        {fileName && (
-          <p className="text-sm" aria-live="polite">
-            Selected file: <strong>{fileName}</strong>
-          </p>
-        )}
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="space-y-6">
+          <section className="space-y-3 rounded-xl border bg-white p-4 shadow-sm">
+            <label htmlFor="content-upload" className="font-semibold text-slate-800">
+              Upload JSON bundle
+            </label>
+            <input
+              id="content-upload"
+              type="file"
+              accept="application/json"
+              onChange={handleFileChange}
+              aria-describedby="content-upload-help"
+            />
+            <p id="content-upload-help" className="text-sm text-slate-600">
+              The file should follow the SeedBundle schema with <code>lessons</code>, <code>exercises</code>, and
+              <code>flashcards</code> arrays.
+            </p>
+            {fileName && (
+              <p className="text-sm text-slate-600" aria-live="polite">
+                Selected file: <strong>{fileName}</strong>
+              </p>
+            )}
+          </section>
+
+          {status && (
+            <div
+              role="status"
+              className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900"
+              aria-live="polite"
+            >
+              {status}
+            </div>
+          )}
+
+          {errors.length > 0 && (
+            <div
+              role="alert"
+              className="space-y-2 rounded-lg border border-red-200 bg-red-50 p-4"
+              aria-live="assertive"
+            >
+              <h2 className="text-sm font-semibold text-red-700">Validation errors</h2>
+              <ul className="ml-5 list-disc text-sm text-red-700">
+                {errors.map((message, index) => (
+                  <li key={index}>{message}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {bundle && errors.length === 0 && (
+            <section className="space-y-4 rounded-xl border bg-white p-4 shadow-sm" aria-live="polite">
+              <header className="space-y-1">
+                <h2 className="text-xl font-semibold text-slate-900">Preview diff</h2>
+                <p className="text-sm text-slate-600">
+                  Confirm how many lessons and exercises will be inserted or updated before importing.
+                </p>
+              </header>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-lg border border-slate-200 p-3" aria-label="Lesson diff summary">
+                  <h3 className="text-sm font-semibold text-slate-800">Lessons</h3>
+                  <p className="text-sm text-slate-600">New: {diffSummary.lessons.new}</p>
+                  <p className="text-sm text-slate-600">Updated: {diffSummary.lessons.updated}</p>
+                  {diff.newLessons.length > 0 && (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-sm text-blue-700 underline">View new lessons</summary>
+                      <ul className="ml-5 list-disc text-sm text-slate-600">
+                        {diff.newLessons.map((lesson) => (
+                          <li key={lesson.id}>{lesson.title}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                  {diff.updatedLessons.length > 0 && (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-sm text-blue-700 underline">View lesson updates</summary>
+                      <ul className="ml-5 list-disc text-sm text-slate-600">
+                        {diff.updatedLessons.map((lesson) => (
+                          <li key={lesson.id}>{lesson.title}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                </div>
+                <div className="rounded-lg border border-slate-200 p-3" aria-label="Exercise diff summary">
+                  <h3 className="text-sm font-semibold text-slate-800">Exercises</h3>
+                  <p className="text-sm text-slate-600">New: {diffSummary.exercises.new}</p>
+                  <p className="text-sm text-slate-600">Updated: {diffSummary.exercises.updated}</p>
+                  {diff.newExercises.length > 0 && (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-sm text-blue-700 underline">View new exercises</summary>
+                      <ul className="ml-5 list-disc text-sm text-slate-600">
+                        {diff.newExercises.map((exercise) => (
+                          <li key={exercise.id}>{exercise.promptMd.slice(0, 60)}…</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                  {diff.updatedExercises.length > 0 && (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-sm text-blue-700 underline">View exercise updates</summary>
+                      <ul className="ml-5 list-disc text-sm text-slate-600">
+                        {diff.updatedExercises.map((exercise) => (
+                          <li key={exercise.id}>{exercise.promptMd.slice(0, 60)}…</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleImport}
+                className="inline-flex items-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm focus-visible:ring"
+                disabled={importing}
+                aria-label="Import validated content"
+              >
+                {importing ? 'Importing…' : 'Import content'}
+              </button>
+            </section>
+          )}
+        </div>
+
+        <aside className="space-y-4 rounded-xl border bg-white p-4 shadow-sm" aria-label="Import guidance">
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Import checklist</h2>
+            <ol className="space-y-2 text-sm text-slate-600">
+              <li>Download the latest <code>.json</code> bundle from your content pipeline.</li>
+              <li>Upload it here to validate the structure and preview the diff.</li>
+              <li>
+                When the diff looks right, press <span className="font-semibold text-slate-800">Import content</span>{' '}
+                to update the on-device cache.
+              </li>
+            </ol>
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Bundle structure</h2>
+            <ul className="space-y-1 text-sm text-slate-600">
+              <li>
+                <code>lessons[]</code> — Markdown content with <code>level</code>, <code>tags</code>, and optional
+                references.
+              </li>
+              <li>
+                <code>exercises[]</code> — Practice prompts linked by <code>lessonId</code>.
+              </li>
+              <li>
+                <code>flashcards[]</code> — Deck metadata powering the spaced repetition trainer.
+              </li>
+            </ul>
+          </section>
+          <section className="text-sm text-slate-600">
+            <p>
+              After importing, the service worker updates its offline cache so lessons, exercises, and flashcards are
+              available without a connection.
+            </p>
+          </section>
+        </aside>
       </div>
-
-      {status && (
-        <div role="status" className="rounded border border-blue-200 bg-blue-50 p-3" aria-live="polite">
-          {status}
-        </div>
-      )}
-
-      {errors.length > 0 && (
-        <div
-          role="alert"
-          className="rounded border border-red-300 bg-red-50 p-3 space-y-1"
-          aria-live="assertive"
-        >
-          <h2 className="font-semibold">Validation errors</h2>
-          <ul className="list-disc ml-5 text-sm">
-            {errors.map((message, index) => (
-              <li key={index}>{message}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {bundle && errors.length === 0 && (
-        <div className="space-y-4" aria-live="polite">
-          <h2 className="text-xl font-semibold">Preview diff</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="rounded border p-3" aria-label="Lesson diff summary">
-              <h3 className="font-semibold">Lessons</h3>
-              <p className="text-sm">New: {diffSummary.lessons.new}</p>
-              <p className="text-sm">Updated: {diffSummary.lessons.updated}</p>
-              {diff.newLessons.length > 0 && (
-                <details className="mt-2">
-                  <summary className="cursor-pointer text-sm underline">View new lessons</summary>
-                  <ul className="list-disc ml-5 text-sm">
-                    {diff.newLessons.map((lesson) => (
-                      <li key={lesson.id}>{lesson.title}</li>
-                    ))}
-                  </ul>
-                </details>
-              )}
-              {diff.updatedLessons.length > 0 && (
-                <details className="mt-2">
-                  <summary className="cursor-pointer text-sm underline">View lesson updates</summary>
-                  <ul className="list-disc ml-5 text-sm">
-                    {diff.updatedLessons.map((lesson) => (
-                      <li key={lesson.id}>{lesson.title}</li>
-                    ))}
-                  </ul>
-                </details>
-              )}
-            </div>
-            <div className="rounded border p-3" aria-label="Exercise diff summary">
-              <h3 className="font-semibold">Exercises</h3>
-              <p className="text-sm">New: {diffSummary.exercises.new}</p>
-              <p className="text-sm">Updated: {diffSummary.exercises.updated}</p>
-              {diff.newExercises.length > 0 && (
-                <details className="mt-2">
-                  <summary className="cursor-pointer text-sm underline">View new exercises</summary>
-                  <ul className="list-disc ml-5 text-sm">
-                    {diff.newExercises.map((exercise) => (
-                      <li key={exercise.id}>{exercise.promptMd.slice(0, 60)}…</li>
-                    ))}
-                  </ul>
-                </details>
-              )}
-              {diff.updatedExercises.length > 0 && (
-                <details className="mt-2">
-                  <summary className="cursor-pointer text-sm underline">View exercise updates</summary>
-                  <ul className="list-disc ml-5 text-sm">
-                    {diff.updatedExercises.map((exercise) => (
-                      <li key={exercise.id}>{exercise.promptMd.slice(0, 60)}…</li>
-                    ))}
-                  </ul>
-                </details>
-              )}
-            </div>
-          </div>
-
-          <button
-            type="button"
-            onClick={handleImport}
-            className="bg-green-600 text-white px-4 py-2 rounded focus-visible:ring"
-            disabled={importing}
-            aria-label="Import validated content"
-          >
-            {importing ? 'Importing…' : 'Import content'}
-          </button>
-        </div>
-      )}
     </section>
   );
 };

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,11 +1,27 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Dashboard } from '../components/Dashboard';
 
 const DashboardPage: React.FC = () => (
-  <section className="space-y-4" aria-labelledby="dashboard-page-heading">
-    <h1 id="dashboard-page-heading" className="text-2xl font-bold">
-      Progress dashboard
-    </h1>
+  <section className="space-y-6" aria-labelledby="dashboard-page-heading">
+    <header className="space-y-3 rounded-xl border bg-white p-5 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-widest text-blue-600">Analytics</p>
+      <h1 id="dashboard-page-heading" className="text-3xl font-bold text-slate-900">
+        Progress dashboard
+      </h1>
+      <p className="text-sm text-slate-600">
+        Review accuracy, speed, and recommended exercises after each session so you can adjust the next study
+        block with confidence.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <Link to="/" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+          ← Back to overview
+        </Link>
+        <Link to="/flashcards" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+          Drill due flashcards
+        </Link>
+      </div>
+    </header>
     <Dashboard />
   </section>
 );

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -1,12 +1,57 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { FlashcardTrainer } from '../components/FlashcardTrainer';
 
 const FlashcardsPage: React.FC = () => (
-  <section className="space-y-4" aria-labelledby="flashcards-heading">
-    <h1 id="flashcards-heading" className="text-2xl font-bold">
-      Flashcard trainer
-    </h1>
-    <FlashcardTrainer />
+  <section className="space-y-6" aria-labelledby="flashcards-heading">
+    <header className="space-y-3 rounded-xl border bg-white p-5 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-widest text-blue-600">Spaced repetition</p>
+      <h1 id="flashcards-heading" className="text-3xl font-bold text-slate-900">
+        Flashcard trainer
+      </h1>
+      <p className="text-sm text-slate-600">
+        Keep verbs, connectors, and presentation phrases ready. Flip cards with the spacebar and grade your recall
+        with J/K (or the arrow keys) to move quickly.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <Link to="/" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+          ← Back to overview
+        </Link>
+        <Link to="/content-manager" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+          Import new flashcards
+        </Link>
+      </div>
+    </header>
+
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+      <FlashcardTrainer />
+      <aside className="space-y-4 rounded-xl border bg-white p-4 shadow-sm" aria-label="Trainer tips">
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Keyboard flow</h2>
+          <ul className="space-y-1 text-sm text-slate-600">
+            <li>
+              <span className="font-semibold text-slate-800">Space</span> — Reveal the back.
+            </li>
+            <li>
+              <span className="font-semibold text-slate-800">J / ←</span> — Mark as “I forgot”.
+            </li>
+            <li>
+              <span className="font-semibold text-slate-800">K / →</span> — Mark as “I knew it”.
+            </li>
+          </ul>
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Best practice</h2>
+          <ul className="space-y-2 text-sm text-slate-600">
+            <li>Say each answer aloud to build confident speaking reflexes.</li>
+            <li>Mix in a quick dashboard review if you clear the due pile.</li>
+            <li>
+              Rotate between decks—verbs, grammar, vocab, presentations—to keep coverage balanced.
+            </li>
+          </ul>
+        </section>
+      </aside>
+    </div>
   </section>
 );
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,81 +1,288 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { db } from '../db';
 import { Lesson } from '../lib/schemas';
+import { isDue } from '../lib/srs';
+
+interface LibraryStats {
+  totalLessons: number;
+  totalExercises: number;
+  dueCards: number;
+  progress: number;
+}
+
+const levelBlueprint: { level: Lesson['level']; title: string; description: string }[] = [
+  {
+    level: 'B1',
+    title: 'Level B1 · Build confident fluency',
+    description: 'Polish everyday grammar, narration and fast-paced conversations.',
+  },
+  {
+    level: 'C1',
+    title: 'Level C1 · Present like a pro',
+    description: 'Rehearse debates, briefings and formal presentations with advanced vocabulary.',
+  },
+];
 
 export const HomePage: React.FC = () => {
   const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [stats, setStats] = useState<LibraryStats>({
+    totalLessons: 0,
+    totalExercises: 0,
+    dueCards: 0,
+    progress: 0,
+  });
 
   useEffect(() => {
     let active = true;
-    db.lessons
-      .toArray()
-      .then((items) => {
-        if (!active) return;
-        const sorted = [...items].sort((a, b) => a.title.localeCompare(b.title));
-        setLessons(sorted);
+    const load = async () => {
+      const [lessonItems, exercises, flashcards, grades] = await Promise.all([
+        db.lessons.toArray(),
+        db.exercises.toArray(),
+        db.flashcards.toArray(),
+        db.grades.toArray(),
+      ]);
+      if (!active) return;
+      const sorted = [...lessonItems].sort((a, b) => a.title.localeCompare(b.title));
+      setLessons(sorted);
+
+      const mastered = new Set(grades.filter((grade) => grade.isCorrect).map((grade) => grade.exerciseId));
+      const progress = exercises.length ? (mastered.size / exercises.length) * 100 : 0;
+      const due = flashcards.filter(isDue).length;
+      setStats({
+        totalLessons: lessonItems.length,
+        totalExercises: exercises.length,
+        dueCards: due,
+        progress,
       });
+    };
+
+    load();
     return () => {
       active = false;
     };
   }, []);
 
+  const levelGroups = useMemo(
+    () =>
+      levelBlueprint.map((section) => ({
+        ...section,
+        lessons: lessons.filter((lesson) => lesson.level === section.level),
+      })),
+    [lessons]
+  );
+
+  const topTags = useMemo(() => {
+    const counts = new Map<string, number>();
+    lessons.forEach((lesson) => {
+      lesson.tags.forEach((tag) => {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      });
+    });
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8);
+  }, [lessons]);
+
+  const roundedProgress = Math.round(stats.progress);
+
   return (
-    <section className="space-y-6" aria-labelledby="home-heading">
-      <header className="space-y-2">
-        <h1 id="home-heading" className="text-3xl font-bold">Study Spanish Coach</h1>
-        <p className="text-lg" aria-live="polite">
-          Track mastery, practise verbs, and stay ready for C1 presentations—even offline.
-        </p>
-      </header>
+    <div className="space-y-10" aria-labelledby="home-heading">
+      <section className="rounded-2xl border bg-white p-6 shadow-sm" aria-labelledby="home-heading">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center">
+          <div className="space-y-4 lg:max-w-2xl">
+            <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">Plan with intention</p>
+            <h1 id="home-heading" className="text-3xl font-bold text-slate-900">
+              Your bilingual study coach for structured B1–C1 Spanish practice
+            </h1>
+            <p className="text-lg text-slate-600" aria-live="polite">
+              Scan progress, pick a lesson, and drill the right flashcards—all in one organised workspace that
+              works online or offline.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <a
+                href="#lesson-library"
+                className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm focus-visible:ring"
+              >
+                Browse lesson library
+              </a>
+              <Link
+                to="/dashboard"
+                className="inline-flex items-center rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 focus-visible:ring"
+              >
+                Check progress dashboard
+              </Link>
+            </div>
+          </div>
+          <dl className="grid flex-shrink-0 gap-4 sm:grid-cols-2" aria-label="Study stats">
+            <div className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-center">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-600">Lessons imported</dt>
+              <dd className="mt-1 text-2xl font-bold text-blue-900" aria-live="polite">
+                {stats.totalLessons}
+              </dd>
+            </div>
+            <div className="rounded-xl border border-indigo-100 bg-indigo-50 px-4 py-3 text-center">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-indigo-600">Practice items</dt>
+              <dd className="mt-1 text-2xl font-bold text-indigo-900" aria-live="polite">
+                {stats.totalExercises}
+              </dd>
+            </div>
+            <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3 text-center">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-emerald-600">Mastery progress</dt>
+              <dd className="mt-1 text-2xl font-bold text-emerald-900" aria-live="polite">
+                {roundedProgress}%
+              </dd>
+            </div>
+            <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-center">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-amber-600">Due flashcards</dt>
+              <dd className="mt-1 text-2xl font-bold text-amber-900" aria-live="polite">
+                {stats.dueCards}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </section>
 
-      <div>
-        <h2 className="text-xl font-semibold" id="lesson-list-heading">Lessons</h2>
-        <nav aria-labelledby="lesson-list-heading">
-          <ul className="divide-y" role="list">
-            {lessons.map((lesson) => (
-              <li key={lesson.id} className="py-3">
-                <Link
-                  to={`/lessons/${lesson.slug}`}
-                  className="font-medium text-blue-700 underline focus-visible:ring"
-                >
-                  {lesson.title}
-                </Link>
-                <div className="text-sm text-gray-600" aria-label={`Tags for ${lesson.title}`}>
-                  {lesson.tags.join(', ')}
-                </div>
-              </li>
+      <section className="space-y-4" aria-labelledby="focus-heading">
+        <div className="space-y-2">
+          <h2 id="focus-heading" className="text-2xl font-semibold text-slate-900">
+            Today’s focus loop
+          </h2>
+          <p className="text-sm text-slate-600">
+            Cycle through these steps to keep your speaking, writing, and recall sharp.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-slate-900">Check your analytics</h3>
+              <p className="text-sm text-slate-600">
+                Identify the tags and lessons that need another pass before your next conversation.
+              </p>
+            </div>
+            <Link to="/dashboard" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+              Open dashboard
+            </Link>
+          </article>
+          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-slate-900">Pick a lesson objective</h3>
+              <p className="text-sm text-slate-600">
+                Use the library below to choose the next B1 or C1 target for today’s session.
+              </p>
+            </div>
+            <a href="#lesson-library" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+              Browse lessons
+            </a>
+          </article>
+          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-slate-900">Reinforce with flashcards</h3>
+              <p className="text-sm text-slate-600">
+                Rotate through due verbs, connectors, and presentation phrases in the trainer.
+              </p>
+            </div>
+            <Link to="/flashcards" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+              Start trainer
+            </Link>
+          </article>
+          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-slate-900">Update your content</h3>
+              <p className="text-sm text-slate-600">
+                Import the latest JSON bundle so fresh lessons, exercises, and flashcards stay in sync.
+              </p>
+            </div>
+            <Link to="/content-manager" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+              Go to Content manager
+            </Link>
+          </article>
+        </div>
+      </section>
+
+      <section id="lesson-library" className="space-y-5" aria-labelledby="library-heading">
+        <div className="space-y-2">
+          <h2 id="library-heading" className="text-2xl font-semibold text-slate-900">
+            Lesson library
+          </h2>
+          <p className="text-sm text-slate-600">
+            Organised by CEFR level so you can match today’s focus with the right material.
+          </p>
+        </div>
+        {lessons.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-slate-300 bg-slate-100 p-4 text-sm text-slate-600" aria-live="polite">
+            No lessons imported yet. Use the Content manager to add the latest content drop.
+          </p>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {levelGroups.map(({ level, title, description, lessons: groupLessons }) => (
+              <article key={level} className="space-y-3 rounded-xl border bg-white p-4 shadow-sm">
+                <header className="space-y-1">
+                  <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+                  <p className="text-sm text-slate-600">
+                    {description}{' '}
+                    <span className="font-medium text-slate-700">
+                      {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
+                    </span>
+                  </p>
+                </header>
+                {groupLessons.length > 0 ? (
+                  <ul className="space-y-2" role="list">
+                    {groupLessons.map((lesson) => (
+                      <li
+                        key={lesson.id}
+                        className="rounded-lg border border-slate-200 px-3 py-2 transition hover:border-blue-300"
+                      >
+                        <Link
+                          to={`/lessons/${lesson.slug}`}
+                          className="text-sm font-medium text-blue-700 underline focus-visible:ring"
+                        >
+                          {lesson.title}
+                        </Link>
+                        <p className="mt-1 text-xs text-slate-500" aria-label={`Tags for ${lesson.title}`}>
+                          {lesson.tags.join(' · ')}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-slate-600">No lessons imported for this level yet.</p>
+                )}
+              </article>
             ))}
-            {lessons.length === 0 && (
-              <li className="py-3 text-sm" aria-live="polite">
-                No lessons imported yet. Use the Content Manager to add the latest content drop.
-              </li>
-            )}
-          </ul>
-        </nav>
-      </div>
+          </div>
+        )}
+      </section>
 
-      <aside className="bg-gray-100 p-4 rounded" aria-label="Quick actions">
-        <h2 className="text-lg font-semibold">Quick actions</h2>
-        <ul className="list-disc ml-6 space-y-1">
-          <li>
-            <Link to="/dashboard" className="text-blue-700 underline focus-visible:ring">
-              Review your progress dashboard
-            </Link>
-          </li>
-          <li>
-            <Link to="/flashcards" className="text-blue-700 underline focus-visible:ring">
-              Drill high-priority flashcards
-            </Link>
-          </li>
-          <li>
+      <section className="space-y-3" aria-labelledby="tag-heading">
+        <h2 id="tag-heading" className="text-xl font-semibold text-slate-900">
+          Topics on your radar
+        </h2>
+        {topTags.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {topTags.map(([tag, count]) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-800"
+                title={`${count} lesson${count === 1 ? '' : 's'}`}
+              >
+                <span>{tag}</span>
+                <span className="ml-2 text-xs font-normal text-blue-600" aria-hidden="true">
+                  ×{count}
+                </span>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-slate-600">
+            Tags will appear once you import lessons.{' '}
             <Link to="/content-manager" className="text-blue-700 underline focus-visible:ring">
-              Import a new JSON content drop
+              Add a content bundle to get started.
             </Link>
-          </li>
-        </ul>
-      </aside>
-    </section>
+          </p>
+        )}
+      </section>
+    </div>
   );
 };
 

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { db } from '../db';
 import { Exercise, Lesson } from '../lib/schemas';
 import { LessonViewer } from '../components/LessonViewer';
@@ -50,37 +50,102 @@ const LessonPage: React.FC = () => {
   }
 
   return (
-    <article className="space-y-6" aria-labelledby="lesson-title">
-      <header className="space-y-2">
-        <h1 id="lesson-title" className="text-2xl font-bold">
-          {lesson.title}
-        </h1>
-        <p className="text-sm text-gray-600" aria-label="Lesson tags">
-          {lesson.tags.join(', ')}
-        </p>
-      </header>
-
-      <LessonViewer markdown={lesson.markdown} />
-
-      <section className="space-y-4" aria-labelledby="lesson-exercises-heading">
-        <h2 id="lesson-exercises-heading" className="text-xl font-semibold">
-          Practise the lesson
-        </h2>
-        {exercises.map((exercise) => (
-          <div
-            key={exercise.id}
-            className="border rounded p-4 shadow-sm"
-            aria-label={`Exercise ${exercise.id}`}
-          >
-            <ExerciseEngine exercise={exercise} />
+    <article className="space-y-8" aria-labelledby="lesson-title">
+      <div className="space-y-4 rounded-xl border bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Link to="/" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+            ← Back to overview
+          </Link>
+          <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-blue-700">
+            Level {lesson.level}
+          </span>
+        </div>
+        <div className="space-y-3">
+          <h1 id="lesson-title" className="text-3xl font-bold text-slate-900">
+            {lesson.title}
+          </h1>
+          <div className="flex flex-wrap gap-2" aria-label="Lesson tags">
+            {lesson.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700"
+              >
+                {tag}
+              </span>
+            ))}
           </div>
-        ))}
-        {exercises.length === 0 && (
-          <p role="status" className="italic">
-            No exercises found for this lesson yet.
+          <p className="text-sm text-slate-600">
+            {exercises.length > 0
+              ? `${exercises.length} practice activit${exercises.length === 1 ? 'y' : 'ies'} ready to log.`
+              : 'Review the notes, then import a practice set to track mastery.'}
           </p>
-        )}
-      </section>
+        </div>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="space-y-8">
+          <section className="space-y-4 rounded-xl border bg-white p-6 shadow-sm" aria-labelledby="lesson-content-heading">
+            <h2 id="lesson-content-heading" className="text-xl font-semibold text-slate-900">
+              Lesson content
+            </h2>
+            <LessonViewer markdown={lesson.markdown} />
+          </section>
+
+          <section className="space-y-4 rounded-xl border bg-white p-6 shadow-sm" aria-labelledby="lesson-exercises-heading">
+            <div className="space-y-1">
+              <h2 id="lesson-exercises-heading" className="text-xl font-semibold text-slate-900">
+                Practise the lesson
+              </h2>
+              <p className="text-sm text-slate-600">
+                Work through each prompt to log attempts and unlock mastery progress.
+              </p>
+            </div>
+            {exercises.map((exercise) => (
+              <div
+                key={exercise.id}
+                className="rounded-lg border border-slate-200 p-4 shadow-sm"
+                aria-label={`Exercise ${exercise.id}`}
+              >
+                <ExerciseEngine exercise={exercise} />
+              </div>
+            ))}
+            {exercises.length === 0 && (
+              <p role="status" className="text-sm italic text-slate-600">
+                No exercises found for this lesson yet.
+              </p>
+            )}
+          </section>
+        </div>
+
+        <aside className="space-y-4 rounded-xl border bg-white p-6 shadow-sm" aria-label="Study guidance">
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Study roadmap</h2>
+            <ol className="space-y-2 text-sm text-slate-600">
+              <li>Skim the key idea and underline new connectors or discourse markers.</li>
+              <li>Complete the practice set, logging hints and timings for the dashboard.</li>
+              <li>
+                Finish with a flashcard sprint to reinforce the phrases you want to reuse.
+              </li>
+            </ol>
+          </section>
+          <section className="space-y-2 text-sm text-slate-600">
+            <p>Need a quick spaced-repetition loop after this lesson?</p>
+            <Link to="/flashcards" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+              Jump to the flashcard trainer
+            </Link>
+          </section>
+          {lesson.references?.length ? (
+            <section className="space-y-2">
+              <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">References</h2>
+              <ul className="space-y-1 text-sm text-slate-600">
+                {lesson.references.map((reference, index) => (
+                  <li key={`${reference}-${index}`}>{reference}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </aside>
+      </div>
     </article>
   );
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "noEmit": true,
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## Summary
- add an AppShell layout with persistent navigation, study tips, and footer guidance for launching the app locally
- reorganize the home overview, dashboard, flashcards, content manager, and lesson pages into clear cards with contextual guidance
- document how to run the project and prevent TypeScript from emitting build artefacts during checks

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdadba14a083249f9611a78181a667