### PR TITLE
Add slug index for lessons store

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -17,6 +17,14 @@ class AppDB extends Dexie {
       flashcards: 'id,tag,deck',
       settings: 'key'
     });
+
+    this.version(2).stores({
+      lessons: 'id,slug,level,tags',
+      exercises: 'id,lessonId,type',
+      grades: 'id,exerciseId,isCorrect,score',
+      flashcards: 'id,tag,deck',
+      settings: 'key'
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add a Dexie schema upgrade so lessons can be queried by slug
- keep existing stores intact while exposing the new index for slug lookups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef36798f083248db238d15d369abc