### PR TITLE
Ensure preview loads fresh app shell

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,11 +1,21 @@
-const STATIC_CACHE = 'static-v1';
-const DATA_CACHE = 'data-v1';
+const STATIC_CACHE = 'static-v2';
+const DATA_CACHE = 'data-v2';
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(STATIC_CACHE).then((cache) =>
-      cache.addAll(['/', '/index.html', '/manifest.webmanifest', '/icon.svg'])
-    )
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      await cache.addAll(['/manifest.webmanifest', '/icon.svg']);
+      try {
+        const indexRequest = new Request('/index.html', { cache: 'reload' });
+        const response = await fetch(indexRequest);
+        if (response.ok) {
+          await cache.put('/index.html', response.clone());
+        }
+      } catch (error) {
+        console.warn('Skipping index.html prefetch', error);
+      }
+    })()
   );
   self.skipWaiting();
 });
@@ -23,6 +33,26 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+const serveNavigation = async (request) => {
+  const cache = await caches.open(STATIC_CACHE);
+  try {
+    const response = await fetch(request, { cache: 'no-store' });
+    if (response.ok) {
+      await cache.put('/index.html', response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match('/index.html');
+    return (
+      cached ??
+      new Response('Offline', {
+        status: 503,
+        headers: { 'Content-Type': 'text/html' },
+      })
+    );
+  }
+};
+
 const cacheFirst = async (request) => {
   const cached = await caches.match(request);
   if (cached) {
@@ -36,7 +66,7 @@ const cacheFirst = async (request) => {
     }
     return response;
   } catch (error) {
-    return cached ?? new Response('Offline', { status: 503 });
+    return new Response('Offline', { status: 503 });
   }
 };
 
@@ -55,7 +85,20 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  event.respondWith(cacheFirst(request));
+  if (request.mode === 'navigate' || (request.destination === 'document' && request.url.startsWith(self.location.origin))) {
+    event.respondWith(serveNavigation(request));
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (url.origin === self.location.origin) {
+    if (url.pathname.startsWith('/assets/') || url.pathname === '/manifest.webmanifest' || url.pathname === '/icon.svg') {
+      event.respondWith(cacheFirst(request));
+      return;
+    }
+  }
+
+  event.respondWith(fetch(request));
 });
 
 const cacheDataBundle = async ({ lessons = [], exercises = [] }) => {


### PR DESCRIPTION
## Summary
- bump the static/data cache versions and prefetch index.html with a reload request during install
- serve navigation requests with a no-store network fetch and cache the latest app shell for offline fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cedabdda248324b07e5f759920f2d7