### PR TITLE
Restyle study experience with modern UI shell

### DIFF
--- a/src/components/ConjugationTable.tsx
+++ b/src/components/ConjugationTable.tsx
@@ -14,20 +14,23 @@ export const ConjugationTable: React.FC<ConjugationTableProps> = ({ expected, va
   };
 
   return (
-    <table className="table-auto border" aria-label="Conjugation practice table">
-      <thead>
+    <table
+      className="min-w-full overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 text-sm shadow-inner"
+      aria-label="Conjugation practice table"
+    >
+      <thead className="bg-slate-100 text-left text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
         <tr>
-          <th className="border px-2 py-1 text-left">Form</th>
-          <th className="border px-2 py-1 text-left">Your answer</th>
+          <th className="px-3 py-2">Form</th>
+          <th className="px-3 py-2">Your answer</th>
         </tr>
       </thead>
       <tbody>
         {expected.map((_, index) => (
-          <tr key={index}>
-            <td className="border px-2 py-1">{index + 1}</td>
-            <td className="border px-2 py-1">
+          <tr key={index} className="odd:bg-white even:bg-slate-50">
+            <td className="px-3 py-2 font-semibold text-slate-600">{index + 1}</td>
+            <td className="px-3 py-2">
               <input
-                className="border p-1 w-full"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 value={values[index] ?? ''}
                 aria-label={`Answer for conjugation cell ${index + 1}`}
                 onChange={(event) => handleChange(index, event.target.value)}

--- a/src/components/ExerciseEngine.tsx
+++ b/src/components/ExerciseEngine.tsx
@@ -93,21 +93,41 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
     if (exercise.type === 'mcq' || exercise.type === 'multi') {
       const isMulti = exercise.type === 'multi';
       return (
-        <fieldset className="space-y-2" aria-label="Answer choices">
-          <legend className="font-semibold">Choose {isMulti ? 'all that apply' : 'one option'}</legend>
-          <div className="space-y-1">
+        <fieldset className="space-y-4" aria-label="Answer choices">
+          <legend className="text-sm font-semibold text-slate-700">
+            Choose {isMulti ? 'all that apply' : 'one option'}
+          </legend>
+          <div className="grid gap-2">
             {(exercise.options ?? []).map((option) => {
               const checked = selectedOptions.includes(option);
               return (
-                <label key={option} className="flex items-center gap-2">
+                <label
+                  key={option}
+                  className={`group relative flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-sm font-medium transition ${
+                    checked
+                      ? 'border-blue-500 bg-blue-50 text-blue-900 shadow-sm'
+                      : 'border-slate-200/80 bg-white/90 text-slate-700 hover:border-blue-300 hover:bg-blue-50/40'
+                  }`}
+                >
                   <input
                     type={isMulti ? 'checkbox' : 'radio'}
                     name={`exercise-${exercise.id}`}
                     value={option}
                     checked={checked}
                     onChange={() => toggleOption(option)}
+                    className="sr-only"
                   />
                   <span>{option}</span>
+                  <span
+                    aria-hidden="true"
+                    className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs transition ${
+                      checked
+                        ? 'border-blue-500 bg-blue-500 text-white'
+                        : 'border-slate-300 text-slate-400'
+                    }`}
+                  >
+                    {checked ? '✓' : ''}
+                  </span>
                 </label>
               );
             })}
@@ -124,7 +144,7 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
 
     return (
       <input
-        className="border rounded p-2 w-full"
+        className="w-full rounded-xl border border-slate-300 bg-white/90 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
         value={inputValue}
         aria-label="Your answer"
         onChange={(event) => setInputValue(event.target.value)}
@@ -139,20 +159,36 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
   };
 
   return (
-    <div className="space-y-3" aria-live="polite">
-      <div className="prose max-w-none">
-        <ReactMarkdown>{exercise.promptMd}</ReactMarkdown>
+    <div className="space-y-5" aria-live="polite">
+      <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm">
+        <div className="prose prose-slate max-w-none">
+          <ReactMarkdown>{exercise.promptMd}</ReactMarkdown>
+        </div>
       </div>
-      {renderInput()}
-      <button
-        type="button"
-        onClick={submit}
-        className="bg-blue-600 text-white px-4 py-2 rounded focus-visible:ring"
-      >
-        Submit answer
-      </button>
+      <div className="rounded-2xl border border-slate-200/70 bg-white/90 p-5 shadow-inner">
+        {renderInput()}
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={submit}
+          className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-blue-500/30 transition hover:bg-blue-700 focus-visible:ring"
+        >
+          Submit answer
+          <span aria-hidden="true">→</span>
+        </button>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Press Enter to submit</p>
+      </div>
       {feedback && (
-        <div role="status" aria-live="assertive" className="font-medium">
+        <div
+          role="status"
+          aria-live="assertive"
+          className={`rounded-2xl border px-4 py-3 text-sm font-medium ${
+            feedback.includes('Correct')
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+              : 'border-rose-200 bg-rose-50 text-rose-700'
+          }`}
+        >
           {feedback}
         </div>
       )}

--- a/src/components/FlashcardTrainer.tsx
+++ b/src/components/FlashcardTrainer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { db } from '../db';
 import { isDue, updateSRS } from '../lib/srs';
 import { Flashcard } from '../lib/schemas';
@@ -7,6 +8,7 @@ export const FlashcardTrainer: React.FC = () => {
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [current, setCurrent] = useState<Flashcard | null>(null);
   const [showBack, setShowBack] = useState(false);
+  const [totalCards, setTotalCards] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -15,6 +17,8 @@ export const FlashcardTrainer: React.FC = () => {
       const due = all.filter(isDue);
       setCards(due);
       setCurrent(due[0] ?? null);
+      setShowBack(false);
+      setTotalCards(due.length);
     });
     return () => {
       active = false;
@@ -56,56 +60,132 @@ export const FlashcardTrainer: React.FC = () => {
 
   if (!current) {
     return (
-      <div role="status" className="p-4 border rounded bg-green-50">
-        No due cards 🎉
-      </div>
+      <section
+        role="status"
+        className="relative overflow-hidden rounded-3xl border border-emerald-200/70 bg-gradient-to-br from-emerald-100 via-white to-emerald-50 p-8 text-emerald-900 shadow-lg"
+      >
+        <div className="absolute inset-y-0 right-[-140px] h-[320px] w-[320px] rounded-full bg-emerald-300/40 blur-3xl" aria-hidden="true" />
+        <div className="relative z-10 space-y-4">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/80 text-2xl">🎉</span>
+            <div>
+              <h2 className="text-2xl font-semibold">You’re all caught up</h2>
+              <p className="text-sm text-emerald-700">
+                Import new cards or revisit mastered decks for a bonus review sprint.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              to="/content-manager"
+              className="inline-flex items-center gap-2 rounded-full border border-emerald-300 bg-white px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-400 focus-visible:ring"
+            >
+              Import fresh flashcards
+              <span aria-hidden="true">↗</span>
+            </Link>
+            <Link
+              to="/dashboard"
+              className="inline-flex items-center gap-2 rounded-full border border-emerald-200 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:border-emerald-400 focus-visible:ring"
+            >
+              Review progress
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </div>
+      </section>
     );
   }
 
+  const remaining = cards.length;
+  const completed = totalCards - remaining;
+  const progress = totalCards > 0 ? Math.round((completed / totalCards) * 100) : 0;
+
   return (
-    <div className="p-4 border rounded shadow-sm space-y-3" aria-live="polite">
-      <div>
-        <p className="text-sm text-gray-500" aria-label="Remaining cards">
-          {cards.length} cards in session
-        </p>
-        <div className="text-lg font-semibold" aria-label="Flashcard front">
-          {current.front}
+    <section
+      className="relative overflow-hidden rounded-3xl border border-blue-100/80 bg-white/90 p-8 shadow-xl shadow-blue-100/50 backdrop-blur"
+      aria-live="polite"
+    >
+      <div className="absolute inset-y-0 -right-24 h-[420px] w-[420px] rounded-full bg-blue-200/40 blur-3xl" aria-hidden="true" />
+      <div className="relative z-10 space-y-6">
+        <header className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Session progress</p>
+            <p className="text-sm text-slate-600" aria-live="polite">
+              {completed} of {totalCards} cards complete
+            </p>
+          </div>
+          <span className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-blue-600">
+            {remaining} left
+          </span>
+        </header>
+
+        <div className="space-y-5">
+          <div className="rounded-3xl border border-blue-200/70 bg-gradient-to-br from-white via-blue-50 to-white p-6 shadow-inner">
+            <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Prompt</span>
+            <p className="mt-4 text-2xl font-bold leading-snug text-slate-900" aria-label="Flashcard front">
+              {current.front}
+            </p>
+            {showBack && (
+              <div className="mt-6 rounded-2xl border border-emerald-200/70 bg-white/90 p-4 shadow-sm">
+                <span className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-500">Answer</span>
+                <p className="mt-2 text-lg font-semibold leading-relaxed text-emerald-700" aria-label="Flashcard back">
+                  {current.back}
+                </p>
+              </div>
+            )}
+          </div>
+
+          {!showBack ? (
+            <button
+              type="button"
+              onClick={() => setShowBack(true)}
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-500/30 transition hover:bg-blue-700 focus-visible:ring"
+              aria-label="Reveal answer (spacebar)"
+            >
+              Reveal answer
+              <span aria-hidden="true" className="text-base">
+                →
+              </span>
+            </button>
+          ) : (
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => grade(true)}
+                className="flex-1 rounded-full border border-emerald-300 bg-emerald-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600 focus-visible:ring"
+                aria-label="I remembered it (arrow right or K)"
+              >
+                I knew it
+              </button>
+              <button
+                type="button"
+                onClick={() => grade(false)}
+                className="flex-1 rounded-full border border-rose-200 bg-rose-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-600 focus-visible:ring"
+                aria-label="I forgot (arrow left or J)"
+              >
+                I forgot
+              </button>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              <span>Progress</span>
+              <span>{progress}%</span>
+            </div>
+            <div className="h-2 rounded-full bg-slate-200">
+              <div
+                className="h-2 rounded-full bg-blue-500 transition-all"
+                style={{ width: `${totalCards > 0 ? (completed / totalCards) * 100 : 0}%` }}
+              />
+            </div>
+          </div>
+
+          <p className="text-xs text-slate-500">
+            Space — reveal · J / ← — Forgot · K / → — Knew it
+          </p>
         </div>
       </div>
-      {showBack ? (
-        <div className="mt-2 text-green-600" aria-label="Flashcard back">
-          {current.back}
-        </div>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setShowBack(true)}
-          className="bg-blue-600 text-white px-4 py-2 rounded focus-visible:ring"
-          aria-label="Reveal answer (spacebar)"
-        >
-          Show answer
-        </button>
-      )}
-      {showBack && (
-        <div className="flex gap-2 mt-2" role="group" aria-label="Grade your recall">
-          <button
-            type="button"
-            onClick={() => grade(true)}
-            className="bg-green-600 text-white px-4 py-2 rounded focus-visible:ring"
-            aria-label="I remembered it (arrow right or K)"
-          >
-            I knew it
-          </button>
-          <button
-            type="button"
-            onClick={() => grade(false)}
-            className="bg-red-600 text-white px-4 py-2 rounded focus-visible:ring"
-            aria-label="I forgot (arrow left or J)"
-          >
-            I forgot
-          </button>
-        </div>
-      )}
-    </div>
+    </section>
   );
 };

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 
 interface AppShellProps {
@@ -31,76 +31,214 @@ const navigation = [
   },
 ];
 
+const quickActions = [
+  {
+    to: '/dashboard',
+    label: 'Review analytics',
+    description: 'Start with the weakest skills and tags.',
+  },
+  {
+    to: '/flashcards',
+    label: 'Warm-up with flashcards',
+    description: 'Clear due connectors in five focused minutes.',
+  },
+  {
+    to: '/content-manager',
+    label: 'Refresh content bundle',
+    description: 'Import the latest JSON drop before you begin.',
+  },
+];
+
 export const AppShell: React.FC<AppShellProps> = ({
   highContrastEnabled,
   onToggleHighContrast,
   children,
 }) => {
+  const [focusMode, setFocusMode] = useState(false);
+
+  const renderNavigation = () =>
+    navigation.map(({ to, label, description, exact }) => (
+      <NavLink
+        key={to}
+        to={to}
+        end={exact}
+        className={({ isActive }) =>
+          [
+            'group flex min-w-[200px] flex-1 items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left text-sm transition focus-visible:ring',
+            isActive
+              ? highContrastEnabled
+                ? 'border-yellow-400 bg-black text-yellow-100 shadow-none'
+                : 'border-blue-500 bg-white/90 text-blue-900 shadow-lg shadow-blue-100/60 backdrop-blur'
+              : highContrastEnabled
+              ? 'border-slate-500 bg-transparent text-white hover:border-yellow-400'
+              : 'border-transparent bg-white/40 text-slate-600 hover:border-blue-200 hover:bg-white/70 hover:text-slate-900',
+          ].join(' ')
+        }
+      >
+        <span className="space-y-1">
+          <span className="block text-sm font-semibold">{label}</span>
+          <span className="block text-xs text-slate-500 group-hover:text-slate-700">
+            {description}
+          </span>
+        </span>
+        <span
+          aria-hidden="true"
+          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-blue-200 bg-blue-50 text-base text-blue-600 transition-transform group-hover:translate-x-1"
+        >
+          →
+        </span>
+      </NavLink>
+    ));
+
   return (
     <div
-      className={`min-h-screen bg-slate-50 text-slate-900 ${
-        highContrastEnabled ? 'high-contrast' : ''
+      className={`relative min-h-screen ${
+        highContrastEnabled
+          ? 'bg-black text-white'
+          : 'bg-gradient-to-br from-slate-100 via-white to-sky-100 text-slate-900'
       }`}
     >
-      <header className="border-b bg-white/90 backdrop-blur" aria-label="Primary navigation">
-        <div className="mx-auto flex flex-wrap items-center justify-between gap-4 px-4 py-4">
-          <div className="space-y-1">
-            <Link to="/" className="text-2xl font-semibold text-slate-900 focus-visible:ring">
-              Study Spanish Coach
-            </Link>
-            <p className="text-sm text-slate-600">
-              Organise B1–C1 lessons, practice and flashcards in one coach-like workspace.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onToggleHighContrast}
-            aria-pressed={highContrastEnabled}
-            className="rounded border border-slate-400 px-3 py-1 text-sm font-medium focus-visible:ring"
-            aria-label="Toggle high-contrast theme"
-          >
-            {highContrastEnabled ? 'Use standard theme' : 'Enable high contrast'}
-          </button>
+      {!highContrastEnabled && (
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
+          <div className="absolute left-1/2 top-[-14rem] h-[22rem] w-[48rem] -translate-x-1/2 rounded-full bg-gradient-to-r from-sky-200 via-blue-100 to-indigo-200 opacity-60 blur-3xl" />
+          <div className="absolute bottom-[-16rem] right-[-6rem] h-[20rem] w-[20rem] rounded-full bg-gradient-to-br from-emerald-200 to-transparent opacity-70 blur-3xl" />
+          <div className="absolute bottom-[-18rem] left-[-8rem] h-[18rem] w-[18rem] rounded-full bg-gradient-to-tr from-blue-200 via-white to-transparent opacity-60 blur-3xl" />
         </div>
-      </header>
+      )}
 
-      <div className="mx-auto max-w-6xl px-4 py-8">
-        <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_260px]">
-          <aside className="order-1 space-y-4" aria-label="Site navigation">
-            <nav className="rounded-xl border bg-white p-4 shadow-sm" aria-label="Main navigation">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Navigate</h2>
-              <ul className="mt-3 space-y-1" role="list">
-                {navigation.map(({ to, label, description, exact }) => (
-                  <li key={to}>
-                    <NavLink
-                      to={to}
-                      end={exact}
-                      className={({ isActive }) =>
-                        `block rounded-lg border px-3 py-2 transition focus-visible:ring ${
-                          isActive
-                            ? 'border-blue-500 bg-blue-50 text-blue-800'
-                            : 'border-transparent hover:border-blue-200 hover:bg-slate-50'
-                        }`
-                      }
-                    >
-                      <span className="block text-sm font-semibold">{label}</span>
-                      <span className="block text-xs text-slate-500">{description}</span>
-                    </NavLink>
-                  </li>
+      <div className="relative flex min-h-screen flex-col">
+        <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/80 backdrop-blur" aria-label="Primary navigation">
+          <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-4">
+            <div className="space-y-1">
+              <Link to="/" className="text-2xl font-semibold text-slate-900 focus-visible:ring">
+                Study Spanish Coach
+              </Link>
+              <p className="text-sm text-slate-600">
+                Organise B1–C1 lessons, practice, and flashcards in one coach-like workspace.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                <span className="rounded-full bg-slate-900 px-2 py-[2px] text-white">Plan</span>
+                <span className="px-2 py-[2px]">Practice</span>
+                <span className="px-2 py-[2px]">Reflect</span>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={highContrastEnabled}
+                onClick={onToggleHighContrast}
+                className={`relative flex h-9 w-16 items-center rounded-full border px-1 transition focus-visible:ring ${
+                  highContrastEnabled
+                    ? 'border-yellow-400 bg-black text-yellow-200'
+                    : 'border-slate-200 bg-white/80 text-slate-500 hover:border-blue-200'
+                }`}
+                aria-label="Toggle high-contrast theme"
+              >
+                <span className="flex w-full items-center justify-between px-1 text-[11px] font-semibold uppercase">
+                  <span>Aa</span>
+                  <span>HC</span>
+                </span>
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none absolute left-1 top-[6px] inline-flex h-6 w-6 transform items-center justify-center rounded-full bg-white text-[10px] font-semibold text-slate-600 shadow transition ${
+                    highContrastEnabled ? 'translate-x-7 bg-yellow-300 text-slate-900' : ''
+                  }`}
+                >
+                  {highContrastEnabled ? 'On' : 'Off'}
+                </span>
+              </button>
+            </div>
+          </div>
+          <div className="border-t border-slate-200/70 bg-white/70">
+            <div className="mx-auto flex max-w-6xl flex-wrap gap-3 px-4 py-3" role="navigation" aria-label="Site sections">
+              {renderNavigation()}
+            </div>
+          </div>
+        </header>
+
+        <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 xl:grid xl:grid-cols-[260px_minmax(0,1fr)_240px] xl:gap-6">
+          <aside className="order-2 mb-6 space-y-4 xl:order-1 xl:mb-0" aria-label="Session planner">
+            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow-lg shadow-slate-200/40 backdrop-blur">
+              <header className="flex items-center justify-between">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Session planner</h2>
+                <span className="text-xs font-semibold text-blue-600">
+                  {focusMode ? 'Focus mode' : 'Prep mode'}
+                </span>
+              </header>
+              <p className="mt-3 text-sm text-slate-600">
+                Map out the next study sprint with curated shortcuts.
+              </p>
+              <div className="mt-4 space-y-2" role="list">
+                {quickActions.map(({ to, label, description }) => (
+                  <Link
+                    key={to}
+                    to={to}
+                    className="group flex items-center justify-between gap-3 rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-blue-300 hover:text-blue-700 focus-visible:ring"
+                  >
+                    <span className="text-left">
+                      <span className="block font-semibold">{label}</span>
+                      <span className="block text-xs text-slate-500 group-hover:text-slate-600">{description}</span>
+                    </span>
+                    <span aria-hidden="true" className="text-lg text-blue-500 transition-transform group-hover:translate-x-1">
+                      ↗
+                    </span>
+                  </Link>
                 ))}
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={focusMode}
+                onClick={() => setFocusMode((prev) => !prev)}
+                className={`mt-4 w-full rounded-full border px-4 py-2 text-sm font-semibold transition focus-visible:ring ${
+                  focusMode
+                    ? 'border-blue-500 bg-blue-600 text-white shadow'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-blue-200 hover:text-blue-700'
+                }`}
+              >
+                {focusMode ? 'Focus mode enabled' : 'Enable focus mode'}
+              </button>
+            </section>
+
+            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow shadow-slate-200/30 backdrop-blur">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Navigation highlights</h2>
+              <p className="mt-3 text-sm text-slate-600">
+                Each page is optimised for one step of your bilingual workflow—pin this panel if you need a
+                reminder.
+              </p>
+              <ul className="mt-4 space-y-2 text-sm text-slate-600" role="list">
+                <li>
+                  <span className="font-semibold text-slate-800">Overview:</span> plan what to learn next.
+                </li>
+                <li>
+                  <span className="font-semibold text-slate-800">Dashboard:</span> inspect accuracy trends.
+                </li>
+                <li>
+                  <span className="font-semibold text-slate-800">Flashcards:</span> reinforce quick wins.
+                </li>
+                <li>
+                  <span className="font-semibold text-slate-800">Content:</span> keep lessons synced offline.
+                </li>
               </ul>
-            </nav>
+            </section>
           </aside>
 
-          <main id="main-content" tabIndex={-1} className="order-2 min-w-0 space-y-8 focus:outline-none">
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className={`order-1 min-w-0 space-y-10 focus:outline-none ${
+              focusMode
+                ? 'rounded-3xl border border-blue-200/80 bg-white/85 p-6 shadow-2xl shadow-blue-200/50 backdrop-blur'
+                : ''
+            }`}
+          >
             {children}
           </main>
 
           <aside className="order-3 space-y-4" aria-label="Study tips">
-            <section className="rounded-xl border bg-white p-4 shadow-sm">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">
-                Session checklist
-              </h2>
+            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow shadow-slate-200/30 backdrop-blur">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Session checklist</h2>
               <ol className="mt-3 space-y-2 text-sm text-slate-600">
                 <li>
                   <span className="font-medium">1. Review metrics.</span>{' '}
@@ -123,27 +261,35 @@ export const AppShell: React.FC<AppShellProps> = ({
               </ol>
             </section>
 
-            <section className="rounded-xl border bg-white p-4 shadow-sm">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">
-                Keep content fresh
-              </h2>
+            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow shadow-slate-200/30 backdrop-blur">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Keep content fresh</h2>
               <p className="mt-3 text-sm text-slate-600">
-                Import JSON bundles in the Content manager to refresh lessons and practise sets. Once loaded,
+                Import JSON bundles in the content manager to refresh lessons and practise sets. Once loaded,
                 everything is cached for offline work.
               </p>
-              <Link to="/content-manager" className="mt-3 inline-flex text-sm font-medium text-blue-700 underline focus-visible:ring">
+              <Link
+                to="/content-manager"
+                className="mt-3 inline-flex text-sm font-semibold text-blue-700 underline focus-visible:ring"
+              >
                 Go to Content manager
               </Link>
             </section>
           </aside>
         </div>
-      </div>
 
-      <footer className="border-t bg-white" aria-label="Site footer">
-        <div className="mx-auto max-w-6xl px-4 py-4 text-sm text-slate-500">
-          Launch locally with <code>npm install</code> then <code>npm run dev</code>.
-        </div>
-      </footer>
+        <footer
+          className={`border-t ${
+            highContrastEnabled
+              ? 'border-slate-100 bg-black text-slate-100'
+              : 'border-slate-200/70 bg-white/80 text-slate-500 backdrop-blur'
+          }`}
+          aria-label="Site footer"
+        >
+          <div className="mx-auto max-w-6xl px-4 py-4 text-sm">
+            Launch locally with <code>npm install</code> then <code>npm run dev</code>.
+          </div>
+        </footer>
+      </div>
     </div>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,14 +24,43 @@ const levelBlueprint: { level: Lesson['level']; title: string; description: stri
   },
 ];
 
+const focusSteps = [
+  {
+    title: 'Check your analytics',
+    description: 'Identify the tags and lessons that need another pass before your next conversation.',
+    actionLabel: 'Open dashboard',
+    to: '/dashboard',
+  },
+  {
+    title: 'Pick a lesson objective',
+    description: 'Use the library below to choose the next B1 or C1 target for today’s session.',
+    actionLabel: 'Browse lessons',
+    anchor: '#lesson-library',
+  },
+  {
+    title: 'Reinforce with flashcards',
+    description: 'Rotate through due verbs, connectors, and presentation phrases in the trainer.',
+    actionLabel: 'Start trainer',
+    to: '/flashcards',
+  },
+  {
+    title: 'Refresh your content',
+    description: 'Import the latest JSON bundle so fresh lessons, exercises, and flashcards stay in sync.',
+    actionLabel: 'Content manager',
+    to: '/content-manager',
+  },
+];
+
 export const HomePage: React.FC = () => {
   const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [exerciseCounts, setExerciseCounts] = useState<Record<string, number>>({});
   const [stats, setStats] = useState<LibraryStats>({
     totalLessons: 0,
     totalExercises: 0,
     dueCards: 0,
     progress: 0,
   });
+  const [libraryFilter, setLibraryFilter] = useState<'all' | Lesson['level']>('all');
 
   useEffect(() => {
     let active = true;
@@ -49,12 +78,17 @@ export const HomePage: React.FC = () => {
       const mastered = new Set(grades.filter((grade) => grade.isCorrect).map((grade) => grade.exerciseId));
       const progress = exercises.length ? (mastered.size / exercises.length) * 100 : 0;
       const due = flashcards.filter(isDue).length;
+      const counts = exercises.reduce<Record<string, number>>((acc, exercise) => {
+        acc[exercise.lessonId] = (acc[exercise.lessonId] ?? 0) + 1;
+        return acc;
+      }, {});
       setStats({
         totalLessons: lessonItems.length,
         totalExercises: exercises.length,
         dueCards: due,
         progress,
       });
+      setExerciseCounts(counts);
     };
 
     load();
@@ -72,6 +106,14 @@ export const HomePage: React.FC = () => {
     [lessons]
   );
 
+  const filteredGroups = useMemo(
+    () =>
+      libraryFilter === 'all'
+        ? levelGroups
+        : levelGroups.filter((group) => group.level === libraryFilter),
+    [levelGroups, libraryFilter]
+  );
+
   const topTags = useMemo(() => {
     const counts = new Map<string, number>();
     lessons.forEach((lesson) => {
@@ -87,194 +129,264 @@ export const HomePage: React.FC = () => {
   const roundedProgress = Math.round(stats.progress);
 
   return (
-    <div className="space-y-10" aria-labelledby="home-heading">
-      <section className="rounded-2xl border bg-white p-6 shadow-sm" aria-labelledby="home-heading">
-        <div className="flex flex-col gap-6 lg:flex-row lg:items-center">
-          <div className="space-y-4 lg:max-w-2xl">
-            <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">Plan with intention</p>
-            <h1 id="home-heading" className="text-3xl font-bold text-slate-900">
+    <div className="space-y-12" aria-labelledby="home-heading">
+      <section
+        className="relative overflow-hidden rounded-3xl border border-blue-100/80 bg-gradient-to-br from-blue-600 via-indigo-600 to-blue-700 p-8 text-white shadow-2xl"
+        aria-labelledby="home-heading"
+      >
+        <div className="absolute inset-y-0 left-1/2 h-full w-[480px] -translate-x-1/2 rounded-full bg-blue-500/30 blur-3xl" aria-hidden="true" />
+        <div className="absolute -right-32 bottom-[-180px] h-[420px] w-[420px] rounded-full bg-emerald-400/30 blur-3xl" aria-hidden="true" />
+        <div className="relative z-10 grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.4em] text-blue-100/80">Plan with intention</p>
+            <h1 id="home-heading" className="text-4xl font-bold leading-snug">
               Your bilingual study coach for structured B1–C1 Spanish practice
             </h1>
-            <p className="text-lg text-slate-600" aria-live="polite">
+            <p className="max-w-xl text-base text-blue-50/90" aria-live="polite">
               Scan progress, pick a lesson, and drill the right flashcards—all in one organised workspace that
               works online or offline.
             </p>
             <div className="flex flex-wrap gap-3">
               <a
                 href="#lesson-library"
-                className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm focus-visible:ring"
+                className="inline-flex items-center gap-2 rounded-full bg-white/95 px-5 py-2 text-sm font-semibold text-blue-700 shadow-lg shadow-blue-900/20 transition hover:bg-white focus-visible:ring"
               >
                 Browse lesson library
+                <span aria-hidden="true" className="text-base">
+                  ↗
+                </span>
               </a>
               <Link
                 to="/dashboard"
-                className="inline-flex items-center rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 focus-visible:ring"
+                className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-transparent px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring"
               >
                 Check progress dashboard
+                <span aria-hidden="true" className="text-base">
+                  →
+                </span>
               </Link>
             </div>
+            <div className="flex flex-wrap gap-3 text-[11px] font-semibold uppercase tracking-[0.45em] text-blue-100/70">
+              <span className="inline-flex items-center rounded-full border border-blue-200/70 bg-blue-500/40 px-3 py-1">
+                Study smarter
+              </span>
+              <span className="inline-flex items-center rounded-full border border-blue-200/60 bg-blue-500/30 px-3 py-1">
+                Offline ready
+              </span>
+              <span className="inline-flex items-center rounded-full border border-blue-200/60 bg-blue-500/30 px-3 py-1">
+                B1 · C1
+              </span>
+            </div>
           </div>
-          <dl className="grid flex-shrink-0 gap-4 sm:grid-cols-2" aria-label="Study stats">
-            <div className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-center">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-600">Lessons imported</dt>
-              <dd className="mt-1 text-2xl font-bold text-blue-900" aria-live="polite">
+          <dl className="grid gap-4 sm:grid-cols-2" aria-label="Study stats">
+            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Lessons imported</dt>
+              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
                 {stats.totalLessons}
               </dd>
+              <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white/10 to-transparent" aria-hidden="true" />
             </div>
-            <div className="rounded-xl border border-indigo-100 bg-indigo-50 px-4 py-3 text-center">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-indigo-600">Practice items</dt>
-              <dd className="mt-1 text-2xl font-bold text-indigo-900" aria-live="polite">
+            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Practice items</dt>
+              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
                 {stats.totalExercises}
               </dd>
             </div>
-            <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3 text-center">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-emerald-600">Mastery progress</dt>
-              <dd className="mt-1 text-2xl font-bold text-emerald-900" aria-live="polite">
+            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Mastery progress</dt>
+              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
                 {roundedProgress}%
               </dd>
             </div>
-            <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-center">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-amber-600">Due flashcards</dt>
-              <dd className="mt-1 text-2xl font-bold text-amber-900" aria-live="polite">
+            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
+              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Due flashcards</dt>
+              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
                 {stats.dueCards}
               </dd>
+              <p className="mt-2 text-xs uppercase tracking-[0.3em] text-blue-100/70">Ready for a sprint</p>
             </div>
           </dl>
         </div>
       </section>
 
-      <section className="space-y-4" aria-labelledby="focus-heading">
-        <div className="space-y-2">
-          <h2 id="focus-heading" className="text-2xl font-semibold text-slate-900">
-            Today’s focus loop
-          </h2>
-          <p className="text-sm text-slate-600">
-            Cycle through these steps to keep your speaking, writing, and recall sharp.
-          </p>
+      <section
+        className="space-y-6 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-xl shadow-slate-200/60 backdrop-blur"
+        aria-labelledby="focus-heading"
+      >
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 id="focus-heading" className="text-2xl font-semibold text-slate-900">
+              Today’s focus loop
+            </h2>
+            <p className="text-sm text-slate-600">
+              Cycle through these steps to keep your speaking, writing, and recall sharp.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.35em] text-slate-400">
+            <span className="rounded-full border border-slate-200 px-3 py-1">Plan → Learn → Review</span>
+          </div>
         </div>
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-slate-900">Check your analytics</h3>
-              <p className="text-sm text-slate-600">
-                Identify the tags and lessons that need another pass before your next conversation.
-              </p>
-            </div>
-            <Link to="/dashboard" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-              Open dashboard
-            </Link>
-          </article>
-          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-slate-900">Pick a lesson objective</h3>
-              <p className="text-sm text-slate-600">
-                Use the library below to choose the next B1 or C1 target for today’s session.
-              </p>
-            </div>
-            <a href="#lesson-library" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-              Browse lessons
-            </a>
-          </article>
-          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-slate-900">Reinforce with flashcards</h3>
-              <p className="text-sm text-slate-600">
-                Rotate through due verbs, connectors, and presentation phrases in the trainer.
-              </p>
-            </div>
-            <Link to="/flashcards" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-              Start trainer
-            </Link>
-          </article>
-          <article className="flex h-full flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm">
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-slate-900">Update your content</h3>
-              <p className="text-sm text-slate-600">
-                Import the latest JSON bundle so fresh lessons, exercises, and flashcards stay in sync.
-              </p>
-            </div>
-            <Link to="/content-manager" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-              Go to Content manager
-            </Link>
-          </article>
+          {focusSteps.map(({ title, description, actionLabel, to, anchor }) => {
+            const ActionComponent = (to ? Link : 'a') as React.ElementType;
+            const actionProps = to ? { to } : { href: anchor ?? '#' };
+            return (
+              <article
+                key={title}
+                className="group relative flex h-full flex-col justify-between gap-4 overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-xl"
+              >
+                <div className="space-y-3">
+                  <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+                  <p className="text-sm text-slate-600">{description}</p>
+                </div>
+                <ActionComponent
+                  className="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 transition group-hover:text-blue-600 focus-visible:ring"
+                  {...actionProps}
+                >
+                  {actionLabel}
+                  <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+                    →
+                  </span>
+                </ActionComponent>
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 translate-y-12 rounded-t-full bg-gradient-to-t from-blue-100/30 via-transparent" aria-hidden="true" />
+              </article>
+            );
+          })}
         </div>
       </section>
 
-      <section id="lesson-library" className="space-y-5" aria-labelledby="library-heading">
-        <div className="space-y-2">
-          <h2 id="library-heading" className="text-2xl font-semibold text-slate-900">
-            Lesson library
-          </h2>
-          <p className="text-sm text-slate-600">
-            Organised by CEFR level so you can match today’s focus with the right material.
-          </p>
+      <section
+        id="lesson-library"
+        className="space-y-6 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-xl shadow-slate-200/50 backdrop-blur"
+        aria-labelledby="library-heading"
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 id="library-heading" className="text-2xl font-semibold text-slate-900">
+              Lesson library
+            </h2>
+            <p className="text-sm text-slate-600">
+              Organised by CEFR level so you can match today’s focus with the right material.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {(['all', 'B1', 'C1'] as const).map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => setLibraryFilter(filter)}
+                className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-semibold transition focus-visible:ring ${
+                  libraryFilter === filter
+                    ? 'border-blue-500 bg-blue-600 text-white shadow'
+                    : 'border-slate-200 bg-white text-slate-600 hover:border-blue-200 hover:text-blue-700'
+                }`}
+              >
+                {filter === 'all' ? 'All levels' : `Level ${filter}`}
+              </button>
+            ))}
+          </div>
         </div>
         {lessons.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-slate-300 bg-slate-100 p-4 text-sm text-slate-600" aria-live="polite">
+          <p
+            className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-5 text-sm text-slate-600"
+            aria-live="polite"
+          >
             No lessons imported yet. Use the Content manager to add the latest content drop.
           </p>
         ) : (
-          <div className="grid gap-6 md:grid-cols-2">
-            {levelGroups.map(({ level, title, description, lessons: groupLessons }) => (
-              <article key={level} className="space-y-3 rounded-xl border bg-white p-4 shadow-sm">
-                <header className="space-y-1">
+          filteredGroups.map(({ level, title, description, lessons: groupLessons }) => (
+            <article key={level} className="space-y-4 rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm">
+              <header className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-1">
                   <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-                  <p className="text-sm text-slate-600">
-                    {description}{' '}
-                    <span className="font-medium text-slate-700">
-                      {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
-                    </span>
-                  </p>
-                </header>
-                {groupLessons.length > 0 ? (
-                  <ul className="space-y-2" role="list">
-                    {groupLessons.map((lesson) => (
-                      <li
+                  <p className="text-sm text-slate-600">{description}</p>
+                </div>
+                <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                  {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
+                </span>
+              </header>
+              {groupLessons.length > 0 ? (
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  {groupLessons.map((lesson) => {
+                    const count = exerciseCounts[lesson.id] ?? 0;
+                    return (
+                      <Link
                         key={lesson.id}
-                        className="rounded-lg border border-slate-200 px-3 py-2 transition hover:border-blue-300"
+                        to={`/lessons/${lesson.slug}`}
+                        className="group relative flex h-full flex-col justify-between gap-4 overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-4 text-left shadow-sm transition hover:-translate-y-1 hover:border-blue-400 hover:shadow-xl focus-visible:ring"
                       >
-                        <Link
-                          to={`/lessons/${lesson.slug}`}
-                          className="text-sm font-medium text-blue-700 underline focus-visible:ring"
-                        >
-                          {lesson.title}
-                        </Link>
-                        <p className="mt-1 text-xs text-slate-500" aria-label={`Tags for ${lesson.title}`}>
-                          {lesson.tags.join(' · ')}
-                        </p>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-slate-600">No lessons imported for this level yet.</p>
-                )}
-              </article>
-            ))}
-          </div>
+                        <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+                          <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">Level {lesson.level}</span>
+                          <span className="rounded-full bg-blue-50 px-2 py-1 text-blue-600">
+                            {count} practice {count === 1 ? 'item' : 'items'}
+                          </span>
+                        </div>
+                        <div className="space-y-2">
+                          <h4 className="text-base font-semibold text-slate-900">{lesson.title}</h4>
+                          <div className="flex flex-wrap gap-2" aria-label={`Tags for ${lesson.title}`}>
+                            {lesson.tags.slice(0, 3).map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                            {lesson.tags.length === 0 && (
+                              <span className="text-xs text-slate-400">No tags yet</span>
+                            )}
+                            {lesson.tags.length > 3 && (
+                              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">
+                                +{lesson.tags.length - 3}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <span className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 transition group-hover:translate-x-1">
+                          Open lesson
+                          <span aria-hidden="true">→</span>
+                        </span>
+                        <div
+                          className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 translate-y-12 bg-gradient-to-t from-blue-100/30 via-transparent transition group-hover:translate-y-6"
+                          aria-hidden="true"
+                        />
+                      </Link>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-600">No lessons imported for this level yet.</p>
+              )}
+            </article>
+          ))
         )}
       </section>
 
-      <section className="space-y-3" aria-labelledby="tag-heading">
-        <h2 id="tag-heading" className="text-xl font-semibold text-slate-900">
-          Topics on your radar
-        </h2>
+      <section
+        className="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-xl shadow-slate-200/50 backdrop-blur"
+        aria-labelledby="tag-heading"
+      >
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <h2 id="tag-heading" className="text-xl font-semibold text-slate-900">
+            Topics on your radar
+          </h2>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Mix your sessions</p>
+        </div>
         {topTags.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
+          <div className="mt-4 flex flex-wrap gap-3">
             {topTags.map(([tag, count]) => (
               <span
                 key={tag}
-                className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-800"
+                className="inline-flex items-center gap-2 rounded-full border border-blue-200/80 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 shadow-sm"
                 title={`${count} lesson${count === 1 ? '' : 's'}`}
               >
                 <span>{tag}</span>
-                <span className="ml-2 text-xs font-normal text-blue-600" aria-hidden="true">
-                  ×{count}
-                </span>
+                <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-600">×{count}</span>
               </span>
             ))}
           </div>
         ) : (
-          <p className="text-sm text-slate-600">
+          <p className="mt-4 text-sm text-slate-600">
             Tags will appear once you import lessons.{' '}
             <Link to="/content-manager" className="text-blue-700 underline focus-visible:ring">
               Add a content bundle to get started.

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -50,49 +50,79 @@ const LessonPage: React.FC = () => {
   }
 
   return (
-    <article className="space-y-8" aria-labelledby="lesson-title">
-      <div className="space-y-4 rounded-xl border bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <Link to="/" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-            ← Back to overview
-          </Link>
-          <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-blue-700">
-            Level {lesson.level}
-          </span>
-        </div>
-        <div className="space-y-3">
-          <h1 id="lesson-title" className="text-3xl font-bold text-slate-900">
-            {lesson.title}
-          </h1>
-          <div className="flex flex-wrap gap-2" aria-label="Lesson tags">
-            {lesson.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700"
-              >
-                {tag}
-              </span>
-            ))}
+    <article className="space-y-10" aria-labelledby="lesson-title">
+      <header
+        className="relative overflow-hidden rounded-3xl border border-blue-100/80 bg-gradient-to-br from-blue-600 via-indigo-600 to-blue-700 p-8 text-white shadow-2xl"
+      >
+        <div className="absolute inset-y-0 right-[-160px] h-[420px] w-[420px] rounded-full bg-blue-400/40 blur-3xl" aria-hidden="true" />
+        <div className="relative z-10 space-y-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-100 transition hover:text-white focus-visible:ring"
+            >
+              ← Back to overview
+            </Link>
+            <span className="inline-flex items-center rounded-full border border-white/40 bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white">
+              Level {lesson.level}
+            </span>
           </div>
-          <p className="text-sm text-slate-600">
-            {exercises.length > 0
-              ? `${exercises.length} practice activit${exercises.length === 1 ? 'y' : 'ies'} ready to log.`
-              : 'Review the notes, then import a practice set to track mastery.'}
-          </p>
+          <div className="space-y-4">
+            <h1 id="lesson-title" className="text-4xl font-bold leading-tight">
+              {lesson.title}
+            </h1>
+            <div className="flex flex-wrap gap-2" aria-label="Lesson tags">
+              {lesson.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-full border border-white/30 bg-white/20 px-3 py-1 text-xs font-semibold text-white"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <p className="text-sm text-blue-100/90">
+              {exercises.length > 0
+                ? `${exercises.length} practice activit${exercises.length === 1 ? 'y' : 'ies'} ready to log.`
+                : 'Review the notes, then import a practice set to track mastery.'}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="#lesson-exercises-heading"
+              className="inline-flex items-center gap-2 rounded-full bg-white/95 px-4 py-2 text-sm font-semibold text-blue-700 shadow-lg shadow-blue-900/30 transition hover:bg-white focus-visible:ring"
+            >
+              Jump to practise
+              <span aria-hidden="true">↓</span>
+            </a>
+            <Link
+              to="/flashcards"
+              className="inline-flex items-center gap-2 rounded-full border border-white/60 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring"
+            >
+              Start flashcard sprint
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
         </div>
-      </div>
+      </header>
 
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-        <div className="space-y-8">
-          <section className="space-y-4 rounded-xl border bg-white p-6 shadow-sm" aria-labelledby="lesson-content-heading">
+      <div className="grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="space-y-10">
+          <section
+            className="space-y-4 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-sm"
+            aria-labelledby="lesson-content-heading"
+          >
             <h2 id="lesson-content-heading" className="text-xl font-semibold text-slate-900">
               Lesson content
             </h2>
             <LessonViewer markdown={lesson.markdown} />
           </section>
 
-          <section className="space-y-4 rounded-xl border bg-white p-6 shadow-sm" aria-labelledby="lesson-exercises-heading">
-            <div className="space-y-1">
+          <section
+            className="space-y-5 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-sm"
+            aria-labelledby="lesson-exercises-heading"
+          >
+            <div className="space-y-2">
               <h2 id="lesson-exercises-heading" className="text-xl font-semibold text-slate-900">
                 Practise the lesson
               </h2>
@@ -101,11 +131,7 @@ const LessonPage: React.FC = () => {
               </p>
             </div>
             {exercises.map((exercise) => (
-              <div
-                key={exercise.id}
-                className="rounded-lg border border-slate-200 p-4 shadow-sm"
-                aria-label={`Exercise ${exercise.id}`}
-              >
+              <div key={exercise.id} aria-label={`Exercise ${exercise.id}`}>
                 <ExerciseEngine exercise={exercise} />
               </div>
             ))}
@@ -117,26 +143,28 @@ const LessonPage: React.FC = () => {
           </section>
         </div>
 
-        <aside className="space-y-4 rounded-xl border bg-white p-6 shadow-sm" aria-label="Study guidance">
-          <section className="space-y-2">
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Study roadmap</h2>
+        <aside className="space-y-4 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-sm" aria-label="Study guidance">
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-slate-500">Study roadmap</h2>
             <ol className="space-y-2 text-sm text-slate-600">
               <li>Skim the key idea and underline new connectors or discourse markers.</li>
               <li>Complete the practice set, logging hints and timings for the dashboard.</li>
-              <li>
-                Finish with a flashcard sprint to reinforce the phrases you want to reuse.
-              </li>
+              <li>Finish with a flashcard sprint to reinforce the phrases you want to reuse.</li>
             </ol>
           </section>
           <section className="space-y-2 text-sm text-slate-600">
             <p>Need a quick spaced-repetition loop after this lesson?</p>
-            <Link to="/flashcards" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+            <Link
+              to="/flashcards"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 transition hover:text-blue-600 focus-visible:ring"
+            >
               Jump to the flashcard trainer
+              <span aria-hidden="true">↗</span>
             </Link>
           </section>
           {lesson.references?.length ? (
             <section className="space-y-2">
-              <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">References</h2>
+              <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-slate-500">References</h2>
               <ul className="space-y-1 text-sm text-slate-600">
                 {lesson.references.map((reference, index) => (
                   <li key={`${reference}-${index}`}>{reference}</li>


### PR DESCRIPTION
## Summary
- redesign the application shell with a gradient navigation header, focus-mode toggle, and quick-start actions
- refresh the home, lesson, and flashcard experiences with modern card layouts, filters, and progress cues
- restyle shared training components (exercise engine and conjugation table) with polished controls and accessible feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea5bf1dbc8324828fcec10beb6086