### PR TITLE
Fix seed normalization and repair lesson data

### DIFF
--- a/src/seed/b1-nouns-articles.json
+++ b/src/seed/b1-nouns-articles.json
@@ -1,187 +1,205 @@
-[
-  {
-    "id": "b1-nouns-articles-ex1",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose the correct article: ___ libro",
-    "options": ["la","el","una","un"],
-    "answer": "el",
-    "feedback": { "correct": "Correct — el libro.", "wrong": "libro is masculine." },
-    "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Definite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex2",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose: ___ mesas",
-    "options": ["el","los","la","las"],
-    "answer": "las",
-    "feedback": { "correct": "Correct — mesas is feminine plural.", "wrong": "Plural and ends in -a." },
-    "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Definite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex3",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose: ___ problemas",
-    "options": ["los","las","el","la"],
-    "answer": "los",
-    "feedback": { "correct": "Correct — problema is masculine.", "wrong": "Watch out: ends in -a but masculine." },
-    "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
-  },
-  {
-    "id": "b1-nouns-articles-ex4",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose: ___ manos",
-    "options": ["los","las","el","la"],
-    "answer": "las",
-    "feedback": { "correct": "Correct — la mano is feminine.", "wrong": "Irregular: mano is feminine." },
-    "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
-  },
-  {
-    "id": "b1-nouns-articles-ex5",
-    "lessonId": "b1-nouns-articles",
-    "type": "cloze",
-    "promptMd": "**____ casa** (the house)",
-    "answer": "la",
-    "accepted": ["re:^la$"],
-    "feedback": { "correct": "Yes — la casa.", "wrong": "Feminine singular needs la." },
-    "meta": { "difficulty": "A2", "skills": ["write"], "topic": "Definite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex6",
-    "lessonId": "b1-nouns-articles",
-    "type": "cloze",
-    "promptMd": "**____ coches** (the cars)",
-    "answer": "los",
-    "accepted": ["re:^los$"],
-    "feedback": { "correct": "Correct — los coches.", "wrong": "Plural masculine." },
-    "meta": { "difficulty": "A2", "skills": ["write"], "topic": "Definite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex7",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose the correct indefinite: ___ mesas",
-    "options": ["unas","unos","un","una"],
-    "answer": "unas",
-    "feedback": { "correct": "Correct — unas mesas.", "wrong": "Plural feminine." },
-    "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Indefinite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex8",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose: ___ libros",
-    "options": ["unas","unos","unos","un"],
-    "answer": "unos",
-    "feedback": { "correct": "Yes — unos libros.", "wrong": "Plural masculine." },
-    "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Indefinite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex9",
-    "lessonId": "b1-nouns-articles",
-    "type": "translate",
-    "promptMd": "Translate: **unos amigos**",
-    "answer": "some friends",
-    "accepted": ["re:some friends"],
-    "feedback": { "correct": "Correct.", "wrong": "unos = some." },
-    "meta": { "difficulty": "A2", "skills": ["read","write"], "topic": "Indefinite articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex10",
-    "lessonId": "b1-nouns-articles",
-    "type": "translate",
-    "promptMd": "Translate: **el agua fría**",
-    "answer": "the cold water",
-    "accepted": ["re:the cold water"],
-    "feedback": { "correct": "Correct — el agua (fem).", "wrong": "el agua is feminine, used el for sound." },
-    "meta": { "difficulty": "B1", "skills": ["read","write"], "topic": "El agua" }
-  },
-  {
-    "id": "b1-nouns-articles-ex11",
-    "lessonId": "b1-nouns-articles",
-    "type": "cloze",
-    "promptMd": "**Voy ___ parque** (a + el)",
-    "answer": "al",
-    "accepted": ["re:^al$"],
-    "feedback": { "correct": "Correct — contraction al.", "wrong": "a + el → al." },
-    "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Contracted articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex12",
-    "lessonId": "b1-nouns-articles",
-    "type": "cloze",
-    "promptMd": "**Vengo ___ médico** (de + el)",
-    "answer": "del",
-    "accepted": ["re:^del$"],
-    "feedback": { "correct": "Correct — de + el = del.", "wrong": "Remember contraction." },
-    "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Contracted articles" }
-  },
-  {
-    "id": "b1-nouns-articles-ex13",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Which uses **lo** correctly?",
-    "options": [
-      "lo libros",
-      "lo importante",
-      "lo mesas",
-      "lo gatos"
-    ],
-    "answer": "lo importante",
-    "feedback": { "correct": "Correct — lo + adjective.", "wrong": "lo only with adjectives, not nouns." },
-    "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Lo neutro" }
-  },
-  {
-    "id": "b1-nouns-articles-ex14",
-    "lessonId": "b1-nouns-articles",
-    "type": "translate",
-    "promptMd": "Translate: **Lo mejor es descansar.**",
-    "answer": "The best thing is to rest",
-    "accepted": ["re:the best thing is to rest"],
-    "feedback": { "correct": "Correct — lo + adj = abstract concept.", "wrong": "Don't translate lo literally." },
-    "meta": { "difficulty": "B1", "skills": ["read","write"], "topic": "Lo neutro" }
-  },
-  {
-    "id": "b1-nouns-articles-ex15",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose the correct form: ___ mapas",
-    "options": ["los","las","el","la"],
-    "answer": "los",
-    "feedback": { "correct": "Correct — el mapa is masculine.", "wrong": "Irregular: mapa is masculine." },
-    "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
-  },
-  {
-    "id": "b1-nouns-articles-ex16",
-    "lessonId": "b1-nouns-articles",
-    "type": "mcq",
-    "promptMd": "Choose the correct form: ___ días",
-    "options": ["los","las","el","la"],
-    "answer": "los",
-    "feedback": { "correct": "Correct — el día is masculine.", "wrong": "día is masculine." },
-    "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
-  },
-  {
-    "id": "b1-nouns-articles-ex17",
-    "lessonId": "b1-nouns-articles",
-    "type": "cloze",
-    "promptMd": "**___ problema difícil**",
-    "answer": "un",
-    "accepted": ["re:^un$"],
-    "feedback": { "correct": "Correct — problema is masculine.", "wrong": "Watch gender exceptions." },
-    "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Gender exceptions" }
-  },
-  {
-    "id": "b1-nouns-articles-ex18",
-    "lessonId": "b1-nouns-articles",
-    "type": "translate",
-    "promptMd": "Translate: **las manos frías**",
-    "answer": "the cold hands",
-    "accepted": ["re:the cold hands"],
-    "feedback": { "correct": "Correct — manos is feminine.", "wrong": "la mano is feminine." },
-    "meta": { "difficulty": "B1", "skills": ["read","write"], "topic": "Gender exceptions" }
-  }
-]
+{
+  "lessons": [
+    {
+      "id": "b1-nouns-articles",
+      "level": "B1",
+      "title": "B12 — Nouns & Articles: gender, exceptions and contractions",
+      "slug": "b1-nouns-articles",
+      "tags": ["articles", "gender", "grammar", "b1"],
+      "markdown": "# 📗 B12 — Nouns & Articles (B1)\n\n**Goal:** Master gender, number and the special cases for Spanish articles.\n\n---\n\n## 1. Core patterns\n- Masculine: **el / un** with -o, -ma (*el problema*), -or, -aje.\n- Feminine: **la / una** with -a, -ción, -sión, -dad, -tad.\n- Plural adds **-s** (vowel ending) or **-es** (consonant).\n\n## 2. Definite vs. indefinite\n- Use the definite article when the noun is known or specific.\n- Use the indefinite to introduce new, non-specific items.\n- Drop the indefinite after **ser** with professions: *Es médico*.\n\n## 3. Sound-based exceptions\n- Feminine nouns with stressed **a-** take **el** in the singular: *el águila*, *el agua fría* → **las** in plural.\n- Some nouns ending in **-a** are masculine: *el problema, el tema, el mapa*.\n- Some change meaning with the article: *el capital* (money) / *la capital* (city).\n\n## 4. Contractions & neuter lo\n- **a + el → al**, **de + el → del**.\n- Neuter **lo** + adjective/participle expresses an idea: *lo importante*.\n- Use **lo** to refer back to an entire clause or concept.\n\n---\n\n> 📝 **Summary:** Choose the article that matches gender and number, remember phonetic exceptions, and use contractions plus neuter **lo** to sound natural.",
+      "references": []
+    }
+  ],
+  "exercises": [
+    {
+      "id": "b1-nouns-articles-ex1",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose the correct article: ___ libro",
+      "options": ["la", "el", "una", "un"],
+      "answer": "el",
+      "feedback": { "correct": "Correct — **el libro**.", "wrong": "libro is masculine." },
+      "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Definite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex2",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose: ___ mesas",
+      "options": ["el", "los", "la", "las"],
+      "answer": "las",
+      "feedback": { "correct": "Correct — **las mesas**.", "wrong": "Plural feminine uses las." },
+      "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Definite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex3",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose: ___ problemas",
+      "options": ["los", "las", "el", "la"],
+      "answer": "los",
+      "feedback": { "correct": "Correct — **el problema** is masculine.", "wrong": "Ends in -a but masculine." },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex4",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose: ___ manos",
+      "options": ["los", "las", "el", "la"],
+      "answer": "las",
+      "feedback": { "correct": "Correct — **la mano** is feminine.", "wrong": "Irregular: mano is feminine." },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex5",
+      "lessonId": "b1-nouns-articles",
+      "type": "cloze",
+      "promptMd": "**____ casa** (the house)",
+      "answer": "la",
+      "accepted": ["re:^la$"],
+      "feedback": { "correct": "Yes — **la casa**.", "wrong": "Feminine singular takes la." },
+      "meta": { "difficulty": "A2", "skills": ["write"], "topic": "Definite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex6",
+      "lessonId": "b1-nouns-articles",
+      "type": "cloze",
+      "promptMd": "**____ coches** (the cars)",
+      "answer": "los",
+      "accepted": ["re:^los$"],
+      "feedback": { "correct": "Correct — **los coches**.", "wrong": "Plural masculine uses los." },
+      "meta": { "difficulty": "A2", "skills": ["write"], "topic": "Definite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex7",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose the correct indefinite: ___ mesas",
+      "options": ["unas", "unos", "un", "una"],
+      "answer": "unas",
+      "feedback": { "correct": "Correct — **unas mesas**.", "wrong": "Plural feminine needs unas." },
+      "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Indefinite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex8",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose: ___ libros",
+      "options": ["unas", "unos", "un", "una"],
+      "answer": "unos",
+      "feedback": { "correct": "Yes — **unos libros**.", "wrong": "Plural masculine needs unos." },
+      "meta": { "difficulty": "A2", "skills": ["read"], "topic": "Indefinite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex9",
+      "lessonId": "b1-nouns-articles",
+      "type": "translate",
+      "promptMd": "Translate: **unos amigos**",
+      "answer": "some friends",
+      "accepted": ["re:some friends"],
+      "feedback": { "correct": "Correct — *unos* = some.", "wrong": "unos means some." },
+      "meta": { "difficulty": "A2", "skills": ["read", "write"], "topic": "Indefinite articles" }
+    },
+    {
+      "id": "b1-nouns-articles-ex10",
+      "lessonId": "b1-nouns-articles",
+      "type": "translate",
+      "promptMd": "Translate: **el agua fría**",
+      "answer": "the cold water",
+      "accepted": ["re:the cold water"],
+      "feedback": { "correct": "Correct — feminine but uses **el** for sound.", "wrong": "Remember stressed a- takes el." },
+      "meta": { "difficulty": "B1", "skills": ["read", "write"], "topic": "Sound exceptions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex11",
+      "lessonId": "b1-nouns-articles",
+      "type": "cloze",
+      "promptMd": "**Voy ___ parque** (a + el)",
+      "answer": "al",
+      "accepted": ["re:^al$"],
+      "feedback": { "correct": "Correct — **al** = a + el.", "wrong": "Remember contraction al." },
+      "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Contractions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex12",
+      "lessonId": "b1-nouns-articles",
+      "type": "cloze",
+      "promptMd": "**Vengo ___ médico** (de + el)",
+      "answer": "del",
+      "accepted": ["re:^del$"],
+      "feedback": { "correct": "Correct — **del** = de + el.", "wrong": "Use del for contraction." },
+      "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Contractions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex13",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Which uses **lo** correctly?",
+      "options": ["lo libros", "lo importante", "lo mesas", "lo gatos"],
+      "answer": "lo importante",
+      "feedback": { "correct": "Correct — **lo + adjective** forms an idea.", "wrong": "Use lo with adjectives, not nouns." },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Neuter lo" }
+    },
+    {
+      "id": "b1-nouns-articles-ex14",
+      "lessonId": "b1-nouns-articles",
+      "type": "translate",
+      "promptMd": "Translate: **Lo mejor es descansar.**",
+      "answer": "The best thing is to rest",
+      "accepted": ["re:the best thing is to rest"],
+      "feedback": { "correct": "Correct — **lo mejor** = the best thing.", "wrong": "Do not translate lo literally." },
+      "meta": { "difficulty": "B1", "skills": ["read", "write"], "topic": "Neuter lo" }
+    },
+    {
+      "id": "b1-nouns-articles-ex15",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose the correct form: ___ mapas",
+      "options": ["los", "las", "el", "la"],
+      "answer": "los",
+      "feedback": { "correct": "Correct — **el mapa** is masculine.", "wrong": "Mapa is a masculine exception." },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex16",
+      "lessonId": "b1-nouns-articles",
+      "type": "mcq",
+      "promptMd": "Choose the correct form: ___ días",
+      "options": ["los", "las", "el", "la"],
+      "answer": "los",
+      "feedback": { "correct": "Correct — **el día** is masculine.", "wrong": "día stays masculine." },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Gender exceptions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex17",
+      "lessonId": "b1-nouns-articles",
+      "type": "cloze",
+      "promptMd": "**___ problema difícil**",
+      "answer": "un",
+      "accepted": ["re:^un$"],
+      "feedback": { "correct": "Correct — **problema** is masculine.", "wrong": "Remember -ma nouns are masculine." },
+      "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Gender exceptions" }
+    },
+    {
+      "id": "b1-nouns-articles-ex18",
+      "lessonId": "b1-nouns-articles",
+      "type": "translate",
+      "promptMd": "Translate: **las manos frías**",
+      "answer": "the cold hands",
+      "accepted": ["re:the cold hands"],
+      "feedback": { "correct": "Correct — **las manos**.", "wrong": "La mano is feminine despite ending in -o." },
+      "meta": { "difficulty": "B1", "skills": ["read", "write"], "topic": "Gender exceptions" }
+    }
+  ],
+  "flashcards": [
+    { "id": "b1-nouns-articles-fc1", "front": "Masculine endings", "back": "-o, -ma, -or, -aje", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc2", "front": "Feminine endings", "back": "-a, -ción, -sión, -dad", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc3", "front": "Stressed a- nouns", "back": "Use el in singular: el agua, el águila", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc4", "front": "Indefinite drop", "back": "After ser + profession: Es médico", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc5", "front": "Contractions", "back": "a + el = al, de + el = del", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc6", "front": "Neuter lo", "back": "lo + adj = idea: lo interesante", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc7", "front": "Meaning shift", "back": "el capital (money) / la capital (city)", "tag": "articles", "deck": "grammar" },
+    { "id": "b1-nouns-articles-fc8", "front": "Plural rule", "back": "Vowel + s, consonant + es", "tag": "articles", "deck": "grammar" }
+  ]
+}

--- a/src/seed/b1-phonology-basics.json
+++ b/src/seed/b1-phonology-basics.json
@@ -3,33 +3,147 @@
     {
       "id": "b1-phonology-basics",
       "level": "B1",
-      "title": "Spanish Phonology Basics",
+      "title": "B10 — Phonology basics: vowels, consonants and stress",
       "slug": "b1-phonology-basics",
-      "tags": ["phonology","pronunciation"],
-      "markdown": "# 🗣️ Spanish Phonology Basics (B1)\\n... (lesson markdown from previous message)...",
+      "tags": ["phonology", "pronunciation", "listening", "b1"],
+      "markdown": "# 🎧 B10 — Spanish Phonology Basics\n\n**Goal:** Tune your ear to the core pronunciation rules that make Spanish sound fluid and consistent.**\n\n---\n\n## 1. Five steady vowels\nSpanish vowels are short and pure — no diphthongs inside the vowel itself.\n- **a e i o u** always sound the same.\n- No schwa /ə/; write one vowel, pronounce one vowel.\n\n## 2. Consonant pairs to watch\n- **c** → /k/ before *a, o, u*; /s/ (or /θ/ in Spain) before *e, i*.\n- **g** → hard /g/ before *a, o, u*; /x/ (like harsh *h*) before *e, i*.\n- **j** is always /x/.\n- **b** and **v** share the same sound, a soft bilabial stop.\n- **ll** and **y** merge in most dialects → /ʝ/ or /ʒ/ (Argentina).\n\n## 3. Stress rhythm\n- Words ending in **vowel, n, s** stress the **penultimate** syllable.\n- Words ending in other consonants stress the **final** syllable.\n- Break the rule? Mark it with an **accent**: *café, inglés, médico*.\n\n## 4. Syllable timing\nSpanish is syllable-timed: every syllable has similar length. Link vowels smoothly when words touch: *lo-he-vi-do* → *lohevido*.\n\n---\n\n> 📝 **Summary:** Keep vowels pure, follow consonant context rules, respect stress defaults and accent marks, and let syllables flow evenly for natural Spanish.",
       "references": []
     }
   ],
   "exercises": [
-    { "id": "b1-phonology-basics-ex1", "lessonId": "b1-phonology-basics", "type": "short", "promptMd": "Which five vowel letters exist in Spanish?", "answer": "a e i o u", "accepted": ["re:^a\\s*e\\s*i\\s*o\\s*u$"], "feedback": { "correct": "Correct — they are pure vowels.", "wrong": "Try listing them in order a–u.", "hints": ["Think: same as in the word AEIOU."] }, "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Phonology" } },
-    { "id": "b1-phonology-basics-ex2", "lessonId": "b1-phonology-basics", "type": "cloze", "promptMd": "**c** sounds like /k/ before ___, ___, ___; and /θ/ or /s/ before ___, ___", "answer": ["a","o","u","e","i"], "feedback": { "correct": "Right.", "wrong": "Check the chart again.", "hints": ["/k/ before back vowels, /θ/ or /s/ before front vowels."] }, "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Consonants" } },
-    ... (ex3–ex15 exactly as given earlier)
+    {
+      "id": "b1-phonology-basics-ex1",
+      "lessonId": "b1-phonology-basics",
+      "type": "cloze",
+      "promptMd": "Write the five Spanish vowel letters in order.",
+      "answer": "a e i o u",
+      "accepted": ["re:^a\\s*e\\s*i\\s*o\\s*u$"],
+      "feedback": { "correct": "Correct — five pure vowels.", "wrong": "Remember: a, e, i, o, u." },
+      "meta": { "difficulty": "A2", "skills": ["write"], "topic": "Vowels" }
+    },
+    {
+      "id": "b1-phonology-basics-ex2",
+      "lessonId": "b1-phonology-basics",
+      "type": "cloze",
+      "promptMd": "**c** sounds like /k/ before ___, ___, ___.",
+      "answer": ["a", "o", "u"],
+      "accepted": ["re:^a$", "re:^o$", "re:^u$"],
+      "feedback": { "correct": "Correct — /k/ with back vowels.", "wrong": "Use a, o, u for /k/." },
+      "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Consonants" }
+    },
+    {
+      "id": "b1-phonology-basics-ex3",
+      "lessonId": "b1-phonology-basics",
+      "type": "cloze",
+      "promptMd": "**c** sounds like /s/ (or /θ/) before ___ and ___",
+      "answer": ["e", "i"],
+      "accepted": ["re:^e$", "re:^i$"],
+      "feedback": { "correct": "Correct — front vowels trigger /s/ or /θ/.", "wrong": "Use e, i." },
+      "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Consonants" }
+    },
+    {
+      "id": "b1-phonology-basics-ex4",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "How do you pronounce **g** in *gente*?",
+      "options": ["/g/ like go", "/x/ like harsh h", "/s/ like sun"],
+      "answer": "/x/ like harsh h",
+      "feedback": { "correct": "Correct — g + e/i gives /x/.", "wrong": "Remember g + e/i sounds like Spanish j." },
+      "meta": { "difficulty": "B1", "skills": ["listen"], "topic": "Consonants" }
+    },
+    {
+      "id": "b1-phonology-basics-ex5",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "Where is the stress in **computadora**?",
+      "options": ["com", "pu", "ta", "do"],
+      "answer": "do",
+      "feedback": { "correct": "Correct — ends in vowel so stress penultimate: compuTAdo-ra.", "wrong": "Ends in vowel: stress penultimate syllable." },
+      "meta": { "difficulty": "A2", "skills": ["listen"], "topic": "Stress" }
+    },
+    {
+      "id": "b1-phonology-basics-ex6",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "Which word needs an accent mark to show stress?",
+      "options": ["cafe", "casas", "doctor"],
+      "answer": "cafe",
+      "feedback": { "correct": "Correct — should be café to mark final stress.", "wrong": "Words ending in vowel stressed on final syllable need an accent: café." },
+      "meta": { "difficulty": "B1", "skills": ["read"], "topic": "Stress" }
+    },
+    {
+      "id": "b1-phonology-basics-ex7",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "How are **b** and **v** pronounced in most Spanish dialects?",
+      "options": ["Different sounds", "Same bilabial sound", "Like English v"],
+      "answer": "Same bilabial sound",
+      "feedback": { "correct": "Correct — both merge in pronunciation.", "wrong": "Both letters share a single bilabial sound." },
+      "meta": { "difficulty": "A2", "skills": ["listen"], "topic": "Consonants" }
+    },
+    {
+      "id": "b1-phonology-basics-ex8",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "The letters **ll** and **y** usually sound like...",
+      "options": ["/ʝ/ (soft y sound)", "/l/", "/r/"],
+      "answer": "/ʝ/ (soft y sound)",
+      "feedback": { "correct": "Correct — yeísmo merges ll and y.", "wrong": "Most dialects pronounce ll and y alike." },
+      "meta": { "difficulty": "B1", "skills": ["listen"], "topic": "Consonants" }
+    },
+    {
+      "id": "b1-phonology-basics-ex9",
+      "lessonId": "b1-phonology-basics",
+      "type": "cloze",
+      "promptMd": "Break **hablar** into syllables.",
+      "answer": "ha-blar",
+      "accepted": ["re:^ha-?blar$", "re:^ha\\s*blar$"],
+      "feedback": { "correct": "Correct — two syllables: ha-blar.", "wrong": "Divide after the consonant cluster: ha-blar." },
+      "meta": { "difficulty": "A2", "skills": ["write"], "topic": "Syllables" }
+    },
+    {
+      "id": "b1-phonology-basics-ex10",
+      "lessonId": "b1-phonology-basics",
+      "type": "translate",
+      "promptMd": "Explain in English why *inglés* has an accent.",
+      "answer": "It ends in s but the stress is on the final syllable",
+      "accepted": ["re:ends in s.*final", "re:stress.*final"],
+      "feedback": { "correct": "Right — accent marks the final stress against the default.", "wrong": "Because stress falls on the last syllable despite ending in -s." },
+      "meta": { "difficulty": "B1", "skills": ["write"], "topic": "Stress" }
+    },
+    {
+      "id": "b1-phonology-basics-ex11",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "What happens when two vowels meet across words, as in *lo invito*?",
+      "options": ["A pause is required", "They link smoothly", "Drop one vowel"],
+      "answer": "They link smoothly",
+      "feedback": { "correct": "Correct — Spanish links vowels between words.", "wrong": "Spanish favours linking: loinvito." },
+      "meta": { "difficulty": "B1", "skills": ["listen"], "topic": "Connected speech" }
+    },
+    {
+      "id": "b1-phonology-basics-ex12",
+      "lessonId": "b1-phonology-basics",
+      "type": "mcq",
+      "promptMd": "Which option shows the correct stress for *médico*?",
+      "options": ["ME-di-co", "me-DI-co", "me-di-CO"],
+      "answer": "ME-di-co",
+      "feedback": { "correct": "Correct — the accent mark shows stress on the first syllable.", "wrong": "Accent on é means stress the first syllable." },
+      "meta": { "difficulty": "B1", "skills": ["listen"], "topic": "Stress" }
+    }
   ],
   "flashcards": [
-    { "id": "b1-phonology-basics-fc1","front":"Vowels","back":"a e i o u","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc2","front":"c before e/i","back":"/θ/ (Spain) or /s/ (LatAm)","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc3","front":"c before a/o/u","back":"/k/","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc4","front":"g before e/i","back":"/x/ (like harsh h)","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc5","front":"j sound","back":"/x/ (like harsh h)","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc6","front":"Stress rule","back":"Penultimate if ends in vowel/n/s","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc7","front":"Accent mark (´)","back":"Shows stressed syllable","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc8","front":"Rhythm","back":"Syllable-timed","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc9","front":"Spain c/z","back":"/θ/","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc10","front":"LatAm c/z","back":"/s/","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc11","front":"hablar syllables","back":"ha-blar","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc12","front":"casa syllables","back":"ca-sa","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc13","front":"los amigos syllables","back":"los-a-mi-gos","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc14","front":"difícil syllables","back":"di-fí-cil","tag":"phonology","deck":"grammar" },
-    { "id": "b1-phonology-basics-fc15","front":"Linking","back":"No silent syllables","tag":"phonology","deck":"grammar" }
+    { "id": "b1-phonology-basics-fc1", "front": "Spanish vowels", "back": "a e i o u — pure, stable sounds", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc2", "front": "c + a/o/u", "back": "Pronounce /k/", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc3", "front": "c + e/i", "back": "/s/ (or /θ/ in Spain)", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc4", "front": "g + e/i", "back": "Sounds like j: /x/", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc5", "front": "b & v", "back": "Same soft bilabial sound", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc6", "front": "Stress rule", "back": "Vowel/n/s → penultimate stress", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc7", "front": "Accent marks", "back": "Show when stress breaks the default", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc8", "front": "ll & y", "back": "Merge to /ʝ/ (yeísmo)", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc9", "front": "Syllable timing", "back": "Keep rhythm even across syllables", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc10", "front": "Linking vowels", "back": "Connect words: loinvito", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc11", "front": "j sound", "back": "Always /x/ like harsh h", "tag": "phonology", "deck": "grammar" },
+    { "id": "b1-phonology-basics-fc12", "front": "Final consonants", "back": "Stress final syllable unless accented", "tag": "phonology", "deck": "grammar" }
   ]
 }

--- a/src/seed/ensureSeedData.ts
+++ b/src/seed/ensureSeedData.ts
@@ -1,10 +1,6 @@
 import { db } from '../db';
-import {
-  Exercise,
-  Flashcard,
-  Lesson,
-  SeedBundleSchema,
-} from './seedTypes';
+import { Exercise, Flashcard, Lesson } from './seedTypes';
+import { normalizeSeedInput } from './normalizeSeedBundle';
 
 export const SEED_VERSION_KEY = 'seed-version';
 export const DEFAULT_SEED_VERSION = '2024-05-07';
@@ -111,18 +107,16 @@ export async function ensureSeedData(): Promise<SeedResult> {
         console.warn('Skipping seed file due to parse errors', path, error);
         continue;
       }
-      const parsed = SeedBundleSchema.safeParse(data);
-      if (!parsed.success) {
-        console.warn('Skipping seed file due to validation errors', path, parsed.error);
-        continue;
-      }
-      for (const lesson of parsed.data.lessons) {
+      const bundle = normalizeSeedInput(data, {
+        onItemSkipped: (item) => console.warn('Skipping unrecognized item in seed file', path, item),
+      });
+      for (const lesson of bundle.lessons) {
         lessonMap.set(lesson.id, lesson);
       }
-      for (const exercise of parsed.data.exercises) {
+      for (const exercise of bundle.exercises) {
         exerciseMap.set(exercise.id, exercise);
       }
-      for (const flashcard of parsed.data.flashcards) {
+      for (const flashcard of bundle.flashcards) {
         flashcardMap.set(flashcard.id, flashcard);
       }
     } catch (error) {

--- a/src/seed/importSeed.ts
+++ b/src/seed/importSeed.ts
@@ -1,15 +1,7 @@
 import { db } from '../db';
 import { CUSTOM_SEED_MARKER, SEED_VERSION_KEY } from './ensureSeedData';
-import {
-  LessonSchema,
-  ExerciseSchema,
-  FlashcardSchema,
-  SeedBundleSchema,
-  type Lesson,
-  type Exercise,
-  type Flashcard,
-  type SeedBundle,
-} from './seedTypes';
+import { SeedBundleSchema } from './seedTypes';
+import { normalizeSeedInput } from './normalizeSeedBundle';
 
 /**
  * Accepts either:
@@ -19,56 +11,11 @@ import {
  */
 export async function importSeed(raw: unknown) {
   // Normalize input into a SeedBundle
-  let bundle: SeedBundle;
-  if (
-    raw &&
-    typeof raw === 'object' &&
-    ('lessons' in (raw as any) ||
-      'exercises' in (raw as any) ||
-      'flashcards' in (raw as any))
-  ) {
-    bundle = SeedBundleSchema.parse({
-      lessons: (raw as any).lessons ?? [],
-      exercises: (raw as any).exercises ?? [],
-      flashcards: (raw as any).flashcards ?? [],
-    });
-  } else if (Array.isArray(raw)) {
-    // If an array is passed, try to detect the type by validating samples
-    const arr = raw as unknown[];
-    const lessons: Lesson[] = [];
-    const exercises: Exercise[] = [];
-    const flashcards: Flashcard[] = [];
-    for (const item of arr) {
-      // try each schema; push into the one that passes
-      const asLesson = tryParse(LessonSchema, item);
-      if (asLesson) {
-        lessons.push(asLesson);
-        continue;
-      }
-      const asExercise = tryParse(ExerciseSchema, item);
-      if (asExercise) {
-        exercises.push(asExercise);
-        continue;
-      }
-      const asFlash = tryParse(FlashcardSchema, item);
-      if (asFlash) {
-        flashcards.push(asFlash);
-        continue;
-      }
-      console.warn('Skipped unrecognized item during seed import:', item);
-    }
-    bundle = SeedBundleSchema.parse({ lessons, exercises, flashcards });
-  } else {
-    // Last chance: try to parse as a single entity
-    const lesson = tryParse(LessonSchema, raw);
-    const exercise = tryParse(ExerciseSchema, raw);
-    const flash = tryParse(FlashcardSchema, raw);
-    bundle = SeedBundleSchema.parse({
-      lessons: lesson ? [lesson] : [],
-      exercises: exercise ? [exercise] : [],
-      flashcards: flash ? [flash] : [],
-    });
-  }
+  const bundle = normalizeSeedInput(raw, {
+    onItemSkipped: (item) => console.warn('Skipped unrecognized item during seed import:', item),
+  });
+
+  SeedBundleSchema.parse(bundle);
 
   // Upsert into Dexie and mark that a manual import has occurred
   await db.transaction('rw', [db.lessons, db.exercises, db.flashcards, db.settings], async () => {
@@ -83,12 +30,4 @@ export async function importSeed(raw: unknown) {
     exercisesImported: bundle.exercises.length,
     flashcardsImported: bundle.flashcards.length,
   };
-}
-
-function tryParse<T>(schema: { parse: (v: unknown) => T }, value: unknown): T | null {
-  try {
-    return schema.parse(value);
-  } catch {
-    return null;
-  }
 }

--- a/src/seed/normalizeSeedBundle.ts
+++ b/src/seed/normalizeSeedBundle.ts
@@ -1,0 +1,77 @@
+import { ExerciseSchema, FlashcardSchema, LessonSchema, SeedBundleSchema, type Exercise, type Flashcard, type Lesson, type SeedBundle } from './seedTypes';
+
+type NormalizerOptions = {
+  onItemSkipped?: (item: unknown) => void;
+};
+
+const tryParse = <T>(schema: { parse: (value: unknown) => T }, value: unknown): T | null => {
+  try {
+    return schema.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+const warn = (options: NormalizerOptions | undefined, item: unknown) => {
+  options?.onItemSkipped?.(item);
+};
+
+export const normalizeSeedInput = (raw: unknown, options?: NormalizerOptions): SeedBundle => {
+  if (raw == null) {
+    return { lessons: [], exercises: [], flashcards: [] };
+  }
+
+  if (Array.isArray(raw)) {
+    const lessons: Lesson[] = [];
+    const exercises: Exercise[] = [];
+    const flashcards: Flashcard[] = [];
+
+    for (const item of raw) {
+      const lesson = tryParse(LessonSchema, item);
+      if (lesson) {
+        lessons.push(lesson);
+        continue;
+      }
+      const exercise = tryParse(ExerciseSchema, item);
+      if (exercise) {
+        exercises.push(exercise);
+        continue;
+      }
+      const flashcard = tryParse(FlashcardSchema, item);
+      if (flashcard) {
+        flashcards.push(flashcard);
+        continue;
+      }
+      warn(options, item);
+    }
+
+    return SeedBundleSchema.parse({ lessons, exercises, flashcards });
+  }
+
+  if (typeof raw === 'object') {
+    try {
+      return SeedBundleSchema.parse({
+        lessons: (raw as { lessons?: unknown }).lessons ?? [],
+        exercises: (raw as { exercises?: unknown }).exercises ?? [],
+        flashcards: (raw as { flashcards?: unknown }).flashcards ?? [],
+      });
+    } catch {
+      // fall through to try single-entity parsing
+    }
+  }
+
+  const lesson = tryParse(LessonSchema, raw);
+  const exercise = tryParse(ExerciseSchema, raw);
+  const flashcard = tryParse(FlashcardSchema, raw);
+
+  if (lesson || exercise || flashcard) {
+    return SeedBundleSchema.parse({
+      lessons: lesson ? [lesson] : [],
+      exercises: exercise ? [exercise] : [],
+      flashcards: flashcard ? [flashcard] : [],
+    });
+  }
+
+  warn(options, raw);
+  return { lessons: [], exercises: [], flashcards: [] };
+};


### PR DESCRIPTION
## Summary
- add a shared seed normalizer so both automatic seeding and manual imports can consume bundles, arrays or single records without failing
- refresh the B1 nouns/articles and phonology seed files with full lesson metadata, validated exercises, and flashcards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec360cc6483248e5d29031b7b07e4