### PR TITLE
Ignore inverted Spanish punctuation in grader

### DIFF
--- a/src/lib/__tests__/grader.test.ts
+++ b/src/lib/__tests__/grader.test.ts
@@ -34,6 +34,12 @@ describe('gradeAnswer normalization and diacritics', () => {
 
     expect(gradeAnswer(exercise, 'vivis').isCorrect).toBe(true);
   });
+
+  it('ignores inverted punctuation when comparing answers', () => {
+    const exercise = createExercise({ type: 'short', answer: '¿Qué?' });
+
+    expect(gradeAnswer(exercise, 'Que').isCorrect).toBe(true);
+  });
 });
 
 describe('Levenshtein threshold logic', () => {

--- a/src/lib/grader.ts
+++ b/src/lib/grader.ts
@@ -13,6 +13,8 @@ const restoreEnye = (value: string) =>
     .replace(new RegExp(ENYE_PLACEHOLDER, 'g'), 'ñ')
     .replace(new RegExp(ENYE_PLACEHOLDER_UPPER, 'g'), 'Ñ');
 
+const stripInvertedPunctuation = (value: string) => value.replace(/[¡¿]/g, '');
+
 const stripDiacritics = (value: string) =>
   restoreEnye(
     preserveEnye(value)
@@ -21,7 +23,7 @@ const stripDiacritics = (value: string) =>
   );
 
 const baseNormalize = (value: string, collapseSpaces = true) => {
-  let processed = stripDiacritics(value).toLowerCase();
+  let processed = stripInvertedPunctuation(stripDiacritics(value)).toLowerCase();
   processed = processed.trim();
   return collapseSpaces ? processed.replace(/\s+/g, ' ') : processed;
 };


### PR DESCRIPTION
## Summary
- ignore inverted question/exclamation marks during normalization so answers aren't penalized for missing them
- add a unit test covering inverted punctuation handling in the grader

## Testing
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68cebf1f739083249d39427fd7d0085b