### PR TITLE
Seed app database on startup and refresh offline cache

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { db } from './db';
+import { ensureSeedData } from './seed';
 import './styles/global.css';
 
 const container = document.getElementById('root');
@@ -8,11 +10,46 @@ if (!container) {
   throw new Error('Root element not found');
 }
 
-ReactDOM.createRoot(container).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const renderApp = () => {
+  ReactDOM.createRoot(container).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+};
+
+const refreshOfflineCache = async () => {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+  try {
+    const [lessons, exercises] = await Promise.all([
+      db.lessons.toArray(),
+      db.exercises.toArray(),
+    ]);
+    const registration = await navigator.serviceWorker.ready;
+    registration.active?.postMessage({
+      type: 'CACHE_DATA',
+      lessons,
+      exercises,
+    });
+  } catch (error) {
+    console.warn('Unable to refresh offline cache after seeding', error);
+  }
+};
+
+const bootstrap = async () => {
+  try {
+    const result = await ensureSeedData();
+    if (result.seeded) {
+      await refreshOfflineCache();
+    }
+  } catch (error) {
+    console.error('Failed to ensure initial seed data', error);
+  } finally {
+    renderApp();
+  }
+};
+
+void bootstrap();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,14 +1,8 @@
-import { db } from './db';
-import { LessonSchema, ExerciseSchema, FlashcardSchema } from './lib/schemas';
-
-export const importSeed = async (data: {
-  lessons: any[], exercises: any[], flashcards: any[]
-}) => {
-  const lessons = data.lessons.map(l => LessonSchema.parse(l));
-  const exercises = data.exercises.map(e => ExerciseSchema.parse(e));
-  const flashcards = data.flashcards.map(f => FlashcardSchema.parse(f));
-
-  await db.lessons.bulkPut(lessons);
-  await db.exercises.bulkPut(exercises);
-  await db.flashcards.bulkPut(flashcards);
-};
+export { importSeed } from './seed/importSeed';
+export {
+  ensureSeedData,
+  DEFAULT_SEED_VERSION,
+  SEED_VERSION_KEY,
+  CUSTOM_SEED_MARKER,
+  type SeedResult,
+} from './seed/ensureSeedData';

--- a/src/seed/ensureSeedData.ts
+++ b/src/seed/ensureSeedData.ts
@@ -1,0 +1,157 @@
+import { db } from '../db';
+import {
+  Exercise,
+  Flashcard,
+  Lesson,
+  SeedBundleSchema,
+} from './seedTypes';
+
+export const SEED_VERSION_KEY = 'seed-version';
+export const DEFAULT_SEED_VERSION = '2024-05-07';
+export const CUSTOM_SEED_MARKER = 'custom';
+
+const seedFiles = import.meta.glob<string>('./**/*.json', { import: 'default', query: '?raw' });
+
+const normalizeSeedJson = (raw: string) => {
+  let result = '';
+  let inString = false;
+  let isEscaped = false;
+
+  for (const char of raw) {
+    if (inString) {
+      if (isEscaped) {
+        result += char;
+        isEscaped = false;
+        continue;
+      }
+      if (char === '\\') {
+        result += char;
+        isEscaped = true;
+        continue;
+      }
+      if (char === '"') {
+        result += char;
+        inString = false;
+        continue;
+      }
+      if (char === '\r') {
+        continue;
+      }
+      if (char === '\n') {
+        result += '\\n';
+        continue;
+      }
+      result += char;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    }
+    if (char !== '\r') {
+      result += char;
+    }
+  }
+
+  return result;
+};
+
+export type SeedResult = {
+  seeded: boolean;
+  counts: {
+    lessons: number;
+    exercises: number;
+    flashcards: number;
+  };
+};
+
+export async function ensureSeedData(): Promise<SeedResult> {
+  const existingVersion = await db.settings.get(SEED_VERSION_KEY);
+  const [lessonCount, exerciseCount, flashcardCount] = await Promise.all([
+    db.lessons.count(),
+    db.exercises.count(),
+    db.flashcards.count(),
+  ]);
+  const hasData = lessonCount > 0 || exerciseCount > 0 || flashcardCount > 0;
+
+  if (existingVersion?.value === CUSTOM_SEED_MARKER && hasData) {
+    return {
+      seeded: false,
+      counts: { lessons: lessonCount, exercises: exerciseCount, flashcards: flashcardCount },
+    };
+  }
+
+  if (existingVersion?.value === DEFAULT_SEED_VERSION && hasData) {
+    return {
+      seeded: false,
+      counts: { lessons: lessonCount, exercises: exerciseCount, flashcards: flashcardCount },
+    };
+  }
+
+  if (!existingVersion && hasData) {
+    return {
+      seeded: false,
+      counts: { lessons: lessonCount, exercises: exerciseCount, flashcards: flashcardCount },
+    };
+  }
+
+  const lessonMap = new Map<string, Lesson>();
+  const exerciseMap = new Map<string, Exercise>();
+  const flashcardMap = new Map<string, Flashcard>();
+
+  for (const [path, loader] of Object.entries(seedFiles)) {
+    if (path.endsWith('sections.json')) continue;
+    try {
+      const raw = await loader();
+      const normalized = normalizeSeedJson(raw);
+      let data: unknown;
+      try {
+        data = JSON.parse(normalized);
+      } catch (error) {
+        console.warn('Skipping seed file due to parse errors', path, error);
+        continue;
+      }
+      const parsed = SeedBundleSchema.safeParse(data);
+      if (!parsed.success) {
+        console.warn('Skipping seed file due to validation errors', path, parsed.error);
+        continue;
+      }
+      for (const lesson of parsed.data.lessons) {
+        lessonMap.set(lesson.id, lesson);
+      }
+      for (const exercise of parsed.data.exercises) {
+        exerciseMap.set(exercise.id, exercise);
+      }
+      for (const flashcard of parsed.data.flashcards) {
+        flashcardMap.set(flashcard.id, flashcard);
+      }
+    } catch (error) {
+      console.warn('Failed to load seed file', path, error);
+    }
+  }
+
+  const lessons = Array.from(lessonMap.values());
+  const exercises = Array.from(exerciseMap.values());
+  const flashcards = Array.from(flashcardMap.values());
+
+  if (lessons.length === 0 && exercises.length === 0 && flashcards.length === 0) {
+    console.warn('Initial seed attempted but no seed data was loaded.');
+    return { seeded: false, counts: { lessons: 0, exercises: 0, flashcards: 0 } };
+  }
+
+  await db.transaction('rw', [db.lessons, db.exercises, db.flashcards, db.settings], async () => {
+    if (lessons.length) await db.lessons.bulkPut(lessons);
+    if (exercises.length) await db.exercises.bulkPut(exercises);
+    if (flashcards.length) await db.flashcards.bulkPut(flashcards);
+    await db.settings.put({ key: SEED_VERSION_KEY, value: DEFAULT_SEED_VERSION });
+  });
+
+  return {
+    seeded: true,
+    counts: {
+      lessons: lessons.length,
+      exercises: exercises.length,
+      flashcards: flashcards.length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- ensure the app populates Dexie with the bundled lessons before rendering
- add a utility that normalises the bundled JSON seed files and imports lessons, exercises, and flashcards
- update manual imports to run inside a transaction and mark the database as customised

## Testing
- npm run build
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68ceb7a2c5848324ae6c828e633be99d