### PR TITLE
Redesign study workspace with modern social-inspired UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ const App: React.FC = () => {
           <Route
             path="*"
             element={
-              <p role="alert" className="text-red-600">
+              <p role="alert" className="ui-alert ui-alert--danger">
                 Page not found. Use the navigation links above to continue learning.
               </p>
             }

--- a/src/components/ConjugationTable.module.css
+++ b/src/components/ConjugationTable.module.css
@@ -1,0 +1,51 @@
+.tableWrapper {
+  width: 100%;
+  border-radius: var(--ui-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  box-shadow: var(--ui-shadow);
+}
+
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.table thead {
+  background: rgba(148, 163, 184, 0.15);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--ui-text-muted);
+}
+
+.table th,
+.table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--ui-border-muted);
+}
+
+.table tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.input {
+  width: 100%;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  color: var(--ui-text-primary);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus-visible {
+  outline: none;
+  border-color: var(--ui-accent);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
+}

--- a/src/components/ConjugationTable.tsx
+++ b/src/components/ConjugationTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styles from './ConjugationTable.module.css';
 
 interface ConjugationTableProps {
   expected: string[];
@@ -14,31 +15,30 @@ export const ConjugationTable: React.FC<ConjugationTableProps> = ({ expected, va
   };
 
   return (
-    <table
-      className="min-w-full overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 text-sm shadow-inner"
-      aria-label="Conjugation practice table"
-    >
-      <thead className="bg-slate-100 text-left text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
-        <tr>
-          <th className="px-3 py-2">Form</th>
-          <th className="px-3 py-2">Your answer</th>
-        </tr>
-      </thead>
-      <tbody>
-        {expected.map((_, index) => (
-          <tr key={index} className="odd:bg-white even:bg-slate-50">
-            <td className="px-3 py-2 font-semibold text-slate-600">{index + 1}</td>
-            <td className="px-3 py-2">
-              <input
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                value={values[index] ?? ''}
-                aria-label={`Answer for conjugation cell ${index + 1}`}
-                onChange={(event) => handleChange(index, event.target.value)}
-              />
-            </td>
+    <div className={styles.tableWrapper}>
+      <table className={styles.table} aria-label="Conjugation practice table">
+        <thead>
+          <tr>
+            <th>Form</th>
+            <th>Your answer</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {expected.map((_, index) => (
+            <tr key={index}>
+              <td>{index + 1}</td>
+              <td>
+                <input
+                  className={styles.input}
+                  value={values[index] ?? ''}
+                  aria-label={`Answer for conjugation cell ${index + 1}`}
+                  onChange={(event) => handleChange(index, event.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 };

--- a/src/components/Dashboard.module.css
+++ b/src/components/Dashboard.module.css
@@ -1,0 +1,64 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.progressHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.progressLabel {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.progressBadge {
+  border-radius: var(--ui-radius-pill);
+  padding: 6px 16px;
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-weight: 700;
+}
+
+.progressTrack {
+  position: relative;
+  height: 12px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.progressValue {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-highlight-secondary);
+  transition: width 0.3s ease;
+}
+
+.tableWrapper {
+  border-radius: var(--ui-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--ui-border);
+}
+
+.studyList {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.studyList li {
+  font-size: 0.95rem;
+  color: var(--ui-text-secondary);
+}
+
+.studyList strong {
+  color: var(--ui-text-primary);
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { db } from '../db';
 import { computeAnalytics, AnalyticsSnapshot } from '../lib/analytics';
+import styles from './Dashboard.module.css';
 
 const formatDuration = (ms: number) => {
   if (!ms) return '0m';
@@ -38,7 +39,7 @@ export const Dashboard: React.FC = () => {
 
   if (loading) {
     return (
-      <p role="status" className="rounded-xl border bg-white p-4 text-sm text-slate-600">
+      <p role="status" className="ui-alert ui-alert--info">
         Loading analytics…
       </p>
     );
@@ -46,51 +47,45 @@ export const Dashboard: React.FC = () => {
 
   if (!snapshot) {
     return (
-      <p role="status" className="rounded-xl border bg-white p-4 text-sm text-slate-600">
+      <p role="status" className="ui-alert ui-alert--info">
         No data yet. Complete a few exercises to populate the dashboard.
       </p>
     );
   }
 
   return (
-    <div className="space-y-6" aria-live="polite">
-      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Mastery progress">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-xl font-semibold text-slate-900">Mastery progress</h2>
-          <span className="text-sm font-semibold text-emerald-700">{progress.toFixed(1)}% mastered</span>
+    <div className={styles.dashboard} aria-live="polite">
+      <section className="ui-card ui-card--muted" aria-label="Mastery progress">
+        <div className={styles.progressHeader}>
+          <h2 className={styles.progressLabel}>Mastery progress</h2>
+          <span className={styles.progressBadge}>{progress.toFixed(1)}% mastered</span>
         </div>
-        <div
-          className="h-4 rounded-full bg-slate-200"
-          role="progressbar"
-          aria-valuenow={progress}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          <div className="h-4 rounded-full bg-emerald-500" style={{ width: `${progress}%` }} />
+        <div className={styles.progressTrack} role="progressbar" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
+          <div className={styles.progressValue} style={{ width: `${Math.min(progress, 100)}%` }} />
         </div>
-        <p className="text-sm text-slate-600">
+        <p className="ui-section__subtitle">
           Average attempts to mastery: {snapshot.averageAttemptsToMastery.toFixed(2)}
         </p>
       </section>
 
-      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Time on task by lesson">
-        <h3 className="text-lg font-semibold text-slate-900">Time on task (per lesson)</h3>
+      <section className="ui-card" aria-label="Time on task by lesson">
+        <h3 className="ui-section__title">Time on task (per lesson)</h3>
         {snapshot.lessonTimes.length === 0 ? (
-          <p className="text-sm text-slate-600">No lesson time logged yet.</p>
+          <p className="ui-alert ui-alert--info">No lesson time logged yet.</p>
         ) : (
-          <div className="overflow-hidden rounded-lg border border-slate-200">
-            <table className="min-w-full text-sm" aria-label="Lesson time summary">
-              <thead className="bg-slate-50 text-left text-slate-600">
+          <div className={styles.tableWrapper}>
+            <table className="ui-table" aria-label="Lesson time summary">
+              <thead>
                 <tr>
-                  <th className="px-3 py-2 font-semibold">Lesson</th>
-                  <th className="px-3 py-2 font-semibold">Time</th>
+                  <th>Lesson</th>
+                  <th>Time</th>
                 </tr>
               </thead>
               <tbody>
                 {snapshot.lessonTimes.map((lesson) => (
-                  <tr key={lesson.lessonId} className="odd:bg-white even:bg-slate-50">
-                    <td className="px-3 py-2 text-slate-700">{lesson.lessonTitle}</td>
-                    <td className="px-3 py-2 text-slate-700">{formatDuration(lesson.totalMs)}</td>
+                  <tr key={lesson.lessonId}>
+                    <td>{lesson.lessonTitle}</td>
+                    <td>{formatDuration(lesson.totalMs)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -99,26 +94,26 @@ export const Dashboard: React.FC = () => {
         )}
       </section>
 
-      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Weakest tags">
-        <h3 className="text-lg font-semibold text-slate-900">Weakest tags</h3>
+      <section className="ui-card" aria-label="Weakest tags">
+        <h3 className="ui-section__title">Weakest tags</h3>
         {snapshot.weakestTags.length === 0 ? (
-          <p className="text-sm text-slate-600">No accuracy data by tag yet.</p>
+          <p className="ui-alert ui-alert--info">No accuracy data by tag yet.</p>
         ) : (
-          <div className="overflow-hidden rounded-lg border border-slate-200">
-            <table className="min-w-full text-sm" aria-label="Tags with lowest accuracy">
-              <thead className="bg-slate-50 text-left text-slate-600">
+          <div className={styles.tableWrapper}>
+            <table className="ui-table" aria-label="Tags with lowest accuracy">
+              <thead>
                 <tr>
-                  <th className="px-3 py-2 font-semibold">Tag</th>
-                  <th className="px-3 py-2 font-semibold">Accuracy</th>
-                  <th className="px-3 py-2 font-semibold">Attempts</th>
+                  <th>Tag</th>
+                  <th>Accuracy</th>
+                  <th>Attempts</th>
                 </tr>
               </thead>
               <tbody>
                 {snapshot.weakestTags.map((tag) => (
-                  <tr key={tag.tag} className="odd:bg-white even:bg-slate-50">
-                    <td className="px-3 py-2 text-slate-700">{tag.tag}</td>
-                    <td className="px-3 py-2 text-slate-700">{tag.accuracy.toFixed(1)}%</td>
-                    <td className="px-3 py-2 text-slate-700">{tag.total}</td>
+                  <tr key={tag.tag}>
+                    <td>{tag.tag}</td>
+                    <td>{tag.accuracy.toFixed(1)}%</td>
+                    <td>{tag.total}</td>
                   </tr>
                 ))}
               </tbody>
@@ -127,15 +122,17 @@ export const Dashboard: React.FC = () => {
         )}
       </section>
 
-      <section className="space-y-3 rounded-xl border bg-white p-5 shadow-sm" aria-label="Recommended exercises">
-        <h3 className="text-lg font-semibold text-slate-900">Study plan (next five exercises)</h3>
+      <section className="ui-card" aria-label="Recommended exercises">
+        <h3 className="ui-section__title">Study plan (next five exercises)</h3>
         {snapshot.studyPlan.length === 0 ? (
-          <p className="text-sm text-slate-600">All caught up! Import new lessons or revisit completed content.</p>
+          <p className="ui-alert ui-alert--info">
+            All caught up! Import new lessons or revisit completed content.
+          </p>
         ) : (
-          <ol className="ml-5 list-decimal space-y-1 text-sm text-slate-700">
+          <ol className={styles.studyList}>
             {snapshot.studyPlan.map((item) => (
               <li key={item.exerciseId}>
-                <span className="font-semibold text-slate-900">{item.lessonTitle}</span> – {item.reason}
+                <strong>{item.lessonTitle}</strong> – {item.reason}
               </li>
             ))}
           </ol>

--- a/src/components/ExerciseEngine.module.css
+++ b/src/components/ExerciseEngine.module.css
@@ -1,0 +1,135 @@
+.exercise {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-bottom: 24px;
+}
+
+.prompt {
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  padding: 20px;
+  box-shadow: var(--ui-shadow);
+}
+
+.answerSurface {
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-muted);
+  padding: 20px;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.options {
+  display: grid;
+  gap: 12px;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.option:hover,
+.option:focus-within {
+  transform: translateY(-2px);
+  border-color: var(--ui-accent);
+  box-shadow: var(--ui-shadow);
+}
+
+.optionSelected {
+  border-color: var(--ui-accent);
+  background: rgba(34, 197, 94, 0.12);
+  box-shadow: 0 18px 45px -32px rgba(34, 197, 94, 0.4);
+}
+
+.optionIndicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  color: var(--ui-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.optionSelected .optionIndicator {
+  border-color: var(--ui-accent);
+  background: var(--ui-accent);
+  color: var(--ui-text-inverse);
+}
+
+.textInput {
+  width: 100%;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  padding: 12px 16px;
+  font-size: 1rem;
+  color: var(--ui-text-primary);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.textInput:focus-visible {
+  outline: none;
+  border-color: var(--ui-accent);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
+}
+
+.buttonRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.submitButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: var(--ui-radius-pill);
+  border: none;
+  padding: 12px 20px;
+  background: var(--ui-highlight);
+  color: var(--ui-text-inverse);
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 18px 45px -30px rgba(79, 70, 229, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submitButton:hover,
+.submitButton:focus-visible {
+  transform: translateY(-2px);
+}
+
+.feedback {
+  border-radius: var(--ui-radius-lg);
+  padding: 12px 16px;
+  font-weight: 600;
+}
+
+.feedbackSuccess {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  color: #15803d;
+}
+
+.feedbackError {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: #b91c1c;
+}

--- a/src/components/ExerciseEngine.tsx
+++ b/src/components/ExerciseEngine.tsx
@@ -4,6 +4,7 @@ import { Exercise } from '../lib/schemas';
 import { gradeAnswer } from '../lib/grader';
 import { db } from '../db';
 import { ConjugationTable } from './ConjugationTable';
+import styles from './ExerciseEngine.module.css';
 
 interface ExerciseEngineProps {
   exercise: Exercise;
@@ -93,21 +94,15 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
     if (exercise.type === 'mcq' || exercise.type === 'multi') {
       const isMulti = exercise.type === 'multi';
       return (
-        <fieldset className="space-y-4" aria-label="Answer choices">
-          <legend className="text-sm font-semibold text-slate-700">
-            Choose {isMulti ? 'all that apply' : 'one option'}
-          </legend>
-          <div className="grid gap-2">
+        <fieldset className={styles.answerSurface} aria-label="Answer choices">
+          <legend className="ui-section__tag">{isMulti ? 'Choose all that apply' : 'Choose one option'}</legend>
+          <div className={styles.options}>
             {(exercise.options ?? []).map((option) => {
               const checked = selectedOptions.includes(option);
               return (
                 <label
                   key={option}
-                  className={`group relative flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-sm font-medium transition ${
-                    checked
-                      ? 'border-blue-500 bg-blue-50 text-blue-900 shadow-sm'
-                      : 'border-slate-200/80 bg-white/90 text-slate-700 hover:border-blue-300 hover:bg-blue-50/40'
-                  }`}
+                  className={`${styles.option} ${checked ? styles.optionSelected : ''}`}
                 >
                   <input
                     type={isMulti ? 'checkbox' : 'radio'}
@@ -118,14 +113,7 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
                     className="sr-only"
                   />
                   <span>{option}</span>
-                  <span
-                    aria-hidden="true"
-                    className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs transition ${
-                      checked
-                        ? 'border-blue-500 bg-blue-500 text-white'
-                        : 'border-slate-300 text-slate-400'
-                    }`}
-                  >
+                  <span className={styles.optionIndicator} aria-hidden="true">
                     {checked ? '✓' : ''}
                   </span>
                 </label>
@@ -138,56 +126,49 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise }) => {
 
     if (exercise.type === 'conjugate') {
       return (
-        <ConjugationTable expected={expectedArray} values={tableValues} onChange={setTableValues} />
+        <div className={styles.answerSurface}>
+          <ConjugationTable expected={expectedArray} values={tableValues} onChange={setTableValues} />
+        </div>
       );
     }
 
     return (
-      <input
-        className="w-full rounded-xl border border-slate-300 bg-white/90 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
-        value={inputValue}
-        aria-label="Your answer"
-        onChange={(event) => setInputValue(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' && !event.shiftKey) {
-            event.preventDefault();
-            submit();
-          }
-        }}
-      />
+      <div className={styles.answerSurface}>
+        <input
+          className={styles.textInput}
+          value={inputValue}
+          aria-label="Your answer"
+          onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault();
+              submit();
+            }
+          }}
+        />
+      </div>
     );
   };
 
   return (
-    <div className="space-y-5" aria-live="polite">
-      <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm">
-        <div className="prose prose-slate max-w-none">
+    <div className={styles.exercise} aria-live="polite">
+      <div className={styles.prompt}>
+        <div className="prose">
           <ReactMarkdown>{exercise.promptMd}</ReactMarkdown>
         </div>
       </div>
-      <div className="rounded-2xl border border-slate-200/70 bg-white/90 p-5 shadow-inner">
-        {renderInput()}
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <button
-          type="button"
-          onClick={submit}
-          className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-blue-500/30 transition hover:bg-blue-700 focus-visible:ring"
-        >
-          Submit answer
-          <span aria-hidden="true">→</span>
+      {renderInput()}
+      <div className={styles.buttonRow}>
+        <button type="button" onClick={submit} className={styles.submitButton}>
+          Submit answer →
         </button>
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Press Enter to submit</p>
+        <p className="ui-section__tag">Press Enter to submit</p>
       </div>
       {feedback && (
         <div
           role="status"
           aria-live="assertive"
-          className={`rounded-2xl border px-4 py-3 text-sm font-medium ${
-            feedback.includes('Correct')
-              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-              : 'border-rose-200 bg-rose-50 text-rose-700'
-          }`}
+          className={`${styles.feedback} ${feedback.includes('Correct') ? styles.feedbackSuccess : styles.feedbackError}`}
         >
           {feedback}
         </div>

--- a/src/components/FlashcardTrainer.module.css
+++ b/src/components/FlashcardTrainer.module.css
@@ -1,0 +1,230 @@
+.trainer {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--ui-radius-xl);
+  padding: 32px;
+  background: var(--ui-surface-strong);
+  border: 1px solid var(--ui-border);
+  box-shadow: var(--ui-shadow-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.headerMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.headerTag {
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ui-text-muted);
+}
+
+.headerStatus {
+  border-radius: var(--ui-radius-pill);
+  padding: 6px 14px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.cardSurface {
+  border-radius: var(--ui-radius-xl);
+  padding: 28px;
+  border: 1px solid var(--ui-border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(224, 242, 254, 0.9));
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.promptLabel {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #2563eb;
+  font-weight: 700;
+}
+
+.promptText {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--ui-text-primary);
+  margin: 0;
+}
+
+.answerSurface {
+  border-radius: var(--ui-radius-lg);
+  padding: 20px;
+  background: rgba(240, 253, 244, 0.95);
+  border: 1px solid rgba(52, 211, 153, 0.45);
+  color: #047857;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.revealButton {
+  background: var(--ui-highlight);
+  color: var(--ui-text-inverse);
+  border: none;
+  border-radius: var(--ui-radius-pill);
+  padding: 14px 22px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 18px 45px -28px rgba(79, 70, 229, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.revealButton:hover,
+.revealButton:focus-visible {
+  transform: translateY(-2px);
+}
+
+.gradeButton {
+  flex: 1;
+  border-radius: var(--ui-radius-pill);
+  padding: 12px 18px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gradeSuccess {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: var(--ui-text-inverse);
+  box-shadow: 0 16px 40px -26px rgba(34, 197, 94, 0.6);
+}
+
+.gradeRetry {
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  color: #fff5f5;
+  box-shadow: 0 16px 40px -26px rgba(239, 68, 68, 0.45);
+}
+
+.gradeButton:hover,
+.gradeButton:focus-visible {
+  transform: translateY(-2px);
+}
+
+.progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progressBar {
+  position: relative;
+  height: 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.progressFill {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-highlight-secondary);
+  transition: width 0.25s ease;
+}
+
+.keyboardHint {
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ui-text-muted);
+}
+
+.emptyState {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--ui-radius-xl);
+  padding: 32px;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.95), rgba(45, 212, 191, 0.9));
+  color: #ecfdf5;
+  border: 1px solid rgba(16, 185, 129, 0.45);
+  box-shadow: 0 30px 70px -40px rgba(16, 185, 129, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.emptyHeader {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.emptyIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 1.8rem;
+}
+
+.emptyActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.emptyActions a {
+  border-radius: var(--ui-radius-pill);
+  padding: 10px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  color: #ecfdf5;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.emptyActions a:hover,
+.emptyActions a:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+@media (max-width: 720px) {
+  .trainer,
+  .emptyState {
+    padding: 24px;
+  }
+
+  .cardSurface {
+    padding: 20px;
+  }
+}

--- a/src/components/FlashcardTrainer.tsx
+++ b/src/components/FlashcardTrainer.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { db } from '../db';
 import { isDue, updateSRS } from '../lib/srs';
 import { Flashcard } from '../lib/schemas';
+import styles from './FlashcardTrainer.module.css';
 
 export const FlashcardTrainer: React.FC = () => {
   const [cards, setCards] = useState<Flashcard[]>([]);
@@ -60,37 +61,21 @@ export const FlashcardTrainer: React.FC = () => {
 
   if (!current) {
     return (
-      <section
-        role="status"
-        className="relative overflow-hidden rounded-3xl border border-emerald-200/70 bg-gradient-to-br from-emerald-100 via-white to-emerald-50 p-8 text-emerald-900 shadow-lg"
-      >
-        <div className="absolute inset-y-0 right-[-140px] h-[320px] w-[320px] rounded-full bg-emerald-300/40 blur-3xl" aria-hidden="true" />
-        <div className="relative z-10 space-y-4">
-          <div className="flex items-center gap-3">
-            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/80 text-2xl">🎉</span>
-            <div>
-              <h2 className="text-2xl font-semibold">You’re all caught up</h2>
-              <p className="text-sm text-emerald-700">
-                Import new cards or revisit mastered decks for a bonus review sprint.
-              </p>
-            </div>
+      <section role="status" className={styles.emptyState}>
+        <div className={styles.emptyHeader}>
+          <span className={styles.emptyIcon} aria-hidden="true">
+            🎉
+          </span>
+          <div>
+            <h2 className="ui-section__title">You’re all caught up</h2>
+            <p className="ui-section__subtitle">
+              Import new cards or revisit mastered decks for a bonus review sprint.
+            </p>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <Link
-              to="/content-manager"
-              className="inline-flex items-center gap-2 rounded-full border border-emerald-300 bg-white px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-400 focus-visible:ring"
-            >
-              Import fresh flashcards
-              <span aria-hidden="true">↗</span>
-            </Link>
-            <Link
-              to="/dashboard"
-              className="inline-flex items-center gap-2 rounded-full border border-emerald-200 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:border-emerald-400 focus-visible:ring"
-            >
-              Review progress
-              <span aria-hidden="true">→</span>
-            </Link>
-          </div>
+        </div>
+        <div className={styles.emptyActions}>
+          <Link to="/content-manager">Import fresh flashcards ↗</Link>
+          <Link to="/dashboard">Review progress →</Link>
         </div>
       </section>
     );
@@ -101,90 +86,71 @@ export const FlashcardTrainer: React.FC = () => {
   const progress = totalCards > 0 ? Math.round((completed / totalCards) * 100) : 0;
 
   return (
-    <section
-      className="relative overflow-hidden rounded-3xl border border-blue-100/80 bg-white/90 p-8 shadow-xl shadow-blue-100/50 backdrop-blur"
-      aria-live="polite"
-    >
-      <div className="absolute inset-y-0 -right-24 h-[420px] w-[420px] rounded-full bg-blue-200/40 blur-3xl" aria-hidden="true" />
-      <div className="relative z-10 space-y-6">
-        <header className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Session progress</p>
-            <p className="text-sm text-slate-600" aria-live="polite">
-              {completed} of {totalCards} cards complete
-            </p>
-          </div>
-          <span className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-blue-600">
-            {remaining} left
+    <section className={styles.trainer} aria-live="polite">
+      <header className={styles.header}>
+        <div className={styles.headerMeta}>
+          <span className={styles.headerTag}>Session progress</span>
+          <span className="ui-section__subtitle">
+            {completed} of {totalCards} cards complete
           </span>
-        </header>
+        </div>
+        <span className={styles.headerStatus}>{remaining} left</span>
+      </header>
 
-        <div className="space-y-5">
-          <div className="rounded-3xl border border-blue-200/70 bg-gradient-to-br from-white via-blue-50 to-white p-6 shadow-inner">
-            <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Prompt</span>
-            <p className="mt-4 text-2xl font-bold leading-snug text-slate-900" aria-label="Flashcard front">
-              {current.front}
-            </p>
-            {showBack && (
-              <div className="mt-6 rounded-2xl border border-emerald-200/70 bg-white/90 p-4 shadow-sm">
-                <span className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-500">Answer</span>
-                <p className="mt-2 text-lg font-semibold leading-relaxed text-emerald-700" aria-label="Flashcard back">
-                  {current.back}
-                </p>
-              </div>
-            )}
+      <div className={styles.cardSurface}>
+        <span className={styles.promptLabel}>Prompt</span>
+        <p className={styles.promptText} aria-label="Flashcard front">
+          {current.front}
+        </p>
+        {showBack && (
+          <div className={styles.answerSurface} aria-label="Flashcard back">
+            {current.back}
           </div>
+        )}
+      </div>
 
-          {!showBack ? (
+      <div className={styles.controls}>
+        {!showBack ? (
+          <button
+            type="button"
+            onClick={() => setShowBack(true)}
+            className={styles.revealButton}
+            aria-label="Reveal answer (spacebar)"
+          >
+            Reveal answer →
+          </button>
+        ) : (
+          <div className={styles.buttonRow}>
             <button
               type="button"
-              onClick={() => setShowBack(true)}
-              className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-500/30 transition hover:bg-blue-700 focus-visible:ring"
-              aria-label="Reveal answer (spacebar)"
+              onClick={() => grade(true)}
+              className={`${styles.gradeButton} ${styles.gradeSuccess}`}
+              aria-label="I remembered it (arrow right or K)"
             >
-              Reveal answer
-              <span aria-hidden="true" className="text-base">
-                →
-              </span>
+              I knew it
             </button>
-          ) : (
-            <div className="flex flex-col gap-3 sm:flex-row">
-              <button
-                type="button"
-                onClick={() => grade(true)}
-                className="flex-1 rounded-full border border-emerald-300 bg-emerald-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600 focus-visible:ring"
-                aria-label="I remembered it (arrow right or K)"
-              >
-                I knew it
-              </button>
-              <button
-                type="button"
-                onClick={() => grade(false)}
-                className="flex-1 rounded-full border border-rose-200 bg-rose-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-600 focus-visible:ring"
-                aria-label="I forgot (arrow left or J)"
-              >
-                I forgot
-              </button>
-            </div>
-          )}
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
-              <span>Progress</span>
-              <span>{progress}%</span>
-            </div>
-            <div className="h-2 rounded-full bg-slate-200">
-              <div
-                className="h-2 rounded-full bg-blue-500 transition-all"
-                style={{ width: `${totalCards > 0 ? (completed / totalCards) * 100 : 0}%` }}
-              />
-            </div>
+            <button
+              type="button"
+              onClick={() => grade(false)}
+              className={`${styles.gradeButton} ${styles.gradeRetry}`}
+              aria-label="I forgot (arrow left or J)"
+            >
+              I forgot
+            </button>
           </div>
+        )}
 
-          <p className="text-xs text-slate-500">
-            Space — reveal · J / ← — Forgot · K / → — Knew it
-          </p>
+        <div className={styles.progress}>
+          <div className="ui-section__subtitle">Progress {progress}%</div>
+          <div className={styles.progressBar}>
+            <div
+              className={styles.progressFill}
+              style={{ width: `${totalCards > 0 ? (completed / totalCards) * 100 : 0}%` }}
+            />
+          </div>
         </div>
+
+        <p className={styles.keyboardHint}>Space — reveal · J / ← — Forgot · K / → — Knew it</p>
       </div>
     </section>
   );

--- a/src/components/LessonViewer.tsx
+++ b/src/components/LessonViewer.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 
 export const LessonViewer: React.FC<{ markdown: string }> = ({ markdown }) => {
   return (
-    <div className="prose max-w-none">
+    <div className="prose">
       <ReactMarkdown>{markdown}</ReactMarkdown>
     </div>
   );

--- a/src/components/layout/AppShell.module.css
+++ b/src/components/layout/AppShell.module.css
@@ -1,0 +1,410 @@
+.appShell {
+  position: relative;
+  min-height: 100vh;
+  padding-bottom: 56px;
+}
+
+.background {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+}
+
+.background::before,
+.background::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.55;
+}
+
+.background::before {
+  width: 560px;
+  height: 560px;
+  left: -120px;
+  top: -160px;
+  background: radial-gradient(circle, rgba(125, 211, 252, 0.55), transparent 70%);
+}
+
+.background::after {
+  width: 520px;
+  height: 520px;
+  right: -140px;
+  bottom: -200px;
+  background: radial-gradient(circle, rgba(16, 185, 129, 0.45), transparent 70%);
+}
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 32px 0 96px;
+}
+
+.header {
+  position: sticky;
+  top: 24px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.headerBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px 26px;
+  border-radius: 28px;
+  background: var(--ui-surface-strong);
+  border: 1px solid var(--ui-border-strong);
+  box-shadow: var(--ui-shadow);
+  backdrop-filter: blur(20px);
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 420px;
+}
+
+.logo {
+  font-family: var(--ui-font-display);
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--ui-text-primary);
+  letter-spacing: -0.01em;
+  text-decoration: none;
+}
+
+.tagline {
+  font-size: 0.95rem;
+  color: var(--ui-text-secondary);
+  margin: 0;
+}
+
+.headerActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.flowPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: var(--ui-text-secondary);
+}
+
+.flowPill span:first-child {
+  background: var(--ui-accent);
+  color: var(--ui-text-inverse);
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+}
+
+.contrastToggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  color: var(--ui-text-secondary);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.contrastToggle[data-active='true'] {
+  border-color: var(--ui-accent);
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--ui-accent-strong);
+}
+
+.toggleThumb {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  width: 38px;
+  height: 38px;
+  border-radius: 19px;
+  background: var(--ui-surface-strong);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--ui-text-secondary);
+  transition: transform 0.25s ease, background-color 0.25s ease;
+}
+
+.contrastToggle[data-active='true'] .toggleThumb {
+  transform: translateX(44px);
+  background: var(--ui-accent);
+  color: var(--ui-text-inverse);
+}
+
+.toggleLabels {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nav {
+  padding: 16px;
+  border-radius: 26px;
+  background: var(--ui-surface-muted);
+  border: 1px solid var(--ui-border);
+  box-shadow: var(--ui-shadow);
+  backdrop-filter: blur(18px);
+}
+
+.navList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.navLink {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 16px 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.45);
+  color: var(--ui-text-primary);
+  text-decoration: none;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  min-height: 92px;
+}
+
+.navLink:hover,
+.navLink:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--ui-accent);
+}
+
+.navLinkActive {
+  background: linear-gradient(140deg, rgba(34, 197, 94, 0.18), rgba(96, 165, 250, 0.18));
+  border-color: var(--ui-accent);
+  box-shadow: 0 24px 60px -40px rgba(34, 197, 94, 0.45);
+}
+
+.navIcon {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: var(--ui-accent-soft);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  color: var(--ui-accent-strong);
+  flex-shrink: 0;
+}
+
+.navText {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.navLabel {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.navHint {
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 240px;
+  gap: 24px;
+  margin-top: 36px;
+  flex: 1;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sessionPlanner {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.quickActions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.quickLink {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-radius: 22px;
+  padding: 14px 18px;
+  border: 1px solid var(--ui-border);
+  background: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.quickLink:hover,
+.quickLink:focus-visible {
+  transform: translateX(4px);
+  border-color: var(--ui-accent);
+}
+
+.quickLinkText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.quickLinkLabel {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ui-text-primary);
+}
+
+.quickLinkDescription {
+  font-size: 0.8rem;
+  color: var(--ui-text-secondary);
+}
+
+.quickLinkIcon {
+  font-size: 1.2rem;
+  color: var(--ui-accent-strong);
+  transition: transform 0.2s ease;
+}
+
+.quickLink:hover .quickLinkIcon,
+.quickLink:focus-visible .quickLinkIcon {
+  transform: translateX(4px);
+}
+
+.focusToggle {
+  width: 100%;
+  border-radius: var(--ui-radius-pill);
+  padding: 12px 18px;
+  border: 1px solid var(--ui-border);
+  background: transparent;
+  color: var(--ui-text-primary);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.focusToggle[data-active='true'] {
+  background: var(--ui-highlight);
+  color: var(--ui-text-inverse);
+  border-color: transparent;
+  box-shadow: 0 18px 45px -30px rgba(79, 70, 229, 0.55);
+}
+
+.main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 0;
+}
+
+.mainActive {
+  border-radius: var(--ui-radius-xl);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-strong);
+  box-shadow: var(--ui-shadow-strong);
+  padding: 28px;
+}
+
+.footer {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--ui-border);
+  color: var(--ui-text-secondary);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1200px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar,
+  .main {
+    order: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .inner {
+    padding: 24px 0 72px;
+  }
+
+  .header {
+    top: 12px;
+  }
+
+  .headerBar {
+    padding: 18px 20px;
+  }
+
+  .nav {
+    padding: 12px;
+  }
+
+  .navList {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .headerBar {
+    border-radius: 22px;
+  }
+
+  .nav {
+    border-radius: 20px;
+  }
+
+  .layout {
+    margin-top: 28px;
+  }
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
+import styles from './AppShell.module.css';
 
 interface AppShellProps {
   highContrastEnabled: boolean;
@@ -7,45 +8,60 @@ interface AppShellProps {
   children: React.ReactNode;
 }
 
-const navigation = [
+type NavigationItem = {
+  to: string;
+  label: string;
+  description: string;
+  icon: string;
+  exact?: boolean;
+};
+
+const navigation: NavigationItem[] = [
   {
     to: '/',
     label: 'Overview',
     description: 'Plan the next study block at a glance.',
+    icon: '🧭',
     exact: true,
   },
   {
     to: '/dashboard',
     label: 'Dashboard',
     description: 'Progress analytics and weak spots.',
+    icon: '📊',
   },
   {
     to: '/flashcards',
     label: 'Flashcards',
     description: 'Spaced repetition trainer.',
+    icon: '🧠',
   },
   {
     to: '/content-manager',
     label: 'Content manager',
     description: 'Import JSON lesson bundles.',
+    icon: '📁',
   },
 ];
 
-const quickActions = [
+const quickActions: NavigationItem[] = [
   {
     to: '/dashboard',
     label: 'Review analytics',
     description: 'Start with the weakest skills and tags.',
+    icon: '📈',
   },
   {
     to: '/flashcards',
     label: 'Warm-up with flashcards',
     description: 'Clear due connectors in five focused minutes.',
+    icon: '⚡️',
   },
   {
     to: '/content-manager',
     label: 'Refresh content bundle',
     description: 'Import the latest JSON drop before you begin.',
+    icon: '🔄',
   },
 ];
 
@@ -56,239 +72,172 @@ export const AppShell: React.FC<AppShellProps> = ({
 }) => {
   const [focusMode, setFocusMode] = useState(false);
 
-  const renderNavigation = () =>
-    navigation.map(({ to, label, description, exact }) => (
-      <NavLink
-        key={to}
-        to={to}
-        end={exact}
-        className={({ isActive }) =>
-          [
-            'group flex min-w-[200px] flex-1 items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left text-sm transition focus-visible:ring',
-            isActive
-              ? highContrastEnabled
-                ? 'border-yellow-400 bg-black text-yellow-100 shadow-none'
-                : 'border-blue-500 bg-white/90 text-blue-900 shadow-lg shadow-blue-100/60 backdrop-blur'
-              : highContrastEnabled
-              ? 'border-slate-500 bg-transparent text-white hover:border-yellow-400'
-              : 'border-transparent bg-white/40 text-slate-600 hover:border-blue-200 hover:bg-white/70 hover:text-slate-900',
-          ].join(' ')
-        }
-      >
-        <span className="space-y-1">
-          <span className="block text-sm font-semibold">{label}</span>
-          <span className="block text-xs text-slate-500 group-hover:text-slate-700">
-            {description}
-          </span>
-        </span>
-        <span
-          aria-hidden="true"
-          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-blue-200 bg-blue-50 text-base text-blue-600 transition-transform group-hover:translate-x-1"
-        >
-          →
-        </span>
-      </NavLink>
-    ));
+  const mainContent = useMemo(
+    () => (focusMode ? <div className={styles.mainActive}>{children}</div> : children),
+    [children, focusMode]
+  );
 
   return (
-    <div
-      className={`relative min-h-screen ${
-        highContrastEnabled
-          ? 'bg-black text-white'
-          : 'bg-gradient-to-br from-slate-100 via-white to-sky-100 text-slate-900'
-      }`}
-    >
-      {!highContrastEnabled && (
-        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
-          <div className="absolute left-1/2 top-[-14rem] h-[22rem] w-[48rem] -translate-x-1/2 rounded-full bg-gradient-to-r from-sky-200 via-blue-100 to-indigo-200 opacity-60 blur-3xl" />
-          <div className="absolute bottom-[-16rem] right-[-6rem] h-[20rem] w-[20rem] rounded-full bg-gradient-to-br from-emerald-200 to-transparent opacity-70 blur-3xl" />
-          <div className="absolute bottom-[-18rem] left-[-8rem] h-[18rem] w-[18rem] rounded-full bg-gradient-to-tr from-blue-200 via-white to-transparent opacity-60 blur-3xl" />
-        </div>
-      )}
-
-      <div className="relative flex min-h-screen flex-col">
-        <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/80 backdrop-blur" aria-label="Primary navigation">
-          <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-4">
-            <div className="space-y-1">
-              <Link to="/" className="text-2xl font-semibold text-slate-900 focus-visible:ring">
-                Study Spanish Coach
-              </Link>
-              <p className="text-sm text-slate-600">
-                Organise B1–C1 lessons, practice, and flashcards in one coach-like workspace.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                <span className="rounded-full bg-slate-900 px-2 py-[2px] text-white">Plan</span>
-                <span className="px-2 py-[2px]">Practice</span>
-                <span className="px-2 py-[2px]">Reflect</span>
+    <div className={styles.appShell}>
+      <div className={styles.background} aria-hidden="true" />
+      <div className="ui-max-width">
+        <div className={styles.inner}>
+          <header className={styles.header} aria-label="Primary navigation">
+            <div className={styles.headerBar}>
+              <div className={styles.brand}>
+                <Link to="/" className={styles.logo}>
+                  Study Spanish Coach
+                </Link>
+                <p className={styles.tagline}>
+                  Daily Spanish sprints, analytics and flashcards in a social-inspired dashboard.
+                </p>
               </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={highContrastEnabled}
-                onClick={onToggleHighContrast}
-                className={`relative flex h-9 w-16 items-center rounded-full border px-1 transition focus-visible:ring ${
-                  highContrastEnabled
-                    ? 'border-yellow-400 bg-black text-yellow-200'
-                    : 'border-slate-200 bg-white/80 text-slate-500 hover:border-blue-200'
-                }`}
-                aria-label="Toggle high-contrast theme"
-              >
-                <span className="flex w-full items-center justify-between px-1 text-[11px] font-semibold uppercase">
-                  <span>Aa</span>
-                  <span>HC</span>
-                </span>
-                <span
-                  aria-hidden="true"
-                  className={`pointer-events-none absolute left-1 top-[6px] inline-flex h-6 w-6 transform items-center justify-center rounded-full bg-white text-[10px] font-semibold text-slate-600 shadow transition ${
-                    highContrastEnabled ? 'translate-x-7 bg-yellow-300 text-slate-900' : ''
-                  }`}
+              <div className={styles.headerActions}>
+                <div className={styles.flowPill} aria-hidden="true">
+                  <span>Plan</span>
+                  <span>Practice</span>
+                  <span>Reflect</span>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={highContrastEnabled}
+                  onClick={onToggleHighContrast}
+                  className={styles.contrastToggle}
+                  data-active={highContrastEnabled}
+                  aria-label="Toggle high-contrast theme"
                 >
-                  {highContrastEnabled ? 'On' : 'Off'}
-                </span>
-              </button>
-            </div>
-          </div>
-          <div className="border-t border-slate-200/70 bg-white/70">
-            <div className="mx-auto flex max-w-6xl flex-wrap gap-3 px-4 py-3" role="navigation" aria-label="Site sections">
-              {renderNavigation()}
-            </div>
-          </div>
-        </header>
-
-        <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 xl:grid xl:grid-cols-[260px_minmax(0,1fr)_240px] xl:gap-6">
-          <aside className="order-2 mb-6 space-y-4 xl:order-1 xl:mb-0" aria-label="Session planner">
-            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow-lg shadow-slate-200/40 backdrop-blur">
-              <header className="flex items-center justify-between">
-                <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Session planner</h2>
-                <span className="text-xs font-semibold text-blue-600">
-                  {focusMode ? 'Focus mode' : 'Prep mode'}
-                </span>
-              </header>
-              <p className="mt-3 text-sm text-slate-600">
-                Map out the next study sprint with curated shortcuts.
-              </p>
-              <div className="mt-4 space-y-2" role="list">
-                {quickActions.map(({ to, label, description }) => (
-                  <Link
-                    key={to}
-                    to={to}
-                    className="group flex items-center justify-between gap-3 rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-blue-300 hover:text-blue-700 focus-visible:ring"
-                  >
-                    <span className="text-left">
-                      <span className="block font-semibold">{label}</span>
-                      <span className="block text-xs text-slate-500 group-hover:text-slate-600">{description}</span>
-                    </span>
-                    <span aria-hidden="true" className="text-lg text-blue-500 transition-transform group-hover:translate-x-1">
-                      ↗
-                    </span>
-                  </Link>
-                ))}
+                  <span className={styles.toggleThumb} aria-hidden="true">
+                    {highContrastEnabled ? 'HC' : 'Aa'}
+                  </span>
+                  <span className={styles.toggleLabels}>
+                    <span>Light</span>
+                    <span>Contrast</span>
+                  </span>
+                </button>
               </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={focusMode}
-                onClick={() => setFocusMode((prev) => !prev)}
-                className={`mt-4 w-full rounded-full border px-4 py-2 text-sm font-semibold transition focus-visible:ring ${
-                  focusMode
-                    ? 'border-blue-500 bg-blue-600 text-white shadow'
-                    : 'border-slate-200 bg-white text-slate-700 hover:border-blue-200 hover:text-blue-700'
-                }`}
-              >
-                {focusMode ? 'Focus mode enabled' : 'Enable focus mode'}
-              </button>
-            </section>
-
-            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow shadow-slate-200/30 backdrop-blur">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Navigation highlights</h2>
-              <p className="mt-3 text-sm text-slate-600">
-                Each page is optimised for one step of your bilingual workflow—pin this panel if you need a
-                reminder.
-              </p>
-              <ul className="mt-4 space-y-2 text-sm text-slate-600" role="list">
-                <li>
-                  <span className="font-semibold text-slate-800">Overview:</span> plan what to learn next.
-                </li>
-                <li>
-                  <span className="font-semibold text-slate-800">Dashboard:</span> inspect accuracy trends.
-                </li>
-                <li>
-                  <span className="font-semibold text-slate-800">Flashcards:</span> reinforce quick wins.
-                </li>
-                <li>
-                  <span className="font-semibold text-slate-800">Content:</span> keep lessons synced offline.
-                </li>
+            </div>
+            <nav className={styles.nav} aria-label="Primary sections">
+              <ul className={styles.navList}>
+                {navigation.map(({ to, label, description, exact, icon }) => (
+                  <li key={to}>
+                    <NavLink
+                      to={to}
+                      end={exact}
+                      className={({ isActive }) =>
+                        [styles.navLink, isActive ? styles.navLinkActive : '']
+                          .filter(Boolean)
+                          .join(' ')
+                      }
+                    >
+                      <span className={styles.navIcon} aria-hidden="true">
+                        {icon}
+                      </span>
+                      <span className={styles.navText}>
+                        <span className={styles.navLabel}>{label}</span>
+                        <span className={styles.navHint}>{description}</span>
+                      </span>
+                    </NavLink>
+                  </li>
+                ))}
               </ul>
-            </section>
-          </aside>
+            </nav>
+          </header>
 
-          <main
-            id="main-content"
-            tabIndex={-1}
-            className={`order-1 min-w-0 space-y-10 focus:outline-none ${
-              focusMode
-                ? 'rounded-3xl border border-blue-200/80 bg-white/85 p-6 shadow-2xl shadow-blue-200/50 backdrop-blur'
-                : ''
-            }`}
-          >
-            {children}
-          </main>
+          <div className={styles.layout}>
+            <aside className={styles.sidebar} aria-label="Session planner">
+              <section className={`ui-card ui-card--strong ${styles.sessionPlanner}`}>
+                <header className="ui-section">
+                  <span className="ui-section__tag">Session planner</span>
+                  <span className="ui-section__subtitle">
+                    Map out the next study sprint with curated shortcuts.
+                  </span>
+                </header>
+                <div className={styles.quickActions} role="list">
+                  {quickActions.map(({ to, label, description, icon }) => (
+                    <Link key={to} to={to} className={styles.quickLink} role="listitem">
+                      <span className={styles.quickLinkText}>
+                        <span className={styles.quickLinkLabel}>{label}</span>
+                        <span className={styles.quickLinkDescription}>{description}</span>
+                      </span>
+                      <span className={styles.quickLinkIcon} aria-hidden="true">
+                        {icon}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={focusMode}
+                  onClick={() => setFocusMode((prev) => !prev)}
+                  className={styles.focusToggle}
+                  data-active={focusMode}
+                >
+                  {focusMode ? 'Focus mode enabled' : 'Enable focus mode'}
+                </button>
+              </section>
 
-          <aside className="order-3 space-y-4" aria-label="Study tips">
-            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow shadow-slate-200/30 backdrop-blur">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Session checklist</h2>
-              <ol className="mt-3 space-y-2 text-sm text-slate-600">
-                <li>
-                  <span className="font-medium">1. Review metrics.</span>{' '}
-                  <Link to="/dashboard" className="text-blue-700 underline focus-visible:ring">
-                    Open the dashboard
-                  </Link>{' '}
-                  to choose a focus tag.
-                </li>
-                <li>
-                  <span className="font-medium">2. Work through one lesson.</span>{' '}
-                  Skim the overview below and pick the next item in your queue.
-                </li>
-                <li>
-                  <span className="font-medium">3. Reinforce with flashcards.</span>{' '}
-                  <Link to="/flashcards" className="text-blue-700 underline focus-visible:ring">
-                    Run the due deck
-                  </Link>{' '}
-                  to lock it in.
-                </li>
-              </ol>
-            </section>
+              <section className="ui-card ui-card--muted">
+                <span className="ui-section__tag">Navigation highlights</span>
+                <p className="ui-section__subtitle">
+                  Each page is optimised for one step of your bilingual workflow — pin this panel if you need a reminder.
+                </p>
+                <ul className="ui-section" role="list">
+                  <li>
+                    <strong>Overview:</strong> plan what to learn next.
+                  </li>
+                  <li>
+                    <strong>Dashboard:</strong> inspect accuracy trends.
+                  </li>
+                  <li>
+                    <strong>Flashcards:</strong> reinforce quick wins.
+                  </li>
+                  <li>
+                    <strong>Content:</strong> keep lessons synced offline.
+                  </li>
+                </ul>
+              </section>
+            </aside>
 
-            <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow shadow-slate-200/30 backdrop-blur">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">Keep content fresh</h2>
-              <p className="mt-3 text-sm text-slate-600">
-                Import JSON bundles in the content manager to refresh lessons and practise sets. Once loaded,
-                everything is cached for offline work.
-              </p>
-              <Link
-                to="/content-manager"
-                className="mt-3 inline-flex text-sm font-semibold text-blue-700 underline focus-visible:ring"
-              >
-                Go to Content manager
-              </Link>
-            </section>
-          </aside>
-        </div>
+            <main id="main-content" tabIndex={-1} className={styles.main}>
+              {mainContent}
+            </main>
 
-        <footer
-          className={`border-t ${
-            highContrastEnabled
-              ? 'border-slate-100 bg-black text-slate-100'
-              : 'border-slate-200/70 bg-white/80 text-slate-500 backdrop-blur'
-          }`}
-          aria-label="Site footer"
-        >
-          <div className="mx-auto max-w-6xl px-4 py-4 text-sm">
-            Launch locally with <code>npm install</code> then <code>npm run dev</code>.
+            <aside className={styles.sidebar} aria-label="Study tips">
+              <section className="ui-card ui-card--muted">
+                <span className="ui-section__tag">Session checklist</span>
+                <ol className="ui-section" aria-label="Study session checklist">
+                  <li>
+                    <strong>Review metrics.</strong>{' '}
+                    <Link to="/dashboard">Open the dashboard</Link> to choose a focus tag.
+                  </li>
+                  <li>
+                    <strong>Work through one lesson.</strong> Skim the overview below and pick the next item in your queue.
+                  </li>
+                  <li>
+                    <strong>Reinforce with flashcards.</strong>{' '}
+                    <Link to="/flashcards">Run the due deck</Link> to lock it in.
+                  </li>
+                </ol>
+              </section>
+
+              <section className="ui-card ui-card--muted">
+                <span className="ui-section__tag">Keep content fresh</span>
+                <p className="ui-section__subtitle">
+                  Import JSON bundles in the content manager to refresh lessons and practise sets. Once loaded, everything is cached for offline work.
+                </p>
+                <Link to="/content-manager" className="ui-button ui-button--secondary">
+                  Go to content manager
+                </Link>
+              </section>
+            </aside>
           </div>
-        </footer>
+
+          <footer className={styles.footer} aria-label="Site footer">
+            Launch locally with <code>npm install</code> then <code>npm run dev</code>.
+          </footer>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/ContentManagerPage.module.css
+++ b/src/pages/ContentManagerPage.module.css
@@ -1,0 +1,53 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.sectionGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.summaryGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summaryCard {
+  padding: 16px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  text-align: center;
+}
+
+.summaryCard strong {
+  display: block;
+  font-size: 1.8rem;
+  font-family: var(--ui-font-display);
+  margin-bottom: 4px;
+}
+
+.diffList {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/pages/ContentManagerPage.tsx
+++ b/src/pages/ContentManagerPage.tsx
@@ -3,6 +3,7 @@ import { importSeed } from '../seed';
 import { SeedBundle, SeedBundleSchema } from '../seed/seedTypes';
 import { Exercise, Lesson } from '../lib/schemas';
 import { db } from '../db';
+import styles from './ContentManagerPage.module.css';
 
 interface DiffSummary {
   newLessons: Lesson[];
@@ -98,16 +99,19 @@ const ContentManagerPage: React.FC = () => {
     }
   };
 
-  const diffSummary = useMemo(() => ({
-    lessons: {
-      new: diff.newLessons.length,
-      updated: diff.updatedLessons.length,
-    },
-    exercises: {
-      new: diff.newExercises.length,
-      updated: diff.updatedExercises.length,
-    },
-  }), [diff]);
+  const diffSummary = useMemo(
+    () => ({
+      lessons: {
+        new: diff.newLessons.length,
+        updated: diff.updatedLessons.length,
+      },
+      exercises: {
+        new: diff.newExercises.length,
+        updated: diff.updatedExercises.length,
+      },
+    }),
+    [diff]
+  );
 
   const updateOfflineCache = useCallback(async () => {
     if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
@@ -139,22 +143,23 @@ const ContentManagerPage: React.FC = () => {
   };
 
   return (
-    <section className="space-y-6" aria-labelledby="content-manager-heading">
-      <header className="space-y-3 rounded-xl border bg-white p-5 shadow-sm">
-        <p className="text-xs font-semibold uppercase tracking-widest text-blue-600">Content pipeline</p>
-        <h1 id="content-manager-heading" className="text-3xl font-bold text-slate-900">
+    <section className={styles.page} aria-labelledby="content-manager-heading">
+      <header className="ui-card ui-card--strong">
+        <span className="ui-section__tag">Content pipeline</span>
+        <h1 id="content-manager-heading" className="ui-section__title">
           Content manager
         </h1>
-        <p className="text-sm text-slate-600">
+        <p className="ui-section__subtitle">
           Import vetted JSON content drops, preview the diff, and keep the learner database indexed for offline use.
         </p>
       </header>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-        <div className="space-y-6">
-          <section className="space-y-3 rounded-xl border bg-white p-4 shadow-sm">
-            <label htmlFor="content-upload" className="font-semibold text-slate-800">
-              Upload JSON bundle
+      <div className={styles.layout}>
+        <div className={styles.sectionGroup}>
+          <section className="ui-card">
+            <span className="ui-section__tag">Upload JSON bundle</span>
+            <label htmlFor="content-upload" className="ui-section__title">
+              Select bundle
             </label>
             <input
               id="content-upload"
@@ -163,35 +168,26 @@ const ContentManagerPage: React.FC = () => {
               onChange={handleFileChange}
               aria-describedby="content-upload-help"
             />
-            <p id="content-upload-help" className="text-sm text-slate-600">
-              The file should follow the SeedBundle schema with <code>lessons</code>, <code>exercises</code>, and
-              <code>flashcards</code> arrays.
+            <p id="content-upload-help" className="ui-section__subtitle">
+              The file should follow the SeedBundle schema with <code>lessons</code>, <code>exercises</code>, and <code>flashcards</code> arrays.
             </p>
             {fileName && (
-              <p className="text-sm text-slate-600" aria-live="polite">
+              <p className="ui-section__subtitle" aria-live="polite">
                 Selected file: <strong>{fileName}</strong>
               </p>
             )}
           </section>
 
           {status && (
-            <div
-              role="status"
-              className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900"
-              aria-live="polite"
-            >
+            <div role="status" className="ui-alert ui-alert--info" aria-live="polite">
               {status}
             </div>
           )}
 
           {errors.length > 0 && (
-            <div
-              role="alert"
-              className="space-y-2 rounded-lg border border-red-200 bg-red-50 p-4"
-              aria-live="assertive"
-            >
-              <h2 className="text-sm font-semibold text-red-700">Validation errors</h2>
-              <ul className="ml-5 list-disc text-sm text-red-700">
+            <div role="alert" className="ui-alert ui-alert--danger" aria-live="assertive">
+              <h2 className="ui-section__title">Validation errors</h2>
+              <ul className={styles.diffList}>
                 {errors.map((message, index) => (
                   <li key={index}>{message}</li>
                 ))}
@@ -199,111 +195,100 @@ const ContentManagerPage: React.FC = () => {
             </div>
           )}
 
-          {bundle && errors.length === 0 && (
-            <section className="space-y-4 rounded-xl border bg-white p-4 shadow-sm" aria-live="polite">
-              <header className="space-y-1">
-                <h2 className="text-xl font-semibold text-slate-900">Preview diff</h2>
-                <p className="text-sm text-slate-600">
-                  Confirm how many lessons and exercises will be inserted or updated before importing.
-                </p>
-              </header>
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-lg border border-slate-200 p-3" aria-label="Lesson diff summary">
-                  <h3 className="text-sm font-semibold text-slate-800">Lessons</h3>
-                  <p className="text-sm text-slate-600">New: {diffSummary.lessons.new}</p>
-                  <p className="text-sm text-slate-600">Updated: {diffSummary.lessons.updated}</p>
-                  {diff.newLessons.length > 0 && (
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-sm text-blue-700 underline">View new lessons</summary>
-                      <ul className="ml-5 list-disc text-sm text-slate-600">
-                        {diff.newLessons.map((lesson) => (
-                          <li key={lesson.id}>{lesson.title}</li>
-                        ))}
-                      </ul>
-                    </details>
-                  )}
-                  {diff.updatedLessons.length > 0 && (
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-sm text-blue-700 underline">View lesson updates</summary>
-                      <ul className="ml-5 list-disc text-sm text-slate-600">
-                        {diff.updatedLessons.map((lesson) => (
-                          <li key={lesson.id}>{lesson.title}</li>
-                        ))}
-                      </ul>
-                    </details>
-                  )}
+          {bundle && (
+            <section className="ui-card ui-card--muted">
+              <span className="ui-section__tag">Preview diff</span>
+              <p className="ui-section__subtitle">
+                Double-check what’s changing before syncing the bundle to the offline cache.
+              </p>
+              <div className={styles.summaryGrid}>
+                <div className={styles.summaryCard}>
+                  <strong>{diffSummary.lessons.new}</strong>
+                  New lessons
                 </div>
-                <div className="rounded-lg border border-slate-200 p-3" aria-label="Exercise diff summary">
-                  <h3 className="text-sm font-semibold text-slate-800">Exercises</h3>
-                  <p className="text-sm text-slate-600">New: {diffSummary.exercises.new}</p>
-                  <p className="text-sm text-slate-600">Updated: {diffSummary.exercises.updated}</p>
-                  {diff.newExercises.length > 0 && (
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-sm text-blue-700 underline">View new exercises</summary>
-                      <ul className="ml-5 list-disc text-sm text-slate-600">
-                        {diff.newExercises.map((exercise) => (
-                          <li key={exercise.id}>{exercise.promptMd.slice(0, 60)}…</li>
-                        ))}
-                      </ul>
-                    </details>
-                  )}
-                  {diff.updatedExercises.length > 0 && (
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-sm text-blue-700 underline">View exercise updates</summary>
-                      <ul className="ml-5 list-disc text-sm text-slate-600">
-                        {diff.updatedExercises.map((exercise) => (
-                          <li key={exercise.id}>{exercise.promptMd.slice(0, 60)}…</li>
-                        ))}
-                      </ul>
-                    </details>
-                  )}
+                <div className={styles.summaryCard}>
+                  <strong>{diffSummary.lessons.updated}</strong>
+                  Updated lessons
+                </div>
+                <div className={styles.summaryCard}>
+                  <strong>{diffSummary.exercises.new}</strong>
+                  New exercises
+                </div>
+                <div className={styles.summaryCard}>
+                  <strong>{diffSummary.exercises.updated}</strong>
+                  Updated exercises
                 </div>
               </div>
-
+              <div className="ui-section">
+                {diff.newLessons.length > 0 && (
+                  <div>
+                    <h3 className="ui-section__title">New lessons</h3>
+                    <ul className={styles.diffList}>
+                      {diff.newLessons.map((lesson) => (
+                        <li key={lesson.id}>{lesson.title}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {diff.updatedLessons.length > 0 && (
+                  <div>
+                    <h3 className="ui-section__title">Updated lessons</h3>
+                    <ul className={styles.diffList}>
+                      {diff.updatedLessons.map((lesson) => (
+                        <li key={lesson.id}>{lesson.title}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {diff.newExercises.length > 0 && (
+                  <div>
+                    <h3 className="ui-section__title">New exercises</h3>
+                    <ul className={styles.diffList}>
+                      {diff.newExercises.map((exercise) => (
+                        <li key={exercise.id}>{exercise.promptMd.slice(0, 80)}…</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {diff.updatedExercises.length > 0 && (
+                  <div>
+                    <h3 className="ui-section__title">Updated exercises</h3>
+                    <ul className={styles.diffList}>
+                      {diff.updatedExercises.map((exercise) => (
+                        <li key={exercise.id}>{exercise.promptMd.slice(0, 80)}…</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
               <button
                 type="button"
+                className="ui-button ui-button--primary"
                 onClick={handleImport}
-                className="inline-flex items-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm focus-visible:ring"
                 disabled={importing}
-                aria-label="Import validated content"
               >
-                {importing ? 'Importing…' : 'Import content'}
+                {importing ? 'Importing…' : 'Import bundle →'}
               </button>
             </section>
           )}
         </div>
 
-        <aside className="space-y-4 rounded-xl border bg-white p-4 shadow-sm" aria-label="Import guidance">
-          <section className="space-y-2">
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Import checklist</h2>
-            <ol className="space-y-2 text-sm text-slate-600">
-              <li>Download the latest <code>.json</code> bundle from your content pipeline.</li>
-              <li>Upload it here to validate the structure and preview the diff.</li>
-              <li>
-                When the diff looks right, press <span className="font-semibold text-slate-800">Import content</span>{' '}
-                to update the on-device cache.
-              </li>
-            </ol>
-          </section>
-          <section className="space-y-2">
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Bundle structure</h2>
-            <ul className="space-y-1 text-sm text-slate-600">
-              <li>
-                <code>lessons[]</code> — Markdown content with <code>level</code>, <code>tags</code>, and optional
-                references.
-              </li>
-              <li>
-                <code>exercises[]</code> — Practice prompts linked by <code>lessonId</code>.
-              </li>
-              <li>
-                <code>flashcards[]</code> — Deck metadata powering the spaced repetition trainer.
-              </li>
+        <aside className={styles.sectionGroup} aria-label="Content manager tips">
+          <section className="ui-card ui-card--muted">
+            <span className="ui-section__tag">Why it matters</span>
+            <p className="ui-section__subtitle">
+              Use the same bundle across teammates to keep lessons, practice sets, and flashcards aligned. Importing updates the offline cache so learners can work without a connection.
+            </p>
+            <ul className="ui-section">
+              <li>Bundles include lessons, exercises, and flashcards in one JSON file.</li>
+              <li>Offline caching refreshes automatically after each import.</li>
+              <li>Any validation errors are listed before data is committed.</li>
             </ul>
           </section>
-          <section className="text-sm text-slate-600">
-            <p>
-              After importing, the service worker updates its offline cache so lessons, exercises, and flashcards are
-              available without a connection.
+          <section className="ui-card ui-card--muted">
+            <span className="ui-section__tag">Next steps</span>
+            <p className="ui-section__subtitle">
+              After importing, head to the overview to queue a lesson or jump into the flashcard trainer to drill new phrases.
             </p>
           </section>
         </aside>

--- a/src/pages/DashboardPage.module.css
+++ b/src/pages/DashboardPage.module.css
@@ -1,0 +1,17 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.pageHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.headerActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Dashboard } from '../components/Dashboard';
+import styles from './DashboardPage.module.css';
 
 const DashboardPage: React.FC = () => (
-  <section className="space-y-6" aria-labelledby="dashboard-page-heading">
-    <header className="space-y-3 rounded-xl border bg-white p-5 shadow-sm">
-      <p className="text-xs font-semibold uppercase tracking-widest text-blue-600">Analytics</p>
-      <h1 id="dashboard-page-heading" className="text-3xl font-bold text-slate-900">
+  <section className={styles.page} aria-labelledby="dashboard-page-heading">
+    <header className={`ui-card ui-card--strong ${styles.pageHeader}`}>
+      <span className="ui-section__tag">Analytics</span>
+      <h1 id="dashboard-page-heading" className="ui-section__title">
         Progress dashboard
       </h1>
-      <p className="text-sm text-slate-600">
-        Review accuracy, speed, and recommended exercises after each session so you can adjust the next study
-        block with confidence.
+      <p className="ui-section__subtitle">
+        Review accuracy, speed, and recommended exercises after each session so you can adjust the next study block with confidence.
       </p>
-      <div className="flex flex-wrap gap-3">
-        <Link to="/" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+      <div className={styles.headerActions}>
+        <Link to="/" className="ui-button ui-button--ghost">
           ← Back to overview
         </Link>
-        <Link to="/flashcards" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-          Drill due flashcards
+        <Link to="/flashcards" className="ui-button ui-button--secondary">
+          Drill due flashcards →
         </Link>
       </div>
     </header>

--- a/src/pages/FlashcardsPage.module.css
+++ b/src/pages/FlashcardsPage.module.css
@@ -1,0 +1,29 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -1,53 +1,51 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FlashcardTrainer } from '../components/FlashcardTrainer';
+import styles from './FlashcardsPage.module.css';
 
 const FlashcardsPage: React.FC = () => (
-  <section className="space-y-6" aria-labelledby="flashcards-heading">
-    <header className="space-y-3 rounded-xl border bg-white p-5 shadow-sm">
-      <p className="text-xs font-semibold uppercase tracking-widest text-blue-600">Spaced repetition</p>
-      <h1 id="flashcards-heading" className="text-3xl font-bold text-slate-900">
+  <section className={styles.page} aria-labelledby="flashcards-heading">
+    <header className={`ui-card ui-card--strong ${styles.header}`}>
+      <span className="ui-section__tag">Spaced repetition</span>
+      <h1 id="flashcards-heading" className="ui-section__title">
         Flashcard trainer
       </h1>
-      <p className="text-sm text-slate-600">
-        Keep verbs, connectors, and presentation phrases ready. Flip cards with the spacebar and grade your recall
-        with J/K (or the arrow keys) to move quickly.
+      <p className="ui-section__subtitle">
+        Keep verbs, connectors, and presentation phrases ready. Flip cards with the spacebar and grade your recall with J/K or the arrow keys to move quickly.
       </p>
-      <div className="flex flex-wrap gap-3">
-        <Link to="/" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
+      <div className="ui-pill-group">
+        <Link to="/" className="ui-button ui-button--ghost">
           ← Back to overview
         </Link>
-        <Link to="/content-manager" className="text-sm font-semibold text-blue-700 underline focus-visible:ring">
-          Import new flashcards
+        <Link to="/content-manager" className="ui-button ui-button--secondary">
+          Import new flashcards →
         </Link>
       </div>
     </header>
 
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+    <div className={styles.layout}>
       <FlashcardTrainer />
-      <aside className="space-y-4 rounded-xl border bg-white p-4 shadow-sm" aria-label="Trainer tips">
-        <section className="space-y-2">
-          <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Keyboard flow</h2>
-          <ul className="space-y-1 text-sm text-slate-600">
+      <aside className={`${styles.sidebar}`} aria-label="Trainer tips">
+        <section className="ui-card ui-card--muted">
+          <span className="ui-section__tag">Keyboard flow</span>
+          <ul className="ui-section">
             <li>
-              <span className="font-semibold text-slate-800">Space</span> — Reveal the back.
+              <strong>Space</strong> — Reveal the back.
             </li>
             <li>
-              <span className="font-semibold text-slate-800">J / ←</span> — Mark as “I forgot”.
+              <strong>J / ←</strong> — Mark as “I forgot”.
             </li>
             <li>
-              <span className="font-semibold text-slate-800">K / →</span> — Mark as “I knew it”.
+              <strong>K / →</strong> — Mark as “I knew it”.
             </li>
           </ul>
         </section>
-        <section className="space-y-2">
-          <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Best practice</h2>
-          <ul className="space-y-2 text-sm text-slate-600">
+        <section className="ui-card ui-card--muted">
+          <span className="ui-section__tag">Best practice</span>
+          <ul className="ui-section">
             <li>Say each answer aloud to build confident speaking reflexes.</li>
             <li>Mix in a quick dashboard review if you clear the due pile.</li>
-            <li>
-              Rotate between decks—verbs, grammar, vocab, presentations—to keep coverage balanced.
-            </li>
+            <li>Rotate between decks to keep coverage balanced.</li>
           </ul>
         </section>
       </aside>

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,0 +1,347 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.35), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.heroTag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.85);
+  margin: 0;
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: 2.6rem;
+  line-height: 1.15;
+  font-family: var(--ui-font-display);
+}
+
+.heroDescription {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(236, 253, 245, 0.88);
+  max-width: 54ch;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.heroChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.heroStats {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 16px;
+}
+
+.heroStatsItem {
+  border-radius: var(--ui-radius-md);
+  padding: 20px;
+  backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  color: #ecfdf5;
+  min-height: 120px;
+}
+
+.heroStatsItem dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.heroStatsItem dd {
+  margin: 12px 0 0;
+  font-size: 2.4rem;
+  font-family: var(--ui-font-display);
+}
+
+.focusGrid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 12px;
+}
+
+.focusCard {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-strong);
+  box-shadow: var(--ui-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.focusCard:hover,
+.focusCard:focus-within {
+  transform: translateY(-3px);
+  box-shadow: var(--ui-shadow-strong);
+}
+
+.focusCard h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.focusCard p {
+  margin: 0;
+  color: var(--ui-text-secondary);
+  font-size: 0.95rem;
+}
+
+.focusAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--ui-accent-strong);
+}
+
+.libraryHeader {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.filterGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.filterButton {
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: transparent;
+  color: var(--ui-text-secondary);
+  font-weight: 600;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.filterButton[data-active='true'] {
+  background: var(--ui-highlight);
+  color: var(--ui-text-inverse);
+  border-color: transparent;
+  box-shadow: 0 16px 45px -28px rgba(79, 70, 229, 0.55);
+}
+
+.lessonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-strong);
+}
+
+.groupHeader {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.groupTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.groupDescription {
+  margin: 6px 0 0;
+  color: var(--ui-text-secondary);
+}
+
+.groupCount {
+  border-radius: var(--ui-radius-pill);
+  padding: 8px 18px;
+  background: var(--ui-surface-muted);
+  border: 1px solid var(--ui-border);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+}
+
+.lessonGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.lessonCard {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  text-decoration: none;
+  box-shadow: var(--ui-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.lessonCard:hover,
+.lessonCard:focus-visible {
+  transform: translateY(-3px);
+  border-color: var(--ui-accent);
+  box-shadow: var(--ui-shadow-strong);
+}
+
+.lessonMeta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: var(--ui-text-muted);
+}
+
+.lessonTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ui-text-primary);
+}
+
+.lessonTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lessonTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--ui-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.lessonLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ui-accent-strong);
+  font-weight: 600;
+}
+
+.emptyState {
+  border: 1px dashed var(--ui-border);
+  padding: 18px;
+  border-radius: var(--ui-radius-lg);
+  background: rgba(15, 23, 42, 0.03);
+  color: var(--ui-text-secondary);
+}
+
+.topicsCloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.topicTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid rgba(14, 165, 233, 0.35);
+  background: rgba(14, 165, 233, 0.12);
+  color: #0e7490;
+  font-weight: 600;
+}
+
+.topicCount {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(14, 165, 233, 0.22);
+  font-size: 0.75rem;
+}
+
+@media (max-width: 1100px) {
+  .hero {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .heroStats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .heroTitle {
+    font-size: 2.1rem;
+  }
+
+  .heroStats {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .focusGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lessonGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { db } from '../db';
 import { Lesson } from '../lib/schemas';
 import { isDue } from '../lib/srs';
+import styles from './Home.module.css';
 
 interface LibraryStats {
   totalLessons: number;
@@ -129,157 +130,100 @@ export const HomePage: React.FC = () => {
   const roundedProgress = Math.round(stats.progress);
 
   return (
-    <div className="space-y-12" aria-labelledby="home-heading">
-      <section
-        className="relative overflow-hidden rounded-3xl border border-blue-100/80 bg-gradient-to-br from-blue-600 via-indigo-600 to-blue-700 p-8 text-white shadow-2xl"
-        aria-labelledby="home-heading"
-      >
-        <div className="absolute inset-y-0 left-1/2 h-full w-[480px] -translate-x-1/2 rounded-full bg-blue-500/30 blur-3xl" aria-hidden="true" />
-        <div className="absolute -right-32 bottom-[-180px] h-[420px] w-[420px] rounded-full bg-emerald-400/30 blur-3xl" aria-hidden="true" />
-        <div className="relative z-10 grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-          <div className="space-y-6">
-            <p className="text-sm font-semibold uppercase tracking-[0.4em] text-blue-100/80">Plan with intention</p>
-            <h1 id="home-heading" className="text-4xl font-bold leading-snug">
-              Your bilingual study coach for structured B1–C1 Spanish practice
-            </h1>
-            <p className="max-w-xl text-base text-blue-50/90" aria-live="polite">
-              Scan progress, pick a lesson, and drill the right flashcards—all in one organised workspace that
-              works online or offline.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <a
-                href="#lesson-library"
-                className="inline-flex items-center gap-2 rounded-full bg-white/95 px-5 py-2 text-sm font-semibold text-blue-700 shadow-lg shadow-blue-900/20 transition hover:bg-white focus-visible:ring"
-              >
-                Browse lesson library
-                <span aria-hidden="true" className="text-base">
-                  ↗
-                </span>
-              </a>
-              <Link
-                to="/dashboard"
-                className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-transparent px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring"
-              >
-                Check progress dashboard
-                <span aria-hidden="true" className="text-base">
-                  →
-                </span>
-              </Link>
-            </div>
-            <div className="flex flex-wrap gap-3 text-[11px] font-semibold uppercase tracking-[0.45em] text-blue-100/70">
-              <span className="inline-flex items-center rounded-full border border-blue-200/70 bg-blue-500/40 px-3 py-1">
-                Study smarter
-              </span>
-              <span className="inline-flex items-center rounded-full border border-blue-200/60 bg-blue-500/30 px-3 py-1">
-                Offline ready
-              </span>
-              <span className="inline-flex items-center rounded-full border border-blue-200/60 bg-blue-500/30 px-3 py-1">
-                B1 · C1
-              </span>
-            </div>
+    <div className={styles.page} aria-labelledby="home-heading">
+      <section className={`ui-card ui-card--accent ${styles.hero}`} aria-labelledby="home-heading">
+        <div className={styles.heroContent}>
+          <p className={styles.heroTag}>Plan with intention</p>
+          <h1 id="home-heading" className={styles.heroTitle}>
+            Your bilingual study coach for structured B1–C1 Spanish practice
+          </h1>
+          <p className={styles.heroDescription} aria-live="polite">
+            Scan progress, pick a lesson, and drill the right flashcards — all in one organised workspace that works online or offline.
+          </p>
+          <div className={styles.heroActions}>
+            <a href="#lesson-library" className="ui-button ui-button--primary">
+              Browse lesson library ↗
+            </a>
+            <Link to="/dashboard" className="ui-button ui-button--ghost">
+              Check progress dashboard →
+            </Link>
           </div>
-          <dl className="grid gap-4 sm:grid-cols-2" aria-label="Study stats">
-            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Lessons imported</dt>
-              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
-                {stats.totalLessons}
-              </dd>
-              <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white/10 to-transparent" aria-hidden="true" />
-            </div>
-            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Practice items</dt>
-              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
-                {stats.totalExercises}
-              </dd>
-            </div>
-            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Mastery progress</dt>
-              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
-                {roundedProgress}%
-              </dd>
-            </div>
-            <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 shadow-lg shadow-blue-900/30">
-              <dt className="text-xs font-semibold uppercase tracking-widest text-blue-100/80">Due flashcards</dt>
-              <dd className="mt-2 text-3xl font-bold text-white" aria-live="polite">
-                {stats.dueCards}
-              </dd>
-              <p className="mt-2 text-xs uppercase tracking-[0.3em] text-blue-100/70">Ready for a sprint</p>
-            </div>
-          </dl>
+          <div className={styles.heroChips}>
+            <span className="ui-chip">Study smarter</span>
+            <span className="ui-chip">Offline ready</span>
+            <span className="ui-chip">B1 · C1</span>
+          </div>
         </div>
+        <dl className={styles.heroStats} aria-label="Study stats">
+          <div className={styles.heroStatsItem}>
+            <dt>Lessons imported</dt>
+            <dd aria-live="polite">{stats.totalLessons}</dd>
+          </div>
+          <div className={styles.heroStatsItem}>
+            <dt>Practice items</dt>
+            <dd aria-live="polite">{stats.totalExercises}</dd>
+          </div>
+          <div className={styles.heroStatsItem}>
+            <dt>Mastery progress</dt>
+            <dd aria-live="polite">{roundedProgress}%</dd>
+          </div>
+          <div className={styles.heroStatsItem}>
+            <dt>Due flashcards</dt>
+            <dd aria-live="polite">{stats.dueCards}</dd>
+          </div>
+        </dl>
       </section>
 
-      <section
-        className="space-y-6 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-xl shadow-slate-200/60 backdrop-blur"
-        aria-labelledby="focus-heading"
-      >
-        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+      <section className="ui-card" aria-labelledby="focus-heading">
+        <div className="ui-section">
           <div>
-            <h2 id="focus-heading" className="text-2xl font-semibold text-slate-900">
-              Today’s focus loop
+            <p className="ui-section__tag">Today’s focus loop</p>
+            <h2 id="focus-heading" className="ui-section__title">
+              Keep your speaking, writing, and recall sharp
             </h2>
-            <p className="text-sm text-slate-600">
-              Cycle through these steps to keep your speaking, writing, and recall sharp.
+            <p className="ui-section__subtitle">
+              Cycle through these steps to keep your Spanish practice feeling like a Duolingo streak with pro-level depth.
             </p>
           </div>
-          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.35em] text-slate-400">
-            <span className="rounded-full border border-slate-200 px-3 py-1">Plan → Learn → Review</span>
-          </div>
         </div>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className={styles.focusGrid}>
           {focusSteps.map(({ title, description, actionLabel, to, anchor }) => {
             const ActionComponent = (to ? Link : 'a') as React.ElementType;
             const actionProps = to ? { to } : { href: anchor ?? '#' };
             return (
-              <article
-                key={title}
-                className="group relative flex h-full flex-col justify-between gap-4 overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-xl"
-              >
-                <div className="space-y-3">
-                  <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-                  <p className="text-sm text-slate-600">{description}</p>
+              <article key={title} className={styles.focusCard}>
+                <div>
+                  <h3>{title}</h3>
+                  <p>{description}</p>
                 </div>
-                <ActionComponent
-                  className="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 transition group-hover:text-blue-600 focus-visible:ring"
-                  {...actionProps}
-                >
-                  {actionLabel}
-                  <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
-                    →
-                  </span>
+                <ActionComponent className={styles.focusAction} {...actionProps}>
+                  {actionLabel} →
                 </ActionComponent>
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 translate-y-12 rounded-t-full bg-gradient-to-t from-blue-100/30 via-transparent" aria-hidden="true" />
               </article>
             );
           })}
         </div>
       </section>
 
-      <section
-        id="lesson-library"
-        className="space-y-6 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-xl shadow-slate-200/50 backdrop-blur"
-        aria-labelledby="library-heading"
-      >
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <section id="lesson-library" className="ui-card" aria-labelledby="library-heading">
+        <div className={styles.libraryHeader}>
           <div>
-            <h2 id="library-heading" className="text-2xl font-semibold text-slate-900">
-              Lesson library
+            <p className="ui-section__tag">Lesson library</p>
+            <h2 id="library-heading" className="ui-section__title">
+              Match today’s focus with the right material
             </h2>
-            <p className="text-sm text-slate-600">
-              Organised by CEFR level so you can match today’s focus with the right material.
+            <p className="ui-section__subtitle">
+              Organised by CEFR level so you can pick the objective that fits your next conversation or presentation.
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className={styles.filterGroup}>
             {(['all', 'B1', 'C1'] as const).map((filter) => (
               <button
                 key={filter}
                 type="button"
                 onClick={() => setLibraryFilter(filter)}
-                className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-semibold transition focus-visible:ring ${
-                  libraryFilter === filter
-                    ? 'border-blue-500 bg-blue-600 text-white shadow'
-                    : 'border-slate-200 bg-white text-slate-600 hover:border-blue-200 hover:text-blue-700'
-                }`}
+                className={styles.filterButton}
+                data-active={libraryFilter === filter}
               >
                 {filter === 'all' ? 'All levels' : `Level ${filter}`}
               </button>
@@ -287,110 +231,82 @@ export const HomePage: React.FC = () => {
           </div>
         </div>
         {lessons.length === 0 ? (
-          <p
-            className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-5 text-sm text-slate-600"
-            aria-live="polite"
-          >
+          <p className={styles.emptyState} aria-live="polite">
             No lessons imported yet. Use the Content manager to add the latest content drop.
           </p>
         ) : (
           filteredGroups.map(({ level, title, description, lessons: groupLessons }) => (
-            <article key={level} className="space-y-4 rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm">
-              <header className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-                <div className="space-y-1">
-                  <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-                  <p className="text-sm text-slate-600">{description}</p>
+            <article key={level} className={styles.lessonGroup}>
+              <header className={styles.groupHeader}>
+                <div>
+                  <h3 className={styles.groupTitle}>{title}</h3>
+                  <p className={styles.groupDescription}>{description}</p>
                 </div>
-                <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                <span className={styles.groupCount}>
                   {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
                 </span>
               </header>
               {groupLessons.length > 0 ? (
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className={styles.lessonGrid}>
                   {groupLessons.map((lesson) => {
                     const count = exerciseCounts[lesson.id] ?? 0;
                     return (
-                      <Link
-                        key={lesson.id}
-                        to={`/lessons/${lesson.slug}`}
-                        className="group relative flex h-full flex-col justify-between gap-4 overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-4 text-left shadow-sm transition hover:-translate-y-1 hover:border-blue-400 hover:shadow-xl focus-visible:ring"
-                      >
-                        <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
-                          <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">Level {lesson.level}</span>
-                          <span className="rounded-full bg-blue-50 px-2 py-1 text-blue-600">
-                            {count} practice {count === 1 ? 'item' : 'items'}
-                          </span>
+                      <Link key={lesson.id} to={`/lessons/${lesson.slug}`} className={styles.lessonCard}>
+                        <div className={styles.lessonMeta}>
+                          <span>Level {lesson.level}</span>
+                          <span>{count} practice {count === 1 ? 'item' : 'items'}</span>
                         </div>
-                        <div className="space-y-2">
-                          <h4 className="text-base font-semibold text-slate-900">{lesson.title}</h4>
-                          <div className="flex flex-wrap gap-2" aria-label={`Tags for ${lesson.title}`}>
+                        <div>
+                          <h4 className={styles.lessonTitle}>{lesson.title}</h4>
+                          <div className={styles.lessonTags} aria-label={`Tags for ${lesson.title}`}>
                             {lesson.tags.slice(0, 3).map((tag) => (
-                              <span
-                                key={tag}
-                                className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600"
-                              >
+                              <span key={tag} className={styles.lessonTag}>
                                 {tag}
                               </span>
                             ))}
-                            {lesson.tags.length === 0 && (
-                              <span className="text-xs text-slate-400">No tags yet</span>
-                            )}
+                            {lesson.tags.length === 0 && <span className={styles.lessonTag}>No tags yet</span>}
                             {lesson.tags.length > 3 && (
-                              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">
-                                +{lesson.tags.length - 3}
-                              </span>
+                              <span className={styles.lessonTag}>+{lesson.tags.length - 3}</span>
                             )}
                           </div>
                         </div>
-                        <span className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 transition group-hover:translate-x-1">
-                          Open lesson
-                          <span aria-hidden="true">→</span>
+                        <span className={styles.lessonLink}>
+                          Open lesson →
                         </span>
-                        <div
-                          className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 translate-y-12 bg-gradient-to-t from-blue-100/30 via-transparent transition group-hover:translate-y-6"
-                          aria-hidden="true"
-                        />
                       </Link>
                     );
                   })}
                 </div>
               ) : (
-                <p className="text-sm text-slate-600">No lessons imported for this level yet.</p>
+                <p className={styles.emptyState}>No lessons imported for this level yet.</p>
               )}
             </article>
           ))
         )}
       </section>
 
-      <section
-        className="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-xl shadow-slate-200/50 backdrop-blur"
-        aria-labelledby="tag-heading"
-      >
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <h2 id="tag-heading" className="text-xl font-semibold text-slate-900">
-            Topics on your radar
-          </h2>
-          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Mix your sessions</p>
+      <section className="ui-card" aria-labelledby="tag-heading">
+        <div className="ui-section">
+          <div>
+            <p className="ui-section__tag">Topics on your radar</p>
+            <h2 id="tag-heading" className="ui-section__title">
+              Mix your sessions
+            </h2>
+          </div>
         </div>
         {topTags.length > 0 ? (
-          <div className="mt-4 flex flex-wrap gap-3">
+          <div className={styles.topicsCloud}>
             {topTags.map(([tag, count]) => (
-              <span
-                key={tag}
-                className="inline-flex items-center gap-2 rounded-full border border-blue-200/80 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 shadow-sm"
-                title={`${count} lesson${count === 1 ? '' : 's'}`}
-              >
+              <span key={tag} className={styles.topicTag} title={`${count} lesson${count === 1 ? '' : 's'}`}>
                 <span>{tag}</span>
-                <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-600">×{count}</span>
+                <span className={styles.topicCount}>×{count}</span>
               </span>
             ))}
           </div>
         ) : (
-          <p className="mt-4 text-sm text-slate-600">
+          <p className={styles.emptyState}>
             Tags will appear once you import lessons.{' '}
-            <Link to="/content-manager" className="text-blue-700 underline focus-visible:ring">
-              Add a content bundle to get started.
-            </Link>
+            <Link to="/content-manager">Add a content bundle to get started.</Link>
           </p>
         )}
       </section>

--- a/src/pages/LessonPage.module.css
+++ b/src/pages/LessonPage.module.css
@@ -1,0 +1,123 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--ui-radius-xl);
+  padding: 32px;
+  background: linear-gradient(135deg, #2563eb, #7c3aed, #db2777);
+  color: #f8fafc;
+  box-shadow: 0 30px 70px -45px rgba(76, 29, 149, 0.6);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 10%, rgba(255, 255, 255, 0.25), transparent 60%);
+  pointer-events: none;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.heroTop {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.heroTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.heroTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(255, 255, 255, 0.2);
+  font-weight: 600;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.mainSections {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.lessonCard {
+  border-radius: var(--ui-radius-xl);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-strong);
+  box-shadow: var(--ui-shadow);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sidebarSection {
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  padding: 20px;
+  box-shadow: var(--ui-shadow);
+}
+
+.sidebarList {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 24px;
+  }
+
+  .lessonCard {
+    padding: 20px;
+  }
+}

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -4,6 +4,7 @@ import { db } from '../db';
 import { Exercise, Lesson } from '../lib/schemas';
 import { LessonViewer } from '../components/LessonViewer';
 import { ExerciseEngine } from '../components/ExerciseEngine';
+import styles from './LessonPage.module.css';
 
 const LessonPage: React.FC = () => {
   const { slug } = useParams();
@@ -35,7 +36,7 @@ const LessonPage: React.FC = () => {
 
   if (status === 'loading') {
     return (
-      <p role="status" className="italic">
+      <p role="status" className="ui-alert ui-alert--info">
         Loading lesson…
       </p>
     );
@@ -43,90 +44,69 @@ const LessonPage: React.FC = () => {
 
   if (status === 'missing' || !lesson) {
     return (
-      <p role="alert" className="text-red-600">
+      <p role="alert" className="ui-alert ui-alert--danger">
         Lesson not found. Import the latest content drop to continue.
       </p>
     );
   }
 
   return (
-    <article className="space-y-10" aria-labelledby="lesson-title">
-      <header
-        className="relative overflow-hidden rounded-3xl border border-blue-100/80 bg-gradient-to-br from-blue-600 via-indigo-600 to-blue-700 p-8 text-white shadow-2xl"
-      >
-        <div className="absolute inset-y-0 right-[-160px] h-[420px] w-[420px] rounded-full bg-blue-400/40 blur-3xl" aria-hidden="true" />
-        <div className="relative z-10 space-y-5">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <Link
-              to="/"
-              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-100 transition hover:text-white focus-visible:ring"
-            >
+    <article className={styles.page} aria-labelledby="lesson-title">
+      <header className={styles.hero}>
+        <div className={styles.heroContent}>
+          <div className={styles.heroTop}>
+            <Link to="/" className="ui-button ui-button--ghost">
               ← Back to overview
             </Link>
-            <span className="inline-flex items-center rounded-full border border-white/40 bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white">
-              Level {lesson.level}
-            </span>
+            <span className="ui-chip">Level {lesson.level}</span>
           </div>
-          <div className="space-y-4">
-            <h1 id="lesson-title" className="text-4xl font-bold leading-tight">
+          <div>
+            <h1 id="lesson-title" className="ui-section__title" style={{ color: '#f8fafc' }}>
               {lesson.title}
             </h1>
-            <div className="flex flex-wrap gap-2" aria-label="Lesson tags">
-              {lesson.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center rounded-full border border-white/30 bg-white/20 px-3 py-1 text-xs font-semibold text-white"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <p className="text-sm text-blue-100/90">
+            <p className="ui-section__subtitle" style={{ color: 'rgba(241, 245, 249, 0.85)' }}>
               {exercises.length > 0
                 ? `${exercises.length} practice activit${exercises.length === 1 ? 'y' : 'ies'} ready to log.`
                 : 'Review the notes, then import a practice set to track mastery.'}
             </p>
           </div>
-          <div className="flex flex-wrap gap-3">
-            <a
-              href="#lesson-exercises-heading"
-              className="inline-flex items-center gap-2 rounded-full bg-white/95 px-4 py-2 text-sm font-semibold text-blue-700 shadow-lg shadow-blue-900/30 transition hover:bg-white focus-visible:ring"
-            >
-              Jump to practise
-              <span aria-hidden="true">↓</span>
+          <div className={styles.heroTags} aria-label="Lesson tags">
+            {lesson.tags.length > 0 ? (
+              lesson.tags.map((tag) => (
+                <span key={tag} className={styles.heroTag}>
+                  {tag}
+                </span>
+              ))
+            ) : (
+              <span className={styles.heroTag}>No tags yet</span>
+            )}
+          </div>
+          <div className={styles.heroActions}>
+            <a href="#lesson-exercises-heading" className="ui-button ui-button--primary">
+              Jump to practise ↓
             </a>
-            <Link
-              to="/flashcards"
-              className="inline-flex items-center gap-2 rounded-full border border-white/60 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring"
-            >
-              Start flashcard sprint
-              <span aria-hidden="true">→</span>
+            <Link to="/flashcards" className="ui-button ui-button--secondary">
+              Start flashcard sprint →
             </Link>
           </div>
         </div>
       </header>
 
-      <div className="grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-        <div className="space-y-10">
-          <section
-            className="space-y-4 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-sm"
-            aria-labelledby="lesson-content-heading"
-          >
-            <h2 id="lesson-content-heading" className="text-xl font-semibold text-slate-900">
+      <div className={styles.layout}>
+        <div className={styles.mainSections}>
+          <section className={styles.lessonCard} aria-labelledby="lesson-content-heading">
+            <h2 id="lesson-content-heading" className="ui-section__title">
               Lesson content
             </h2>
             <LessonViewer markdown={lesson.markdown} />
           </section>
 
-          <section
-            className="space-y-5 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-sm"
-            aria-labelledby="lesson-exercises-heading"
-          >
-            <div className="space-y-2">
-              <h2 id="lesson-exercises-heading" className="text-xl font-semibold text-slate-900">
+          <section className={styles.lessonCard} aria-labelledby="lesson-exercises-heading">
+            <div>
+              <h2 id="lesson-exercises-heading" className="ui-section__title">
                 Practise the lesson
               </h2>
-              <p className="text-sm text-slate-600">
+              <p className="ui-section__subtitle">
                 Work through each prompt to log attempts and unlock mastery progress.
               </p>
             </div>
@@ -136,36 +116,35 @@ const LessonPage: React.FC = () => {
               </div>
             ))}
             {exercises.length === 0 && (
-              <p role="status" className="text-sm italic text-slate-600">
+              <p role="status" className="ui-alert ui-alert--info">
                 No exercises found for this lesson yet.
               </p>
             )}
           </section>
         </div>
 
-        <aside className="space-y-4 rounded-3xl border border-slate-200/80 bg-white/90 p-6 shadow-sm" aria-label="Study guidance">
-          <section className="space-y-3">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-slate-500">Study roadmap</h2>
-            <ol className="space-y-2 text-sm text-slate-600">
+        <aside className={styles.sidebar} aria-label="Study guidance">
+          <section className={styles.sidebarSection}>
+            <span className="ui-section__tag">Study roadmap</span>
+            <ol className={styles.sidebarList}>
               <li>Skim the key idea and underline new connectors or discourse markers.</li>
               <li>Complete the practice set, logging hints and timings for the dashboard.</li>
               <li>Finish with a flashcard sprint to reinforce the phrases you want to reuse.</li>
             </ol>
           </section>
-          <section className="space-y-2 text-sm text-slate-600">
-            <p>Need a quick spaced-repetition loop after this lesson?</p>
-            <Link
-              to="/flashcards"
-              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 transition hover:text-blue-600 focus-visible:ring"
-            >
-              Jump to the flashcard trainer
-              <span aria-hidden="true">↗</span>
+          <section className={styles.sidebarSection}>
+            <span className="ui-section__tag">Need a quick loop?</span>
+            <p className="ui-section__subtitle">
+              Jump to the flashcard trainer once you finish the exercises to cement new phrases.
+            </p>
+            <Link to="/flashcards" className="ui-button ui-button--secondary">
+              Flashcard trainer ↗
             </Link>
           </section>
           {lesson.references?.length ? (
-            <section className="space-y-2">
-              <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-slate-500">References</h2>
-              <ul className="space-y-1 text-sm text-slate-600">
+            <section className={styles.sidebarSection}>
+              <span className="ui-section__tag">References</span>
+              <ul className={styles.sidebarList}>
                 {lesson.references.map((reference, index) => (
                   <li key={`${reference}-${index}`}>{reference}</li>
                 ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,107 +1,489 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Nunito:wght@600;700;800&display=swap');
+
 :root {
   color-scheme: light;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.5;
+  --ui-bg: radial-gradient(circle at 0% 0%, rgba(94, 234, 212, 0.25), transparent 60%),
+    radial-gradient(circle at 90% 0%, rgba(196, 181, 253, 0.28), transparent 55%),
+    linear-gradient(145deg, #f8fbff, #eef6ff 45%, #f7f5ff 100%);
+  --ui-surface: rgba(255, 255, 255, 0.86);
+  --ui-surface-strong: rgba(255, 255, 255, 0.94);
+  --ui-surface-muted: rgba(255, 255, 255, 0.72);
+  --ui-border: rgba(15, 23, 42, 0.12);
+  --ui-border-strong: rgba(15, 23, 42, 0.18);
+  --ui-border-muted: rgba(148, 163, 184, 0.18);
+  --ui-shadow: 0 28px 80px -48px rgba(15, 23, 42, 0.55);
+  --ui-shadow-strong: 0 40px 100px -60px rgba(30, 64, 175, 0.55);
+  --ui-text-primary: #0f172a;
+  --ui-text-secondary: #475569;
+  --ui-text-inverse: #0f172a;
+  --ui-text-muted: #64748b;
+  --ui-accent: #22c55e;
+  --ui-accent-strong: #16a34a;
+  --ui-accent-soft: rgba(34, 197, 94, 0.18);
+  --ui-highlight: linear-gradient(135deg, #22d3ee, #60a5fa, #a855f7, #f472b6);
+  --ui-highlight-secondary: linear-gradient(135deg, #22c55e, #10b981, #0ea5e9);
+  --ui-focus: rgba(96, 165, 250, 0.6);
+  --ui-radius-sm: 12px;
+  --ui-radius-md: 18px;
+  --ui-radius-lg: 26px;
+  --ui-radius-xl: 32px;
+  --ui-radius-pill: 999px;
+  --ui-font-display: 'Nunito', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --ui-font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 body {
   margin: 0;
-  background: #f9fafb;
-  color: #111827;
+  background: var(--ui-bg);
+  background-attachment: fixed;
+  color: var(--ui-text-primary);
+  font-family: var(--ui-font-body);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+body.high-contrast {
+  color-scheme: dark;
+  --ui-bg: radial-gradient(circle at 0% 0%, rgba(251, 191, 36, 0.18), transparent 65%),
+    radial-gradient(circle at 85% 10%, rgba(248, 113, 113, 0.18), transparent 60%),
+    linear-gradient(150deg, #020617, #000000 55%, #030712 100%);
+  --ui-surface: rgba(15, 23, 42, 0.92);
+  --ui-surface-strong: rgba(15, 23, 42, 0.96);
+  --ui-surface-muted: rgba(15, 23, 42, 0.85);
+  --ui-border: rgba(226, 232, 240, 0.32);
+  --ui-border-strong: rgba(226, 232, 240, 0.48);
+  --ui-border-muted: rgba(148, 163, 184, 0.35);
+  --ui-shadow: 0 32px 90px -50px rgba(15, 23, 42, 0.9);
+  --ui-shadow-strong: 0 45px 120px -70px rgba(254, 215, 102, 0.45);
+  --ui-text-primary: #f8fafc;
+  --ui-text-secondary: #dbeafe;
+  --ui-text-inverse: #020617;
+  --ui-text-muted: #94a3b8;
+  --ui-accent: #facc15;
+  --ui-accent-strong: #fbbf24;
+  --ui-accent-soft: rgba(250, 204, 21, 0.2);
+  --ui-highlight: linear-gradient(135deg, #fde047, #f97316, #fb7185);
+  --ui-highlight-secondary: linear-gradient(135deg, #facc15, #f97316, #ef4444);
+  --ui-focus: rgba(250, 204, 21, 0.55);
 }
 
 a {
-  color: #1d4ed8;
+  color: inherit;
   text-decoration: none;
 }
 
 a:hover,
-a:focus {
+a:focus-visible {
+  color: inherit;
   text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
 
 button {
-  font: inherit;
-  cursor: pointer;
+  font-family: inherit;
+  font-size: 1rem;
 }
 
 .skip-link {
   position: absolute;
   left: -999px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  z-index: -1000;
-}
-
-.skip-link:focus {
-  left: 1rem;
   top: 1rem;
-  width: auto;
-  height: auto;
-  padding: 0.5rem 1rem;
-  background: #1d4ed8;
-  color: #ffffff;
-  border-radius: 0.375rem;
+  padding: 0.65rem 1.25rem;
+  background: var(--ui-highlight);
+  color: var(--ui-text-inverse);
+  border-radius: var(--ui-radius-pill);
+  font-weight: 600;
+  letter-spacing: 0.05em;
   z-index: 1000;
 }
 
-.high-contrast,
-body.high-contrast {
-  background: #000000;
-  color: #ffffff;
+.skip-link:focus-visible {
+  left: 1rem;
+  outline: 3px solid var(--ui-focus);
+  outline-offset: 3px;
 }
 
-.high-contrast a,
-body.high-contrast a {
-  color: #66e3ff;
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
-.high-contrast button,
-body.high-contrast button {
-  background: #000000;
-  color: #ffffff;
-  border: 2px solid #ffffff;
+.ui-max-width {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
 }
 
-.high-contrast .border,
-body.high-contrast .border {
-  border-color: #f8fafc !important;
+.ui-card {
+  background: var(--ui-surface);
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  padding: 24px;
+  box-shadow: var(--ui-shadow);
+  backdrop-filter: blur(18px);
+  color: var(--ui-text-primary);
 }
 
-.high-contrast .bg-gray-50,
-body.high-contrast .bg-gray-50 {
-  background-color: #111111 !important;
+.ui-card--compact {
+  padding: 20px;
 }
 
-.high-contrast .bg-gray-100,
-body.high-contrast .bg-gray-100 {
-  background-color: #1f1f1f !important;
+.ui-card--muted {
+  background: var(--ui-surface-muted);
+  border-color: var(--ui-border-muted);
 }
 
-.high-contrast .text-gray-600,
-body.high-contrast .text-gray-600 {
-  color: #d1d5db !important;
+.ui-card--strong {
+  background: var(--ui-surface-strong);
+  border-color: var(--ui-border-strong);
+  box-shadow: var(--ui-shadow-strong);
 }
 
-.high-contrast .text-gray-900,
-body.high-contrast .text-gray-900 {
-  color: #f9fafb !important;
+.ui-card--accent {
+  background: var(--ui-highlight-secondary);
+  border: none;
+  color: #ecfdf5;
+  box-shadow: 0 25px 60px -40px rgba(16, 185, 129, 0.65);
 }
 
-.high-contrast .shadow-sm,
-body.high-contrast .shadow-sm {
-  box-shadow: 0 0 0 1px #ffffff inset;
+body.high-contrast .ui-card--accent {
+  color: #020617;
+  box-shadow: 0 25px 70px -45px rgba(250, 204, 21, 0.4);
 }
 
-.focus-visible\:ring:focus-visible {
-  outline: 3px solid #2563eb;
-  outline-offset: 2px;
+.ui-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 14px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
-.high-contrast .focus-visible\:ring:focus-visible,
-body.high-contrast .focus-visible\:ring:focus-visible {
-  outline: 3px solid #ffb400;
-  outline-offset: 2px;
+.ui-chip--muted {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--ui-text-muted);
+}
+
+.ui-chip--outline {
+  border: 1px solid var(--ui-border);
+  background: transparent;
+  color: var(--ui-text-secondary);
+}
+
+.ui-pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ui-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid transparent;
+  padding: 0.7rem 1.6rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  background: var(--ui-surface);
+  color: var(--ui-text-primary);
+}
+
+.ui-button--primary {
+  background: var(--ui-highlight);
+  color: var(--ui-text-inverse);
+  box-shadow: 0 18px 45px -28px rgba(79, 70, 229, 0.6);
+}
+
+body.high-contrast .ui-button--primary {
+  color: var(--ui-text-inverse);
+  box-shadow: 0 18px 45px -28px rgba(250, 204, 21, 0.5);
+}
+
+.ui-button--secondary {
+  background: transparent;
+  border-color: var(--ui-border);
+  color: var(--ui-text-primary);
+}
+
+.ui-button--secondary:hover,
+.ui-button--secondary:focus-visible {
+  border-color: var(--ui-accent);
+  color: var(--ui-accent-strong);
+}
+
+.ui-button--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--ui-text-secondary);
+}
+
+.ui-button:focus-visible {
+  outline: 3px solid var(--ui-focus);
+  outline-offset: 3px;
+}
+
+.ui-button:hover {
+  transform: translateY(-2px);
+}
+
+.ui-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ui-section__title {
+  font-family: var(--ui-font-display);
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.ui-section__subtitle {
+  font-size: 0.95rem;
+  color: var(--ui-text-secondary);
+  max-width: 56ch;
+}
+
+.ui-section__tag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-weight: 700;
+  color: var(--ui-text-muted);
+}
+
+.ui-stat-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.ui-stat-card {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: var(--ui-radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  padding: 20px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+
+body.high-contrast .ui-stat-card {
+  background: rgba(2, 6, 23, 0.5);
+  border-color: rgba(250, 204, 21, 0.25);
+}
+
+.ui-stat-card strong {
+  display: block;
+  font-family: var(--ui-font-display);
+  font-size: 2.2rem;
+  margin-top: 6px;
+}
+
+.ui-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.ui-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: var(--ui-radius-pill);
+  padding: 6px 14px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--ui-text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.ui-alert {
+  border-radius: var(--ui-radius-md);
+  padding: 16px 20px;
+  font-size: 0.9rem;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-muted);
+  color: var(--ui-text-primary);
+}
+
+.ui-alert--info {
+  border-color: rgba(37, 99, 235, 0.35);
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+}
+
+.ui-alert--danger {
+  border-color: rgba(244, 63, 94, 0.35);
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+}
+
+body.high-contrast .ui-alert--info {
+  color: #60a5fa;
+  border-color: rgba(191, 219, 254, 0.5);
+  background: rgba(59, 130, 246, 0.16);
+}
+
+body.high-contrast .ui-alert--danger {
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.ui-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid var(--ui-border);
+}
+
+.ui-table thead {
+  background: rgba(148, 163, 184, 0.12);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: var(--ui-text-secondary);
+}
+
+.ui-table th,
+.ui-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--ui-border-muted);
+}
+
+.ui-table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.03);
+}
+
+body.high-contrast .ui-table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+input,
+textarea,
+select {
+  font-family: inherit;
+  font-size: 0.95rem;
+  background: var(--ui-surface-strong);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius-md);
+  padding: 0.7rem 1rem;
+  color: var(--ui-text-primary);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: none;
+  border-color: var(--ui-accent);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+body.high-contrast input:focus-visible,
+body.high-contrast textarea:focus-visible,
+body.high-contrast select:focus-visible {
+  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.25);
+}
+
+code {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 6px;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.85rem;
+}
+
+body.high-contrast code {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.prose {
+  max-width: none;
+  font-size: 1rem;
+  color: var(--ui-text-primary);
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+  font-family: var(--ui-font-display);
+  color: var(--ui-text-primary);
+  letter-spacing: -0.01em;
+}
+
+.prose h1 { font-size: 2rem; }
+.prose h2 { font-size: 1.6rem; }
+.prose h3 { font-size: 1.3rem; }
+.prose h4 { font-size: 1.1rem; }
+
+.prose p {
+  color: var(--ui-text-secondary);
+  margin: 1rem 0;
+}
+
+.prose ul,
+.prose ol {
+  margin: 1rem 0;
+  padding-left: 1.4rem;
+  color: var(--ui-text-secondary);
+}
+
+.prose blockquote {
+  border-left: 4px solid var(--ui-accent);
+  margin: 1rem 0;
+  padding-left: 1rem;
+  color: var(--ui-text-secondary);
+  font-style: italic;
+}
+
+.prose a {
+  color: var(--ui-accent-strong);
+  text-decoration: none;
+}
+
+.prose a:hover,
+.prose a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .ui-card {
+    border-radius: var(--ui-radius-md);
+    padding: 20px;
+  }
+
+  .ui-stat-card {
+    padding: 16px;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    background-attachment: scroll;
+  }
+
+  .skip-link:focus-visible {
+    left: 0.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- replace placeholder tailwind classes with handcrafted design tokens and CSS modules across the shell, pages, and shared components for a Duolingo/Instagram-inspired look
- restyle learning flows including the lesson view, flashcard trainer, dashboard, and content manager with glassmorphism cards, vibrant gradients, and reusable utility classes
- refresh global theme tokens and high-contrast support while keeping accessibility features like alerts, skip links, and keyboard hints intact

## Testing
- npm test -- --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceaa9a0ba08324a6202a3f9f6359a0