### PR TITLE
Implement workspace UX and analytics refresh

### DIFF
--- a/docs/anki-export.md
+++ b/docs/anki-export.md
@@ -1,0 +1,14 @@
+# Export Spanish Coach decks to Anki
+
+Need to run a focused review in Anki? Use this quick checklist to turn the in-app flashcards into an `.apkg` you can share or review offline.
+
+1. **Open the Content manager** and download the latest seed bundle so your local JSON matches the cards in the trainer.
+2. **Run the export script** from the project root:
+   ```bash
+   npm run build
+   node scripts/export-anki-deck.mjs
+   ```
+   This generates an Anki-friendly package inside the `exports/` folder.
+3. **Import the package into Anki** and assign it to the deck of your choice. All cards retain their tags (`grammar`, `verbs`, `vocab`, `presentations`) so you can keep filters aligned with the web app.
+
+For screenshots and troubleshooting tips, read the full [Anki export playbook](./d2-anki-guide.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2024-06-14 — Workspace refresh
+- Rebuilt the home overview with search, level filters, recommendations, and flashcard readiness panels.
+- Expanded the dashboard with streak insights, SRS summaries, export buttons, and sortable mastery tables.
+- Upgraded the flashcard trainer with deck/tag filters, adjustable session lengths, and 4-grade spaced repetition.
+- Added lesson session logs, per-exercise history, and mastery summaries to track progress mid-run.
+- Introduced richer content-manager diffing, remote bundle fetching, and offline cache updates after imports.
+- Improved the shell with analytics-driven quick actions, a global search, documentation links, and focus mode enhancements.

--- a/docs/exam-day-checklist.md
+++ b/docs/exam-day-checklist.md
@@ -1,0 +1,11 @@
+# Exam-day speaking checklist
+
+Heading into an oral exam or live assessment? Run through this abbreviated list to stay calm and structured.
+
+- **Warm up with a micro sprint.** Spend 5 minutes on due flashcards and one targeted lesson exercise so your brain is already in Spanish mode.
+- **Review your anchor phrases.** Re-read the connectors and idioms you rely on for introductions, transitions, and conclusions.
+- **Plan your structure.** Jot down a three-part outline (opening, development, wrap-up) before you start speaking.
+- **Track time cues.** Set subtle timers or glances so you hit every section without rushing the finale.
+- **Debrief immediately.** After the session, capture wins and fixes in the changelog so you can iterate before the next run.
+
+Need the full scenario walkthrough? Dive into the detailed [exam-day speaking guide](./d3-exam-cheatsheet.md).

--- a/docs/study-playbook.md
+++ b/docs/study-playbook.md
@@ -1,0 +1,18 @@
+# Study session playbook
+
+Use this 3-step loop whenever you open Study Spanish Coach. It keeps your practice balanced and ensures analytics stay meaningful.
+
+## 1. Plan (2 minutes)
+- Open the **Overview** and scan the quick actions. Note the streak, weakest tag, and due decks.
+- Glance at the dashboard sparkline for recent activity, then pick one lesson or tag to emphasise.
+
+## 2. Practise (15–25 minutes)
+- Work through the recommended lesson first. Use the hint and rubric toggles sparingly and log every attempt.
+- Keep the new session log open in the sidebar to spot timing and accuracy trends as you go.
+- When you clear the lesson, pivot to the flashcard trainer. Filter by deck or tag to reinforce what you just studied and pick a session length that fits the time you have left.
+
+## 3. Reflect (3 minutes)
+- Return to the dashboard to confirm how the session changed your mastery and streak metrics.
+- Add a short note to the changelog or your personal journal so you can compare future runs.
+
+Repeat the loop daily and you’ll move from reactive cramming to deliberate progress.

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -74,7 +74,11 @@ self.addEventListener('fetch', (event) => {
   const { request } = event;
   if (request.method !== 'GET') return;
 
-  if (request.url.endsWith('/offline-lessons') || request.url.endsWith('/offline-exercises')) {
+  if (
+    request.url.endsWith('/offline-lessons') ||
+    request.url.endsWith('/offline-exercises') ||
+    request.url.endsWith('/offline-flashcards')
+  ) {
     event.respondWith(
       caches.open(DATA_CACHE).then((cache) =>
         cache.match(request).then((response) =>
@@ -101,7 +105,7 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(fetch(request));
 });
 
-const cacheDataBundle = async ({ lessons = [], exercises = [] }) => {
+const cacheDataBundle = async ({ lessons = [], exercises = [], flashcards = [] }) => {
   const cache = await caches.open(DATA_CACHE);
   await cache.put(
     new Request('/offline-lessons'),
@@ -112,6 +116,12 @@ const cacheDataBundle = async ({ lessons = [], exercises = [] }) => {
   await cache.put(
     new Request('/offline-exercises'),
     new Response(JSON.stringify(exercises), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+  await cache.put(
+    new Request('/offline-flashcards'),
+    new Response(JSON.stringify(flashcards), {
       headers: { 'Content-Type': 'application/json' },
     })
   );
@@ -153,9 +163,9 @@ const markGradesSynced = async () => {
 };
 
 self.addEventListener('message', (event) => {
-  const { type, lessons, exercises } = event.data || {};
+  const { type, lessons, exercises, flashcards } = event.data || {};
   if (type === 'CACHE_DATA') {
-    event.waitUntil(cacheDataBundle({ lessons, exercises }));
+    event.waitUntil(cacheDataBundle({ lessons, exercises, flashcards }));
   }
   if (type === 'SYNC_GRADES') {
     event.waitUntil(markGradesSynced());

--- a/src/components/Dashboard.module.css
+++ b/src/components/Dashboard.module.css
@@ -40,6 +40,22 @@
   transition: width 0.3s ease;
 }
 
+.progressMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+  color: var(--ui-text-secondary);
+  font-size: 0.9rem;
+}
+
+.actionsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
 .tableWrapper {
   border-radius: var(--ui-radius-lg);
   overflow: hidden;
@@ -61,4 +77,113 @@
 
 .studyList strong {
   color: var(--ui-text-primary);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.sectionControls {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.sortButton {
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: transparent;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sortButton[data-active='true'] {
+  border-color: var(--ui-accent);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+}
+
+.activitySummary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activityMeta {
+  margin: 0;
+  color: var(--ui-text-secondary);
+}
+
+.sparkline {
+  display: grid;
+  grid-template-columns: repeat(14, minmax(0, 1fr));
+  gap: 8px;
+  height: 80px;
+  align-items: end;
+}
+
+.sparklineBar {
+  background: rgba(59, 130, 246, 0.35);
+  border-radius: var(--ui-radius-sm);
+  transition: transform 0.2s ease;
+}
+
+.sparklineBar[data-active='true'] {
+  background: var(--ui-highlight-secondary);
+}
+
+.sparklineBar:hover {
+  transform: translateY(-4px);
+}
+
+.srsGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-bottom: 12px;
+}
+
+.srsTile {
+  padding: 14px;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.srsLabel {
+  font-size: 0.8rem;
+  color: var(--ui-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.srsValue {
+  font-size: 1.4rem;
+  font-family: var(--ui-font-display);
+}
+
+.bucketList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.bucketChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(14, 165, 233, 0.12);
+  color: #0e7490;
+  font-size: 0.85rem;
+  font-weight: 600;
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { liveQuery } from 'dexie';
 import { db } from '../db';
-import { computeAnalytics, AnalyticsSnapshot } from '../lib/analytics';
+import {
+  computeAnalytics,
+  AnalyticsSnapshot,
+  LessonMasteryStat,
+  SkillAccuracy,
+  StudyActivityPoint,
+} from '../lib/analytics';
 import styles from './Dashboard.module.css';
 
 const formatDuration = (ms: number) => {
@@ -17,25 +25,113 @@ const formatDuration = (ms: number) => {
   return parts.join(' ');
 };
 
+const downloadCsv = (filename: string, rows: string[][]) => {
+  const csv = rows.map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+const formatActivityTooltip = (point: StudyActivityPoint) =>
+  `${point.date}: ${point.correct}/${point.total} correct`;
+
+const formatLastStudied = (value?: string) => {
+  if (!value) return 'Never';
+  return new Date(value).toLocaleString();
+};
+
+type LessonSort = 'recent' | 'accuracy';
+
+type SkillSort = 'accuracy' | 'volume';
+
 export const Dashboard: React.FC = () => {
   const [progress, setProgress] = useState(0);
   const [snapshot, setSnapshot] = useState<AnalyticsSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
+  const [lessonSort, setLessonSort] = useState<LessonSort>('recent');
+  const [skillSort, setSkillSort] = useState<SkillSort>('accuracy');
 
-  useEffect(() => {
-    const load = async () => {
-      const [lessons, exercises, grades] = await Promise.all([
+  React.useEffect(() => {
+    const subscription = liveQuery(async () => {
+      const [lessons, exercises, grades, flashcards] = await Promise.all([
         db.lessons.toArray(),
         db.exercises.toArray(),
         db.grades.toArray(),
+        db.flashcards.toArray(),
       ]);
-      const mastered = new Set(grades.filter((grade) => grade.isCorrect).map((grade) => grade.exerciseId));
-      setProgress(exercises.length ? (mastered.size / exercises.length) * 100 : 0);
-      setSnapshot(computeAnalytics(lessons, exercises, grades));
-      setLoading(false);
-    };
-    load();
+      return { lessons, exercises, grades, flashcards };
+    }).subscribe({
+      next: ({ lessons, exercises, grades, flashcards }) => {
+        const mastery = computeAnalytics(lessons, exercises, grades, flashcards);
+        const masteredExercises = mastery.lessonMastery.reduce(
+          (total, entry) => total + entry.masteredExercises,
+          0
+        );
+        setProgress(exercises.length ? (masteredExercises / exercises.length) * 100 : 0);
+        setSnapshot(mastery);
+        setLoading(false);
+      },
+      error: (error) => {
+        console.error('Failed to load analytics snapshot', error);
+      },
+    });
+
+    return () => subscription.unsubscribe();
   }, []);
+
+  const sortedLessons = useMemo(() => {
+    if (!snapshot) return [] as LessonMasteryStat[];
+    const entries = [...snapshot.lessonMastery];
+    if (lessonSort === 'accuracy') {
+      return entries.sort((a, b) => a.accuracy - b.accuracy);
+    }
+    return entries.sort((a, b) => {
+      const aTime = a.lastAttemptAt ? new Date(a.lastAttemptAt).getTime() : 0;
+      const bTime = b.lastAttemptAt ? new Date(b.lastAttemptAt).getTime() : 0;
+      return bTime - aTime;
+    });
+  }, [lessonSort, snapshot]);
+
+  const sortedSkills = useMemo(() => {
+    if (!snapshot) return [] as SkillAccuracy[];
+    const entries = [...snapshot.skillAccuracy];
+    if (skillSort === 'volume') {
+      return entries.sort((a, b) => b.total - a.total);
+    }
+    return entries.sort((a, b) => a.accuracy - b.accuracy);
+  }, [skillSort, snapshot]);
+
+  const handleExportLessons = () => {
+    if (!snapshot) return;
+    const rows = [
+      ['Lesson', 'Mastered', 'Exercises', 'Accuracy %', 'Last studied'],
+      ...snapshot.lessonMastery.map((entry) => [
+        entry.lessonTitle,
+        `${entry.masteredExercises}`,
+        `${entry.totalExercises}`,
+        entry.accuracy.toFixed(1),
+        entry.lastAttemptAt ? new Date(entry.lastAttemptAt).toLocaleString() : 'Never',
+      ]),
+    ];
+    downloadCsv('lesson-mastery.csv', rows);
+  };
+
+  const handleCopySummary = async () => {
+    if (!snapshot) return;
+    const summary = `Mastery: ${progress.toFixed(1)}%\nCurrent streak: ${snapshot.streak.current} days (best ${snapshot.streak.best})\nWeakest tag: ${snapshot.weakestTags[0]?.tag ?? 'N/A'}\nDue flashcards: ${snapshot.srs.dueNow}`;
+    try {
+      await navigator.clipboard.writeText(summary);
+      // eslint-disable-next-line no-console
+      console.info('Copied summary to clipboard');
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Clipboard unavailable', error);
+    }
+  };
 
   if (loading) {
     return (
@@ -60,38 +156,148 @@ export const Dashboard: React.FC = () => {
           <h2 className={styles.progressLabel}>Mastery progress</h2>
           <span className={styles.progressBadge}>{progress.toFixed(1)}% mastered</span>
         </div>
-        <div className={styles.progressTrack} role="progressbar" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
+        <div
+          className={styles.progressTrack}
+          role="progressbar"
+          aria-valuenow={progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
           <div className={styles.progressValue} style={{ width: `${Math.min(progress, 100)}%` }} />
         </div>
-        <p className="ui-section__subtitle">
-          Average attempts to mastery: {snapshot.averageAttemptsToMastery.toFixed(2)}
-        </p>
+        <div className={styles.progressMeta}>
+          <span>Average attempts to mastery: {snapshot.averageAttemptsToMastery.toFixed(2)}</span>
+          <span>Current streak: {snapshot.streak.current} days (best {snapshot.streak.best})</span>
+        </div>
+        <div className={styles.actionsRow}>
+          <button type="button" className="ui-button ui-button--secondary" onClick={handleExportLessons}>
+            Export lesson CSV
+          </button>
+          <button type="button" className="ui-button ui-button--ghost" onClick={handleCopySummary}>
+            Copy summary
+          </button>
+        </div>
       </section>
 
-      <section className="ui-card" aria-label="Time on task by lesson">
-        <h3 className="ui-section__title">Time on task (per lesson)</h3>
-        {snapshot.lessonTimes.length === 0 ? (
-          <p className="ui-alert ui-alert--info">No lesson time logged yet.</p>
-        ) : (
-          <div className={styles.tableWrapper}>
-            <table className="ui-table" aria-label="Lesson time summary">
-              <thead>
-                <tr>
-                  <th>Lesson</th>
-                  <th>Time</th>
-                </tr>
-              </thead>
-              <tbody>
-                {snapshot.lessonTimes.map((lesson) => (
-                  <tr key={lesson.lessonId}>
-                    <td>{lesson.lessonTitle}</td>
-                    <td>{formatDuration(lesson.totalMs)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      <section className="ui-card" aria-label="Recent activity trend">
+        <h3 className="ui-section__title">Activity streak and trend</h3>
+        <div className={styles.activitySummary}>
+          <p className={styles.activityMeta}>
+            Last studied: {snapshot.streak.lastStudiedOn ? new Date(snapshot.streak.lastStudiedOn).toLocaleString() : 'No attempts yet'}
+          </p>
+          <div className={styles.sparkline} role="img" aria-label="Exercise attempts over the last 14 days">
+            {snapshot.activityTrend.map((point) => {
+              const ratio = point.total ? point.correct / point.total : 0;
+              return (
+                <div
+                  key={point.date}
+                  className={styles.sparklineBar}
+                  style={{ height: `${Math.max(12, ratio * 100)}%` }}
+                  title={formatActivityTooltip(point)}
+                  data-active={point.total > 0}
+                />
+              );
+            })}
           </div>
-        )}
+        </div>
+      </section>
+
+      <section className="ui-card" aria-label="Lesson mastery table">
+        <div className={styles.sectionHeader}>
+          <h3 className="ui-section__title">Lesson mastery</h3>
+          <div className={styles.sectionControls}>
+            <button
+              type="button"
+              className={styles.sortButton}
+              data-active={lessonSort === 'recent'}
+              onClick={() => setLessonSort('recent')}
+            >
+              Sort by recency
+            </button>
+            <button
+              type="button"
+              className={styles.sortButton}
+              data-active={lessonSort === 'accuracy'}
+              onClick={() => setLessonSort('accuracy')}
+            >
+              Sort by accuracy
+            </button>
+          </div>
+        </div>
+        <div className={styles.tableWrapper}>
+          <table className="ui-table" aria-label="Lesson mastery">
+            <thead>
+              <tr>
+                <th>Lesson</th>
+                <th>Mastered</th>
+                <th>Accuracy</th>
+                <th>Last studied</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedLessons.map((lesson) => (
+                <tr key={lesson.lessonId}>
+                  <td>
+                    {lesson.lessonSlug ? (
+                      <Link to={`/lessons/${lesson.lessonSlug}`}>{lesson.lessonTitle}</Link>
+                    ) : (
+                      lesson.lessonTitle
+                    )}
+                  </td>
+                  <td>
+                    {lesson.masteredExercises}/{lesson.totalExercises}
+                  </td>
+                  <td>{lesson.accuracy.toFixed(1)}%</td>
+                  <td>{formatLastStudied(lesson.lastAttemptAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="ui-card" aria-label="Skill breakdown">
+        <div className={styles.sectionHeader}>
+          <h3 className="ui-section__title">Skill accuracy</h3>
+          <div className={styles.sectionControls}>
+            <button
+              type="button"
+              className={styles.sortButton}
+              data-active={skillSort === 'accuracy'}
+              onClick={() => setSkillSort('accuracy')}
+            >
+              Lowest accuracy
+            </button>
+            <button
+              type="button"
+              className={styles.sortButton}
+              data-active={skillSort === 'volume'}
+              onClick={() => setSkillSort('volume')}
+            >
+              Most attempts
+            </button>
+          </div>
+        </div>
+        <div className={styles.tableWrapper}>
+          <table className="ui-table" aria-label="Skill accuracy">
+            <thead>
+              <tr>
+                <th>Skill</th>
+                <th>Accuracy</th>
+                <th>Attempts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedSkills.map((skill) => (
+                <tr key={skill.skill}>
+                  <td>{skill.skill}</td>
+                  <td>{skill.accuracy.toFixed(1)}%</td>
+                  <td>{skill.total}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </section>
 
       <section className="ui-card" aria-label="Weakest tags">
@@ -122,6 +328,29 @@ export const Dashboard: React.FC = () => {
         )}
       </section>
 
+      <section className="ui-card" aria-label="SRS summary">
+        <h3 className="ui-section__title">Spaced repetition load</h3>
+        <div className={styles.srsGrid}>
+          <div className={styles.srsTile}>
+            <span className={styles.srsLabel}>Due now</span>
+            <span className={styles.srsValue}>{snapshot.srs.dueNow}</span>
+          </div>
+          {snapshot.srs.upcoming.map((entry) => (
+            <div key={entry.label} className={styles.srsTile}>
+              <span className={styles.srsLabel}>{entry.label}</span>
+              <span className={styles.srsValue}>{entry.count}</span>
+            </div>
+          ))}
+        </div>
+        <div className={styles.bucketList}>
+          {snapshot.srs.bucketBreakdown.map((bucket) => (
+            <span key={bucket.bucket} className={styles.bucketChip}>
+              Bucket {bucket.bucket}: {bucket.due}/{bucket.total} due
+            </span>
+          ))}
+        </div>
+      </section>
+
       <section className="ui-card" aria-label="Recommended exercises">
         <h3 className="ui-section__title">Study plan (next five exercises)</h3>
         {snapshot.studyPlan.length === 0 ? (
@@ -138,6 +367,34 @@ export const Dashboard: React.FC = () => {
           </ol>
         )}
       </section>
+
+      <section className="ui-card" aria-label="Time on task by lesson">
+        <h3 className="ui-section__title">Time on task (per lesson)</h3>
+        {snapshot.lessonTimes.length === 0 ? (
+          <p className="ui-alert ui-alert--info">No lesson time logged yet.</p>
+        ) : (
+          <div className={styles.tableWrapper}>
+            <table className="ui-table" aria-label="Lesson time summary">
+              <thead>
+                <tr>
+                  <th>Lesson</th>
+                  <th>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.lessonTimes.map((lesson) => (
+                  <tr key={lesson.lessonId}>
+                    <td>{lesson.lessonTitle}</td>
+                    <td>{formatDuration(lesson.totalMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
     </div>
   );
 };
+
+export default Dashboard;

--- a/src/components/ExerciseEngine.module.css
+++ b/src/components/ExerciseEngine.module.css
@@ -5,6 +5,23 @@
   margin-bottom: 24px;
 }
 
+.exerciseMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.topicBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
 .prompt {
   border-radius: var(--ui-radius-lg);
   border: 1px solid var(--ui-border);
@@ -132,4 +149,44 @@
   background: rgba(248, 113, 113, 0.12);
   border: 1px solid rgba(248, 113, 113, 0.45);
   color: #b91c1c;
+}
+
+.supportRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.supportButton {
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-surface);
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.supportButton:hover,
+.supportButton:focus-visible {
+  border-color: var(--ui-accent);
+  color: var(--ui-accent-strong);
+}
+
+.hintList {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--ui-text-secondary);
+}
+
+.rubric {
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  padding: 16px;
+  color: var(--ui-text-secondary);
 }

--- a/src/components/FlashcardTrainer.module.css
+++ b/src/components/FlashcardTrainer.module.css
@@ -32,6 +32,35 @@
   color: var(--ui-text-muted);
 }
 
+.deckStats {
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.controlGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.controlLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ui-text-secondary);
+}
+
+.controlLabel select {
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  padding: 8px 14px;
+  background: var(--ui-surface);
+  font-size: 0.9rem;
+}
+
 .headerStatus {
   border-radius: var(--ui-radius-pill);
   padding: 6px 14px;
@@ -52,6 +81,14 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.cardMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
 }
 
 .promptLabel {
@@ -120,16 +157,28 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.gradeSuccess {
+.gradeAgain {
+  background: linear-gradient(135deg, #f97316, #ef4444);
+  color: #fff7ed;
+  box-shadow: 0 16px 40px -26px rgba(239, 68, 68, 0.45);
+}
+
+.gradeHard {
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+  color: #451a03;
+  box-shadow: 0 16px 40px -26px rgba(245, 158, 11, 0.45);
+}
+
+.gradeGood {
   background: linear-gradient(135deg, #22c55e, #16a34a);
   color: var(--ui-text-inverse);
   box-shadow: 0 16px 40px -26px rgba(34, 197, 94, 0.6);
 }
 
-.gradeRetry {
-  background: linear-gradient(135deg, #f87171, #ef4444);
-  color: #fff5f5;
-  box-shadow: 0 16px 40px -26px rgba(239, 68, 68, 0.45);
+.gradeEasy {
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+  color: #ecf4ff;
+  box-shadow: 0 16px 40px -26px rgba(59, 130, 246, 0.45);
 }
 
 .gradeButton:hover,
@@ -164,6 +213,24 @@
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--ui-text-muted);
+}
+
+.bucketSummary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.bucketChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(14, 165, 233, 0.12);
+  color: #0e7490;
+  font-weight: 600;
+  font-size: 0.85rem;
 }
 
 .emptyState {

--- a/src/components/FlashcardTrainer.tsx
+++ b/src/components/FlashcardTrainer.tsx
@@ -1,43 +1,131 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { db } from '../db';
-import { isDue, updateSRS } from '../lib/srs';
+import { describeDueStatus, isDue, summarizeBuckets, updateSRS, ReviewGrade } from '../lib/srs';
 import { Flashcard } from '../lib/schemas';
 import styles from './FlashcardTrainer.module.css';
 
+const sessionOptions = [
+  { value: 10, label: '10 cards' },
+  { value: 20, label: '20 cards' },
+  { value: 0, label: 'All due cards' },
+];
+
+const gradeChoices: { grade: ReviewGrade; label: string; hotkey: string }[] = [
+  { grade: 'again', label: 'Again', hotkey: '1' },
+  { grade: 'hard', label: 'Hard', hotkey: '2' },
+  { grade: 'good', label: 'Good', hotkey: '3' },
+  { grade: 'easy', label: 'Easy', hotkey: '4' },
+];
+
+interface TrainerStats {
+  dueTotal: number;
+  buckets: ReturnType<typeof summarizeBuckets>;
+}
+
+const computeStats = (cards: Flashcard[]): TrainerStats => ({
+  dueTotal: cards.filter(isDue).length,
+  buckets: summarizeBuckets(cards),
+});
+
+const sortByDue = (cards: Flashcard[]) =>
+  [...cards].sort((a, b) => {
+    const aDue = a.srs?.nextDue ? new Date(a.srs.nextDue).getTime() : 0;
+    const bDue = b.srs?.nextDue ? new Date(b.srs.nextDue).getTime() : 0;
+    return aDue - bDue;
+  });
+
 export const FlashcardTrainer: React.FC = () => {
-  const [cards, setCards] = useState<Flashcard[]>([]);
+  const [allCards, setAllCards] = useState<Flashcard[]>([]);
+  const [queue, setQueue] = useState<Flashcard[]>([]);
   const [current, setCurrent] = useState<Flashcard | null>(null);
   const [showBack, setShowBack] = useState(false);
+  const [deckFilter, setDeckFilter] = useState<'all' | Flashcard['deck']>('all');
+  const [tagFilter, setTagFilter] = useState<'all' | string>('all');
+  const [sessionLength, setSessionLength] = useState<number>(20);
   const [totalCards, setTotalCards] = useState(0);
+  const [completed, setCompleted] = useState(0);
+  const [skipRebuild, setSkipRebuild] = useState(false);
+  const [stats, setStats] = useState<TrainerStats>({ dueTotal: 0, buckets: [] });
 
   useEffect(() => {
     let active = true;
-    db.flashcards.toArray().then((all) => {
+    const load = async () => {
+      const cards = await db.flashcards.toArray();
       if (!active) return;
-      const due = all.filter(isDue);
-      setCards(due);
-      setCurrent(due[0] ?? null);
-      setShowBack(false);
-      setTotalCards(due.length);
-    });
+      setAllCards(cards);
+      setStats(computeStats(cards));
+    };
+    load();
     return () => {
       active = false;
     };
   }, []);
 
-  const advance = useCallback((remaining: Flashcard[]) => {
-    setCards(remaining);
-    setCurrent(remaining[0] ?? null);
-    setShowBack(false);
-  }, []);
+  const deckOptions = useMemo(() => {
+    const entries = new Set<Flashcard['deck']>();
+    allCards.forEach((card) => entries.add(card.deck));
+    return Array.from(entries.values());
+  }, [allCards]);
 
-  const grade = useCallback(async (success: boolean) => {
-    if (!current) return;
-    const updated = updateSRS(current, success);
-    await db.flashcards.put(updated);
-    advance(cards.slice(1));
-  }, [advance, cards, current]);
+  const tagOptions = useMemo(() => {
+    const entries = new Set<string>();
+    allCards.forEach((card) => entries.add(card.tag));
+    return Array.from(entries.values()).sort((a, b) => a.localeCompare(b));
+  }, [allCards]);
+
+  const buildQueue = useCallback(
+    (source: Flashcard[], resetProgress: boolean) => {
+      const byDeck = deckFilter === 'all' ? source : source.filter((card) => card.deck === deckFilter);
+      const byTag = tagFilter === 'all' ? byDeck : byDeck.filter((card) => card.tag === tagFilter);
+      const dueCards = sortByDue(byTag.filter(isDue));
+      const pool = dueCards.length ? dueCards : sortByDue(byTag);
+      const limit = sessionLength > 0 ? sessionLength : pool.length;
+      const nextQueue = pool.slice(0, limit);
+      setQueue(nextQueue);
+      setCurrent(nextQueue[0] ?? null);
+      setShowBack(false);
+      if (resetProgress) {
+        setCompleted(0);
+        setTotalCards(nextQueue.length);
+      } else {
+        setTotalCards((prev) => Math.max(prev, nextQueue.length + completed));
+      }
+    },
+    [deckFilter, tagFilter, sessionLength, completed]
+  );
+
+  useEffect(() => {
+    if (skipRebuild) {
+      setSkipRebuild(false);
+      return;
+    }
+    buildQueue(allCards, true);
+  }, [allCards, deckFilter, tagFilter, sessionLength, skipRebuild, buildQueue]);
+
+  const progress = totalCards > 0 ? Math.round((completed / totalCards) * 100) : 0;
+
+  const gradeCard = useCallback(
+    async (grade: ReviewGrade) => {
+      if (!current) return;
+      const updated = updateSRS(current, grade);
+      await db.flashcards.put(updated);
+      setSkipRebuild(true);
+      setQueue((prev) => {
+        const nextQueue = prev.slice(1);
+        setCurrent(nextQueue[0] ?? null);
+        return nextQueue;
+      });
+      setCompleted((prev) => prev + 1);
+      setShowBack(false);
+      setAllCards((prev) => {
+        const next = prev.map((card) => (card.id === updated.id ? updated : card));
+        setStats(computeStats(next));
+        return next;
+      });
+    },
+    [current]
+  );
 
   useEffect(() => {
     const handleKey = (event: KeyboardEvent) => {
@@ -45,19 +133,28 @@ export const FlashcardTrainer: React.FC = () => {
       if (event.key === ' ' || event.key === 'Spacebar') {
         event.preventDefault();
         setShowBack((prev) => !prev);
+        return;
       }
-      if (showBack && (event.key === 'ArrowRight' || event.key.toLowerCase() === 'k')) {
+      if (!showBack) return;
+      const keyMap: Record<string, ReviewGrade> = {
+        '1': 'again',
+        '2': 'hard',
+        '3': 'good',
+        '4': 'easy',
+        ArrowLeft: 'hard',
+        ArrowRight: 'good',
+        ArrowDown: 'again',
+        ArrowUp: 'easy',
+      };
+      const grade = keyMap[event.key];
+      if (grade) {
         event.preventDefault();
-        grade(true);
-      }
-      if (showBack && (event.key === 'ArrowLeft' || event.key.toLowerCase() === 'j')) {
-        event.preventDefault();
-        grade(false);
+        gradeCard(grade);
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [current, grade, showBack]);
+  }, [current, gradeCard, showBack]);
 
   if (!current) {
     return (
@@ -81,9 +178,7 @@ export const FlashcardTrainer: React.FC = () => {
     );
   }
 
-  const remaining = cards.length;
-  const completed = totalCards - remaining;
-  const progress = totalCards > 0 ? Math.round((completed / totalCards) * 100) : 0;
+  const deckBreakdown = stats.buckets.filter((bucket) => bucket.total > 0);
 
   return (
     <section className={styles.trainer} aria-live="polite">
@@ -93,8 +188,53 @@ export const FlashcardTrainer: React.FC = () => {
           <span className="ui-section__subtitle">
             {completed} of {totalCards} cards complete
           </span>
+          <div className={styles.deckStats}>
+            Due total: {stats.dueTotal}
+          </div>
         </div>
-        <span className={styles.headerStatus}>{remaining} left</span>
+        <div className={styles.controlGroup}>
+          <label className={styles.controlLabel}>
+            Deck
+            <select
+              value={deckFilter}
+              onChange={(event) => setDeckFilter(event.target.value as typeof deckFilter)}
+            >
+              <option value="all">All decks</option>
+              {deckOptions.map((deck) => (
+                <option key={deck} value={deck}>
+                  {deck}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.controlLabel}>
+            Tag
+            <select
+              value={tagFilter}
+              onChange={(event) => setTagFilter(event.target.value as typeof tagFilter)}
+            >
+              <option value="all">All tags</option>
+              {tagOptions.map((tag) => (
+                <option key={tag} value={tag}>
+                  {tag}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.controlLabel}>
+            Session length
+            <select
+              value={sessionLength}
+              onChange={(event) => setSessionLength(Number(event.target.value))}
+            >
+              {sessionOptions.map((option) => (
+                <option key={option.label} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </header>
 
       <div className={styles.cardSurface}>
@@ -102,6 +242,11 @@ export const FlashcardTrainer: React.FC = () => {
         <p className={styles.promptText} aria-label="Flashcard front">
           {current.front}
         </p>
+        <div className={styles.cardMeta}>
+          <span>{current.deck}</span>
+          <span>{current.tag}</span>
+          <span>{describeDueStatus(current)}</span>
+        </div>
         {showBack && (
           <div className={styles.answerSurface} aria-label="Flashcard back">
             {current.back}
@@ -121,37 +266,41 @@ export const FlashcardTrainer: React.FC = () => {
           </button>
         ) : (
           <div className={styles.buttonRow}>
-            <button
-              type="button"
-              onClick={() => grade(true)}
-              className={`${styles.gradeButton} ${styles.gradeSuccess}`}
-              aria-label="I remembered it (arrow right or K)"
-            >
-              I knew it
-            </button>
-            <button
-              type="button"
-              onClick={() => grade(false)}
-              className={`${styles.gradeButton} ${styles.gradeRetry}`}
-              aria-label="I forgot (arrow left or J)"
-            >
-              I forgot
-            </button>
+            {gradeChoices.map((choice) => (
+              <button
+                key={choice.grade}
+                type="button"
+                onClick={() => gradeCard(choice.grade)}
+                className={`${styles.gradeButton} ${styles[`grade${choice.grade[0].toUpperCase()}${choice.grade.slice(1)}`] ?? ''}`}
+                aria-label={`${choice.label} (hotkey ${choice.hotkey})`}
+              >
+                {choice.label}
+              </button>
+            ))}
           </div>
         )}
 
         <div className={styles.progress}>
           <div className="ui-section__subtitle">Progress {progress}%</div>
           <div className={styles.progressBar}>
-            <div
-              className={styles.progressFill}
-              style={{ width: `${totalCards > 0 ? (completed / totalCards) * 100 : 0}%` }}
-            />
+            <div className={styles.progressFill} style={{ width: `${progress}%` }} />
           </div>
         </div>
 
-        <p className={styles.keyboardHint}>Space — reveal · J / ← — Forgot · K / → — Knew it</p>
+        <p className={styles.keyboardHint}>
+          Space — reveal · 1 Again · 2 Hard · 3 Good · 4 Easy · Arrows also grade
+        </p>
       </div>
+
+      {deckBreakdown.length > 0 && (
+        <div className={styles.bucketSummary}>
+          {deckBreakdown.map((bucket) => (
+            <span key={bucket.bucket} className={styles.bucketChip}>
+              Bucket {bucket.bucket}: {bucket.due}/{bucket.total}
+            </span>
+          ))}
+        </div>
+      )}
     </section>
   );
 };

--- a/src/components/layout/AppShell.module.css
+++ b/src/components/layout/AppShell.module.css
@@ -64,6 +64,10 @@
   scrollbar-width: thin;
 }
 
+.primaryColumn[data-collapsed='true'] {
+  display: none;
+}
+
 .primaryColumn::-webkit-scrollbar {
   width: 6px;
 }
@@ -259,6 +263,27 @@
   color: var(--ui-text-secondary);
 }
 
+.quickLinkMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.quickLinkBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .quickLinkIcon {
   font-size: 1.2rem;
   color: var(--ui-accent-strong);
@@ -307,6 +332,28 @@
   flex: 1;
 }
 
+.navToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  color: var(--ui-text-secondary);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.navToggle[aria-pressed='true'] {
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--ui-accent-strong);
+  border-color: var(--ui-accent);
+}
+
 .flowPill {
   display: inline-flex;
   align-items: center;
@@ -352,6 +399,47 @@
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.toolbarSearch {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 8px;
+  padding: 4px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+}
+
+.searchInput {
+  border: none;
+  background: transparent;
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  font-size: 0.9rem;
+  min-width: 220px;
+  outline: none;
+  color: var(--ui-text-primary);
+}
+
+.searchInput::placeholder {
+  color: var(--ui-text-muted);
+}
+
+.searchButton {
+  border: none;
+  border-radius: var(--ui-radius-pill);
+  padding: 6px 14px;
+  background: var(--ui-accent);
+  color: var(--ui-text-inverse);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.searchButton:hover,
+.searchButton:focus-visible {
+  background: var(--ui-accent-strong);
 }
 
 .contrastToggle {
@@ -448,6 +536,14 @@
   min-width: 0;
 }
 
+.contentArea[data-focus='on'] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.contentArea[data-focus='on'] .sidePanel {
+  display: none;
+}
+
 .main {
   min-width: 0;
 }
@@ -484,6 +580,10 @@
   font-size: 0.9rem;
 }
 
+[data-focus-mode='on'] .footer {
+  display: none;
+}
+
 @media (max-width: 1200px) {
   .shellLayout {
     grid-template-columns: minmax(0, 1fr);
@@ -516,12 +616,31 @@
     gap: 16px;
   }
 
+  .navToggle {
+    align-self: flex-end;
+  }
+
   .flowPill {
     order: 1;
   }
 
   .toolbarText {
     order: 0;
+  }
+
+  .toolbarActions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .toolbarSearch {
+    flex: 1;
+    width: 100%;
+  }
+
+  .searchInput {
+    min-width: 0;
+    flex: 1;
   }
 }
 

--- a/src/hooks/useHighContrast.ts
+++ b/src/hooks/useHighContrast.ts
@@ -8,9 +8,16 @@ type HighContrastState = {
   toggle: () => void;
 };
 
+const applyClass = (enabled: boolean) => {
+  if (typeof document === 'undefined') return;
+  document.body.classList.toggle('high-contrast', enabled);
+  document.documentElement.dataset.contrast = enabled ? 'high' : 'default';
+};
+
 export const useHighContrast = (): HighContrastState => {
   const [enabled, setEnabled] = useState(false);
   const [hydrated, setHydrated] = useState(false);
+  const [hasExplicitPreference, setHasExplicitPreference] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -18,7 +25,13 @@ export const useHighContrast = (): HighContrastState => {
       try {
         const setting = await db.settings.get(STORAGE_KEY);
         if (!active) return;
-        if (setting) setEnabled(Boolean(setting.value));
+        if (setting) {
+          setEnabled(Boolean(setting.value));
+          setHasExplicitPreference(true);
+        } else if (typeof window !== 'undefined' && window.matchMedia) {
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          setEnabled(prefersDark);
+        }
       } finally {
         if (active) setHydrated(true);
       }
@@ -31,13 +44,23 @@ export const useHighContrast = (): HighContrastState => {
 
   useEffect(() => {
     if (!hydrated) return;
-    if (typeof document !== 'undefined') {
-      document.body.classList.toggle('high-contrast', enabled);
-    }
+    applyClass(enabled);
     db.settings.put({ key: STORAGE_KEY, value: enabled });
   }, [enabled, hydrated]);
 
+  useEffect(() => {
+    if (!hydrated || hasExplicitPreference) return;
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const query = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = (event: MediaQueryListEvent) => {
+      setEnabled(event.matches);
+    };
+    query.addEventListener('change', listener);
+    return () => query.removeEventListener('change', listener);
+  }, [hasExplicitPreference, hydrated]);
+
   const toggle = useCallback(() => {
+    setHasExplicitPreference(true);
     setEnabled((prev) => !prev);
   }, []);
 

--- a/src/hooks/useWorkspaceSnapshot.ts
+++ b/src/hooks/useWorkspaceSnapshot.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { liveQuery } from 'dexie';
+import { db } from '../db';
+import { computeAnalytics, StudyRecommendation } from '../lib/analytics';
+import { Lesson } from '../lib/schemas';
+
+export interface ResumeLesson {
+  lessonId: string;
+  lessonSlug?: string;
+  lessonTitle: string;
+  lastAttemptAt?: string;
+  masteredCount: number;
+  totalExercises: number;
+}
+
+export interface WorkspaceSnapshot {
+  loading: boolean;
+  lessons: Lesson[];
+  resumeLesson?: ResumeLesson;
+  dueFlashcards: number;
+  deckDue: { deck: string; due: number; total: number }[];
+  weakestTag?: { tag: string; accuracy: number };
+  studyPlan: StudyRecommendation[];
+}
+
+const initialState: WorkspaceSnapshot = {
+  loading: true,
+  lessons: [],
+  dueFlashcards: 0,
+  deckDue: [],
+  studyPlan: [],
+};
+
+export const useWorkspaceSnapshot = () => {
+  const [snapshot, setSnapshot] = useState<WorkspaceSnapshot>(initialState);
+
+  useEffect(() => {
+    const subscription = liveQuery(async () => {
+      const [lessons, exercises, grades, flashcards] = await Promise.all([
+        db.lessons.toArray(),
+        db.exercises.toArray(),
+        db.grades.toArray(),
+        db.flashcards.toArray(),
+      ]);
+      return { lessons, exercises, grades, flashcards };
+    }).subscribe({
+      next: ({ lessons, exercises, grades, flashcards }) => {
+        const analytics = computeAnalytics(lessons, exercises, grades, flashcards);
+
+        const resumeLessonEntry = analytics.lessonMastery.find((entry) => Boolean(entry.lastAttemptAt));
+
+        const resumeLesson = resumeLessonEntry
+          ? {
+              lessonId: resumeLessonEntry.lessonId,
+              lessonSlug: resumeLessonEntry.lessonSlug,
+              lessonTitle: resumeLessonEntry.lessonTitle,
+              lastAttemptAt: resumeLessonEntry.lastAttemptAt,
+              masteredCount: resumeLessonEntry.masteredExercises,
+              totalExercises: resumeLessonEntry.totalExercises,
+            }
+          : undefined;
+
+        const weakestTag = analytics.weakestTags[0]
+          ? { tag: analytics.weakestTags[0].tag, accuracy: analytics.weakestTags[0].accuracy }
+          : undefined;
+
+        setSnapshot({
+          loading: false,
+          lessons,
+          resumeLesson,
+          dueFlashcards: analytics.srs.dueNow,
+          deckDue: analytics.srs.deckBreakdown,
+          weakestTag,
+          studyPlan: analytics.studyPlan,
+        });
+      },
+      error: (error) => {
+        console.error('Failed to load workspace snapshot', error);
+      },
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return snapshot;
+};

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,163 @@
+import { computeAnalytics } from '../analytics';
+import { Exercise, Flashcard, Grade, Lesson } from '../schemas';
+
+describe('computeAnalytics', () => {
+  const lessons: Lesson[] = [
+    {
+      id: 'lesson-1',
+      level: 'B1',
+      title: 'Subjunctive drill',
+      slug: 'subjunctive-drill',
+      tags: ['subjunctive', 'verbs'],
+      markdown: '# Subjunctive',
+      references: [],
+    },
+    {
+      id: 'lesson-2',
+      level: 'C1',
+      title: 'Presentation polish',
+      slug: 'presentation-polish',
+      tags: ['presentation'],
+      markdown: '# Presentations',
+      references: [],
+    },
+  ];
+
+  const exercises: Exercise[] = [
+    {
+      id: 'ex-1',
+      lessonId: 'lesson-1',
+      type: 'translate',
+      promptMd: 'Traduce **hola**',
+      answer: 'hola',
+      meta: { difficulty: 'B1', skills: ['write', 'speak'] },
+    },
+    {
+      id: 'ex-2',
+      lessonId: 'lesson-1',
+      type: 'translate',
+      promptMd: 'Traduce **adiós**',
+      answer: 'adiós',
+      meta: { difficulty: 'B2', skills: ['write', 'speak'] },
+    },
+    {
+      id: 'ex-3',
+      lessonId: 'lesson-2',
+      type: 'short',
+      promptMd: 'Escribe una frase de cierre impactante.',
+      answer: 'Cierre',
+      meta: { difficulty: 'C1', skills: ['speak'] },
+    },
+  ];
+
+  const baseDate = new Date('2024-06-10T12:00:00.000Z');
+  const daysAgo = (offset: number) => {
+    const date = new Date(baseDate);
+    date.setDate(date.getDate() - offset);
+    return date.toISOString();
+  };
+
+  const grades: Grade[] = [
+    {
+      id: 'grade-1',
+      exerciseId: 'ex-1',
+      userAnswer: 'hola',
+      isCorrect: true,
+      score: 100,
+      attempts: 1,
+      timeMs: 12000,
+      gradedAt: daysAgo(0),
+    },
+    {
+      id: 'grade-2',
+      exerciseId: 'ex-2',
+      userAnswer: 'adios',
+      isCorrect: false,
+      score: 40,
+      attempts: 1,
+      timeMs: 15000,
+      gradedAt: daysAgo(1),
+    },
+    {
+      id: 'grade-3',
+      exerciseId: 'ex-2',
+      userAnswer: 'adiós',
+      isCorrect: true,
+      score: 90,
+      attempts: 2,
+      timeMs: 20000,
+      gradedAt: daysAgo(0),
+    },
+    {
+      id: 'grade-4',
+      exerciseId: 'ex-3',
+      userAnswer: 'Cerrar',
+      isCorrect: false,
+      score: 60,
+      attempts: 1,
+      timeMs: 10000,
+      gradedAt: daysAgo(2),
+    },
+  ];
+
+  const flashcards: Flashcard[] = [
+    {
+      id: 'card-1',
+      front: 'ser',
+      back: 'to be',
+      tag: 'verbs',
+      deck: 'verbs',
+      srs: {
+        bucket: 1,
+        lastReview: daysAgo(1),
+        nextDue: daysAgo(0),
+        streak: 2,
+        lastGrade: 'good',
+      },
+    },
+    {
+      id: 'card-2',
+      front: 'aunque',
+      back: 'although',
+      tag: 'connectors',
+      deck: 'grammar',
+      srs: {
+        bucket: 3,
+        lastReview: daysAgo(2),
+        nextDue: new Date(baseDate.getTime() + 24 * 60 * 60 * 1000).toISOString(),
+        streak: 3,
+        lastGrade: 'easy',
+      },
+    },
+    {
+      id: 'card-3',
+      front: 'pitch',
+      back: 'presentación',
+      tag: 'presentation',
+      deck: 'presentations',
+    },
+  ];
+
+  it('computes streaks, mastery, and SRS summaries', () => {
+    const snapshot = computeAnalytics(lessons, exercises, grades, flashcards);
+
+    expect(snapshot.lessonMastery.length).toBe(2);
+    const lesson = snapshot.lessonMastery.find((entry) => entry.lessonId === 'lesson-1');
+    expect(lesson).toBeDefined();
+    expect(lesson?.masteredExercises).toBe(2);
+    expect(lesson?.attemptedExercises).toBe(2);
+
+    expect(snapshot.skillAccuracy.find((entry) => entry.skill === 'speak')?.total).toBe(4);
+    expect(snapshot.studyPlan.some((entry) => entry.exerciseId === 'ex-3')).toBe(true);
+
+    expect(snapshot.streak.best).toBeGreaterThanOrEqual(3);
+    expect(snapshot.activityTrend).toHaveLength(14);
+
+    expect(snapshot.srs.dueNow).toBeGreaterThanOrEqual(2);
+    const verbsDeck = snapshot.srs.deckBreakdown.find((entry) => entry.deck === 'verbs');
+    expect(verbsDeck).toBeDefined();
+    expect(verbsDeck?.total).toBe(1);
+    expect((verbsDeck?.due ?? 0)).toBeGreaterThanOrEqual(1);
+    expect(snapshot.srs.bucketBreakdown.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,9 +1,21 @@
-import { Exercise, Grade, Lesson } from './schemas';
+import { Exercise, Flashcard, Grade, Lesson } from './schemas';
+import { isDue, summarizeBuckets } from './srs';
 
 export interface LessonTimeStat {
   lessonId: string;
   lessonTitle: string;
   totalMs: number;
+}
+
+export interface LessonMasteryStat {
+  lessonId: string;
+  lessonTitle: string;
+  lessonSlug?: string;
+  totalExercises: number;
+  attemptedExercises: number;
+  masteredExercises: number;
+  accuracy: number;
+  lastAttemptAt?: string;
 }
 
 export interface TagWeakness {
@@ -13,31 +25,86 @@ export interface TagWeakness {
   total: number;
 }
 
+export interface SkillAccuracy {
+  skill: string;
+  accuracy: number;
+  correct: number;
+  total: number;
+}
+
 export interface StudyRecommendation {
   exerciseId: string;
   lessonId: string;
+  lessonSlug?: string;
   lessonTitle: string;
   prompt: string;
   reason: string;
   priority: number;
 }
 
-export interface AnalyticsSnapshot {
-  lessonTimes: LessonTimeStat[];
-  averageAttemptsToMastery: number;
-  weakestTags: TagWeakness[];
-  studyPlan: StudyRecommendation[];
+export interface StudyActivityPoint {
+  date: string;
+  total: number;
+  correct: number;
 }
 
-const byDate = (a: Grade, b: Grade) =>
+export interface StudyStreak {
+  current: number;
+  best: number;
+  lastStudiedOn?: string;
+}
+
+export interface SRSSummaryEntry {
+  label: string;
+  count: number;
+}
+
+export interface SRSDashboardSummary {
+  dueNow: number;
+  upcoming: SRSSummaryEntry[];
+  bucketBreakdown: ReturnType<typeof summarizeBuckets>;
+  deckBreakdown: { deck: Flashcard['deck']; due: number; total: number }[];
+}
+
+export interface AnalyticsSnapshot {
+  lessonTimes: LessonTimeStat[];
+  lessonMastery: LessonMasteryStat[];
+  averageAttemptsToMastery: number;
+  weakestTags: TagWeakness[];
+  skillAccuracy: SkillAccuracy[];
+  studyPlan: StudyRecommendation[];
+  activityTrend: StudyActivityPoint[];
+  streak: StudyStreak;
+  srs: SRSDashboardSummary;
+}
+
+const byDateAsc = (a: Grade, b: Grade) =>
   new Date(a.gradedAt).getTime() - new Date(b.gradedAt).getTime();
+
+const dayKey = (value: string | Date) => {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString().slice(0, 10);
+};
+
+const differenceInDays = (a: Date, b: Date) => {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((a.getTime() - b.getTime()) / msPerDay);
+};
 
 export const computeAnalytics = (
   lessons: Lesson[],
   exercises: Exercise[],
-  grades: Grade[]
+  grades: Grade[],
+  flashcards: Flashcard[] = []
 ): AnalyticsSnapshot => {
   const lessonById = new Map(lessons.map((lesson) => [lesson.id, lesson]));
+  const exercisesByLesson = new Map<string, Exercise[]>();
+  exercises.forEach((exercise) => {
+    const list = exercisesByLesson.get(exercise.lessonId) ?? [];
+    list.push(exercise);
+    exercisesByLesson.set(exercise.lessonId, list);
+  });
   const exerciseById = new Map(exercises.map((exercise) => [exercise.id, exercise]));
 
   const gradesByExercise = new Map<string, Grade[]>();
@@ -46,7 +113,7 @@ export const computeAnalytics = (
     list.push(grade);
     gradesByExercise.set(grade.exerciseId, list);
   });
-  gradesByExercise.forEach((list) => list.sort(byDate));
+  gradesByExercise.forEach((list) => list.sort(byDateAsc));
 
   const lessonTimeMap = new Map<string, number>();
   grades.forEach((grade) => {
@@ -110,6 +177,7 @@ export const computeAnalytics = (
     studyPlan.push({
       exerciseId: exercise.id,
       lessonId: exercise.lessonId,
+      lessonSlug: lesson?.slug,
       lessonTitle: lesson?.title ?? exercise.lessonId,
       prompt: exercise.promptMd,
       reason: 'Not attempted yet',
@@ -146,6 +214,7 @@ export const computeAnalytics = (
     studyPlan.push({
       exerciseId: entry.exercise.id,
       lessonId: entry.exercise.lessonId,
+      lessonSlug: entry.lesson?.slug,
       lessonTitle: entry.lesson?.title ?? entry.exercise.lessonId,
       prompt: entry.exercise.promptMd,
       reason: entry.reason,
@@ -156,10 +225,166 @@ export const computeAnalytics = (
 
   studyPlan.sort((a, b) => a.priority - b.priority || a.lessonTitle.localeCompare(b.lessonTitle));
 
+  const lessonMastery: LessonMasteryStat[] = lessons.map((lesson) => {
+    const lessonExercises = exercisesByLesson.get(lesson.id) ?? [];
+    let attemptedExercises = 0;
+    let masteredExercises = 0;
+    let correct = 0;
+    let total = 0;
+    let lastAttemptAt: string | undefined;
+
+    lessonExercises.forEach((exercise) => {
+      const history = gradesByExercise.get(exercise.id) ?? [];
+      if (history.length > 0) {
+        attemptedExercises += 1;
+        const last = history[history.length - 1];
+        if (!lastAttemptAt || new Date(last.gradedAt) > new Date(lastAttemptAt)) {
+          lastAttemptAt = last.gradedAt;
+        }
+        if (last.isCorrect) masteredExercises += 1;
+        correct += history.filter((grade) => grade.isCorrect).length;
+        total += history.length;
+      }
+    });
+
+    const accuracy = total ? (correct / total) * 100 : 0;
+
+    return {
+      lessonId: lesson.id,
+      lessonTitle: lesson.title,
+      lessonSlug: lesson.slug,
+      totalExercises: lessonExercises.length,
+      attemptedExercises,
+      masteredExercises,
+      accuracy,
+      lastAttemptAt,
+    };
+  });
+
+  const skillStats = new Map<string, { correct: number; total: number }>();
+  grades.forEach((grade) => {
+    const exercise = exerciseById.get(grade.exerciseId);
+    if (!exercise) return;
+    const skills = exercise.meta?.skills?.length ? exercise.meta.skills : ['read'];
+    skills.forEach((skill) => {
+      const stats = skillStats.get(skill) ?? { correct: 0, total: 0 };
+      stats.total += 1;
+      if (grade.isCorrect) stats.correct += 1;
+      skillStats.set(skill, stats);
+    });
+  });
+  const skillAccuracy: SkillAccuracy[] = Array.from(skillStats.entries())
+    .map(([skill, stats]) => ({
+      skill,
+      accuracy: stats.total ? (stats.correct / stats.total) * 100 : 0,
+      correct: stats.correct,
+      total: stats.total,
+    }))
+    .sort((a, b) => a.accuracy - b.accuracy);
+
+  const activityByDay = new Map<string, { total: number; correct: number }>();
+  grades.forEach((grade) => {
+    const key = dayKey(grade.gradedAt);
+    const entry = activityByDay.get(key) ?? { total: 0, correct: 0 };
+    entry.total += 1;
+    if (grade.isCorrect) entry.correct += 1;
+    activityByDay.set(key, entry);
+  });
+
+  const activityTrend: StudyActivityPoint[] = [];
+  for (let offset = 13; offset >= 0; offset -= 1) {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() - offset);
+    const key = dayKey(date);
+    const entry = activityByDay.get(key) ?? { total: 0, correct: 0 };
+    activityTrend.push({ date: key, total: entry.total, correct: entry.correct });
+  }
+
+  const uniqueDays = Array.from(activityByDay.keys()).sort();
+  let bestStreak = 0;
+  let running = 0;
+  let previous: Date | null = null;
+  uniqueDays.forEach((day) => {
+    const current = new Date(day);
+    if (!previous) {
+      running = 1;
+    } else {
+      const diff = differenceInDays(current, previous);
+      running = diff === 1 ? running + 1 : 1;
+    }
+    bestStreak = Math.max(bestStreak, running);
+    previous = current;
+  });
+
+  const sortedDesc = [...uniqueDays].sort((a, b) => (a < b ? 1 : -1));
+  let currentStreak = 0;
+  let lastStudiedOn: string | undefined;
+  let cursor: Date | null = null;
+  const today = new Date();
+  sortedDesc.forEach((day) => {
+    const current = new Date(day);
+    if (currentStreak === 0) {
+      const diff = Math.abs(differenceInDays(today, current));
+      if (diff <= 1) {
+        currentStreak = 1;
+        cursor = current;
+        lastStudiedOn = day;
+      } else {
+        return;
+      }
+    } else if (cursor) {
+      const diff = differenceInDays(cursor, current);
+      if (diff === 1) {
+        currentStreak += 1;
+        cursor = current;
+        lastStudiedOn = day;
+      }
+    }
+  });
+
+  const dueNow = flashcards.filter(isDue).length;
+  const upcomingBuckets: SRSSummaryEntry[] = [
+    { label: 'Due tomorrow', count: 0 },
+    { label: 'Due in 3 days', count: 0 },
+    { label: 'Due in 7 days', count: 0 },
+  ];
+  const deckMap = new Map<Flashcard['deck'], { due: number; total: number }>();
+  flashcards.forEach((card) => {
+    const deck = deckMap.get(card.deck) ?? { due: 0, total: 0 };
+    deck.total += 1;
+    if (isDue(card)) deck.due += 1;
+    else if (card.srs?.nextDue) {
+      const diff = differenceInDays(new Date(card.srs.nextDue), new Date());
+      if (diff === 1) upcomingBuckets[0].count += 1;
+      else if (diff > 1 && diff <= 3) upcomingBuckets[1].count += 1;
+      else if (diff > 3 && diff <= 7) upcomingBuckets[2].count += 1;
+    }
+    deckMap.set(card.deck, deck);
+  });
+
+  const srs: SRSDashboardSummary = {
+    dueNow,
+    upcoming: upcomingBuckets.filter((entry) => entry.count > 0),
+    bucketBreakdown: summarizeBuckets(flashcards),
+    deckBreakdown: Array.from(deckMap.entries())
+      .map(([deck, stats]) => ({ deck, ...stats }))
+      .sort((a, b) => b.due - a.due || b.total - a.total),
+  };
+
   return {
     lessonTimes,
+    lessonMastery: lessonMastery.sort((a, b) => (b.lastAttemptAt ? new Date(b.lastAttemptAt).getTime() : 0) - (a.lastAttemptAt ? new Date(a.lastAttemptAt).getTime() : 0)),
     averageAttemptsToMastery,
     weakestTags,
+    skillAccuracy,
     studyPlan: studyPlan.slice(0, 5),
+    activityTrend,
+    streak: {
+      current: currentStreak,
+      best: bestStreak,
+      lastStudiedOn,
+    },
+    srs,
   };
 };

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const LessonSchema = z.object({
   id: z.string(),
-  level: z.enum(['B1', 'C1']),
+  level: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
   title: z.string(),
   slug: z.string(),
   tags: z.array(z.string()),
@@ -14,7 +14,7 @@ export type Lesson = z.infer<typeof LessonSchema>;
 export const ExerciseSchema = z.object({
   id: z.string(),
   lessonId: z.string(),
-  type: z.enum(['mcq','multi','cloze','short','translate','conjugate','order','match']),
+  type: z.enum(['mcq', 'multi', 'cloze', 'short', 'translate', 'conjugate', 'order', 'match']),
   promptMd: z.string(),
   options: z.array(z.string()).optional(),
   answer: z.union([z.string(), z.array(z.string())]),
@@ -26,8 +26,8 @@ export const ExerciseSchema = z.object({
     hints: z.array(z.string()).optional()
   }).optional(),
   meta: z.object({
-    difficulty: z.enum(['A2','B1','B2','C1']),
-    skills: z.array(z.enum(['read','write','listen','speak'])),
+    difficulty: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
+    skills: z.array(z.enum(['read', 'write', 'listen', 'speak'])),
     topic: z.string().optional()
   }).optional()
 });
@@ -56,7 +56,9 @@ export const FlashcardSchema = z.object({
   srs: z.object({
     bucket: z.number(),
     lastReview: z.string().optional(),
-    nextDue: z.string().optional()
+    nextDue: z.string().optional(),
+    streak: z.number().optional(),
+    lastGrade: z.enum(['again','hard','good','easy']).optional()
   }).optional()
 });
 export type Flashcard = z.infer<typeof FlashcardSchema>;

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -1,17 +1,79 @@
 import { Flashcard } from './schemas';
 
-export const updateSRS = (card: Flashcard, success: boolean) => {
+export type ReviewGrade = 'again' | 'hard' | 'good' | 'easy';
+
+const INTERVAL_DAYS = [0, 1, 3, 7, 14, 30, 60, 90, 180, 365];
+
+const clampBucket = (value: number) => {
+  if (Number.isNaN(value) || value < 0) return 0;
+  return Math.min(value, INTERVAL_DAYS.length - 1);
+};
+
+const nextBucketForGrade = (current: number, grade: ReviewGrade) => {
+  switch (grade) {
+    case 'again':
+      return 0;
+    case 'hard':
+      return clampBucket(Math.max(current - 1, 1));
+    case 'good':
+      return clampBucket(current + 1);
+    case 'easy':
+      return clampBucket(current + 2);
+    default:
+      return clampBucket(current);
+  }
+};
+
+const addDays = (date: Date, days: number) =>
+  new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+
+export const updateSRS = (card: Flashcard, grade: ReviewGrade) => {
   const now = new Date();
-  const bucket = success ? Math.min((card.srs?.bucket ?? 0)+1, 5) : 0;
-  const days = [0,1,3,7,14,30][bucket];
-  const nextDue = new Date(now.getTime() + days*86400000).toISOString();
+  const currentBucket = clampBucket(card.srs?.bucket ?? 0);
+  const nextBucket = nextBucketForGrade(currentBucket, grade);
+  const intervalDays = INTERVAL_DAYS[nextBucket] ?? 0;
+  const nextDue = addDays(now, intervalDays);
+
+  const streak = grade === 'again' ? 0 : (card.srs?.streak ?? 0) + 1;
+
   return {
     ...card,
-    srs: { bucket, lastReview: now.toISOString(), nextDue }
+    srs: {
+      bucket: nextBucket,
+      lastReview: now.toISOString(),
+      nextDue: nextDue.toISOString(),
+      streak,
+      lastGrade: grade,
+    },
   };
 };
 
 export const isDue = (card: Flashcard) => {
   if (!card.srs?.nextDue) return true;
   return new Date(card.srs.nextDue) <= new Date();
+};
+
+export const describeDueStatus = (card: Flashcard) => {
+  if (!card.srs?.nextDue) return 'New';
+  const dueDate = new Date(card.srs.nextDue);
+  const now = new Date();
+  const diffMs = dueDate.getTime() - now.getTime();
+  const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays <= 0) return 'Due now';
+  if (diffDays === 1) return 'Due tomorrow';
+  return `Due in ${diffDays} days`;
+};
+
+export const summarizeBuckets = (cards: Flashcard[]) => {
+  const summary = new Map<number, { total: number; due: number }>();
+  cards.forEach((card) => {
+    const bucket = clampBucket(card.srs?.bucket ?? 0);
+    const entry = summary.get(bucket) ?? { total: 0, due: 0 };
+    entry.total += 1;
+    if (isDue(card)) entry.due += 1;
+    summary.set(bucket, entry);
+  });
+  return Array.from(summary.entries())
+    .map(([bucket, stats]) => ({ bucket, ...stats }))
+    .sort((a, b) => a.bucket - b.bucket);
 };

--- a/src/pages/ContentManagerPage.module.css
+++ b/src/pages/ContentManagerPage.module.css
@@ -37,6 +37,32 @@
   margin-bottom: 4px;
 }
 
+.remoteRow {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.remoteLabel {
+  font-weight: 600;
+}
+
+.remoteControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.remoteControls input {
+  flex: 1;
+  min-width: 240px;
+  padding: 8px 12px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  font-size: 0.95rem;
+}
+
 .diffList {
   margin: 0;
   padding-left: 1.2rem;
@@ -44,6 +70,30 @@
   flex-direction: column;
   gap: 6px;
   font-size: 0.95rem;
+}
+
+.diffColumns {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 24px;
+}
+
+.changeList {
+  margin: 8px 0 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--ui-text-secondary);
+  font-size: 0.85rem;
+}
+
+.changeList code {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(148, 163, 184, 0.2);
 }
 
 @media (max-width: 960px) {

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -11,7 +11,7 @@ const FlashcardsPage: React.FC = () => (
         Flashcard trainer
       </h1>
       <p className="ui-section__subtitle">
-        Keep verbs, connectors, and presentation phrases ready. Flip cards with the spacebar and grade your recall with J/K or the arrow keys to move quickly.
+        Keep verbs, connectors, and presentation phrases ready. Flip cards with the spacebar and grade each recall with the number keys or arrows to log Again, Hard, Good, or Easy in one motion.
       </p>
       <div className="ui-pill-group">
         <Link to="/" className="ui-button ui-button--ghost">
@@ -33,10 +33,16 @@ const FlashcardsPage: React.FC = () => (
               <strong>Space</strong> — Reveal the back.
             </li>
             <li>
-              <strong>J / ←</strong> — Mark as “I forgot”.
+              <strong>1 / ↓</strong> — Mark as “Again” and relearn soon.
             </li>
             <li>
-              <strong>K / →</strong> — Mark as “I knew it”.
+              <strong>2 / ←</strong> — Mark as “Hard” to shorten the next interval.
+            </li>
+            <li>
+              <strong>3 / →</strong> — Mark as “Good” when the recall felt solid.
+            </li>
+            <li>
+              <strong>4 / ↑</strong> — Mark as “Easy” to push the card further out.
             </li>
           </ul>
         </section>

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -140,6 +140,62 @@
   color: var(--ui-accent-strong);
 }
 
+.recommendations {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 14px;
+  font-size: 0.95rem;
+}
+
+.recommendations a {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-decoration: none;
+  color: var(--ui-text-primary);
+}
+
+.recommendationTitle {
+  font-weight: 700;
+}
+
+.recommendationReason {
+  color: var(--ui-text-secondary);
+  font-size: 0.9rem;
+}
+
+.deckGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.deckCard {
+  padding: 16px;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.deckTitle {
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.deckDue {
+  font-size: 1.4rem;
+  font-family: var(--ui-font-display);
+}
+
+.deckHint {
+  color: var(--ui-text-secondary);
+  font-size: 0.85rem;
+}
+
 .libraryHeader {
   display: flex;
   flex-wrap: wrap;
@@ -148,10 +204,52 @@
   justify-content: space-between;
 }
 
+.libraryControls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.searchControl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+}
+
+.searchControl input {
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  outline: none;
+  min-width: 220px;
+}
+
 .filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.sortSelect {
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  padding: 8px 14px;
+  background: var(--ui-surface);
+  color: var(--ui-text-secondary);
+  font-weight: 600;
+}
+
+.filterButtons {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  justify-content: flex-end;
 }
 
 .filterButton {
@@ -275,6 +373,25 @@
   font-weight: 600;
 }
 
+.lessonFooter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.lessonRecommendation {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-weight: 600;
+}
+
 .lessonLink {
   display: inline-flex;
   align-items: center;
@@ -308,6 +425,19 @@
   background: rgba(14, 165, 233, 0.12);
   color: #0e7490;
   font-weight: 600;
+  cursor: pointer;
+}
+
+.topicTag:hover,
+.topicTag:focus-visible {
+  border-color: var(--ui-accent);
+  color: var(--ui-accent-strong);
+}
+
+.topicTagActive {
+  border-color: var(--ui-accent);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
 }
 
 .topicCount {
@@ -325,6 +455,30 @@
 
   .heroStats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .libraryControls {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .searchControl {
+    width: 100%;
+  }
+
+  .searchControl input {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .filterGroup {
+    align-items: stretch;
+  }
+
+  .filterButtons {
+    justify-content: flex-start;
   }
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
+import { liveQuery } from 'dexie';
 import { db } from '../db';
 import { Lesson } from '../lib/schemas';
-import { isDue } from '../lib/srs';
+import { computeAnalytics } from '../lib/analytics';
+import { describeDueStatus, isDue } from '../lib/srs';
 import styles from './Home.module.css';
 
 interface LibraryStats {
@@ -10,122 +12,322 @@ interface LibraryStats {
   totalExercises: number;
   dueCards: number;
   progress: number;
+  streak: number;
+  bestStreak: number;
 }
 
-const levelBlueprint: { level: Lesson['level']; title: string; description: string }[] = [
-  {
-    level: 'B1',
+interface LessonLibraryItem {
+  lesson: Lesson;
+  exerciseCount: number;
+  masteredCount: number;
+  attemptedCount: number;
+  accuracy: number;
+  lastAttemptAt?: string;
+  recommendation?: string;
+  recommendationPriority?: number;
+}
+
+interface RecommendationCard {
+  lessonId: string;
+  lessonSlug?: string;
+  title: string;
+  reason: string;
+  priority: number;
+}
+
+const levelCopy: Record<string, { title: string; description: string }> = {
+  A1: {
+    title: 'Level A1 · Foundations first',
+    description: 'Build confidence with essential verbs, greetings, and survival phrases.',
+  },
+  A2: {
+    title: 'Level A2 · Everyday exchanges',
+    description: 'Tackle routine tasks, preferences, and descriptions with ease.',
+  },
+  B1: {
     title: 'Level B1 · Build confident fluency',
     description: 'Polish everyday grammar, narration and fast-paced conversations.',
   },
-  {
-    level: 'C1',
+  B2: {
+    title: 'Level B2 · Debate and defend ideas',
+    description: 'Stretch your argumentation with precise connectors and register shifts.',
+  },
+  C1: {
     title: 'Level C1 · Present like a pro',
     description: 'Rehearse debates, briefings and formal presentations with advanced vocabulary.',
   },
+  C2: {
+    title: 'Level C2 · Master nuance',
+    description: 'Perfect idiomatic turns of phrase and stylistic control for any audience.',
+  },
+};
+
+const levelOrder = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+
+type SortOrder = 'recommended' | 'recent' | 'alphabetical' | 'mastery';
+
+const sortOptions: { value: SortOrder; label: string }[] = [
+  { value: 'recommended', label: 'Recommended first' },
+  { value: 'recent', label: 'Recently studied' },
+  { value: 'alphabetical', label: 'A → Z' },
+  { value: 'mastery', label: 'Lowest mastery' },
 ];
+
+const formatRelativeTime = (value?: string) => {
+  if (!value) return 'Unseen';
+  const date = new Date(value);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  if (diffMs < 0) return 'Scheduled';
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  if (diffMinutes < 60) {
+    return diffMinutes === 1 ? '1 minute ago' : `${diffMinutes} minutes ago`;
+  }
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    return diffHours === 1 ? '1 hour ago' : `${diffHours} hours ago`;
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) {
+    return diffDays === 1 ? 'Yesterday' : `${diffDays} days ago`;
+  }
+  return date.toLocaleDateString();
+};
 
 const focusSteps = [
   {
-    title: 'Check your analytics',
-    description: 'Identify the tags and lessons that need another pass before your next conversation.',
+    title: 'Study plan preview',
+    description: 'Open the dashboard to review streaks, trends, and the weakest tags before you begin.',
     actionLabel: 'Open dashboard',
     to: '/dashboard',
   },
   {
-    title: 'Pick a lesson objective',
-    description: 'Use the library below to choose the next B1 or C1 target for today’s session.',
+    title: 'Queue the right lesson',
+    description: 'Use search, level filters, and mastery stats below to choose the next objective.',
     actionLabel: 'Browse lessons',
     anchor: '#lesson-library',
   },
   {
-    title: 'Reinforce with flashcards',
-    description: 'Rotate through due verbs, connectors, and presentation phrases in the trainer.',
+    title: 'Targeted flashcard sprint',
+    description: 'Pick the due deck called out in the sidebar and cap the session to match your schedule.',
     actionLabel: 'Start trainer',
     to: '/flashcards',
   },
   {
-    title: 'Refresh your content',
-    description: 'Import the latest JSON bundle so fresh lessons, exercises, and flashcards stay in sync.',
+    title: 'Sync content and notes',
+    description: 'Pull the newest JSON bundle and jot findings in the changelog once you wrap up.',
     actionLabel: 'Content manager',
     to: '/content-manager',
   },
 ];
 
 export const HomePage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [items, setItems] = useState<LessonLibraryItem[]>([]);
   const [lessons, setLessons] = useState<Lesson[]>([]);
-  const [exerciseCounts, setExerciseCounts] = useState<Record<string, number>>({});
   const [stats, setStats] = useState<LibraryStats>({
     totalLessons: 0,
     totalExercises: 0,
     dueCards: 0,
     progress: 0,
+    streak: 0,
+    bestStreak: 0,
   });
-  const [libraryFilter, setLibraryFilter] = useState<'all' | Lesson['level']>('all');
+  const [levelFilter, setLevelFilter] = useState<string>(searchParams.get('level') ?? 'all');
+  const [searchTerm, setSearchTerm] = useState(searchParams.get('q') ?? '');
+  const [sortOrder, setSortOrder] = useState<SortOrder>(
+    (searchParams.get('sort') as SortOrder) ?? 'recommended'
+  );
+  const [tagFilter, setTagFilter] = useState<string>(searchParams.get('tag') ?? 'all');
+  const [topTags, setTopTags] = useState<[string, number][]>([]);
+  const [levelOptions, setLevelOptions] = useState<string[]>([]);
+  const [recommendations, setRecommendations] = useState<RecommendationCard[]>([]);
+  const [deckDue, setDeckDue] = useState<{ deck: string; due: number; status: string }[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    let active = true;
-    const load = async () => {
+    const subscription = liveQuery(async () => {
       const [lessonItems, exercises, flashcards, grades] = await Promise.all([
         db.lessons.toArray(),
         db.exercises.toArray(),
         db.flashcards.toArray(),
         db.grades.toArray(),
       ]);
-      if (!active) return;
-      const sorted = [...lessonItems].sort((a, b) => a.title.localeCompare(b.title));
-      setLessons(sorted);
+      return { lessonItems, exercises, flashcards, grades };
+    }).subscribe({
+      next: ({ lessonItems, exercises, flashcards, grades }) => {
+        const analytics = computeAnalytics(lessonItems, exercises, grades, flashcards);
+        const counts = exercises.reduce<Record<string, number>>((acc, exercise) => {
+          acc[exercise.lessonId] = (acc[exercise.lessonId] ?? 0) + 1;
+          return acc;
+        }, {});
+        const masteryMap = new Map(analytics.lessonMastery.map((entry) => [entry.lessonId, entry]));
+        const recommendationMap = new Map(
+          analytics.studyPlan.map((entry) => [entry.lessonId, entry])
+        );
 
-      const mastered = new Set(grades.filter((grade) => grade.isCorrect).map((grade) => grade.exerciseId));
-      const progress = exercises.length ? (mastered.size / exercises.length) * 100 : 0;
-      const due = flashcards.filter(isDue).length;
-      const counts = exercises.reduce<Record<string, number>>((acc, exercise) => {
-        acc[exercise.lessonId] = (acc[exercise.lessonId] ?? 0) + 1;
-        return acc;
-      }, {});
-      setStats({
-        totalLessons: lessonItems.length,
-        totalExercises: exercises.length,
-        dueCards: due,
-        progress,
-      });
-      setExerciseCounts(counts);
-    };
+        const derivedItems: LessonLibraryItem[] = lessonItems.map((lesson) => {
+          const mastery = masteryMap.get(lesson.id);
+          const rec = recommendationMap.get(lesson.id);
+          return {
+            lesson,
+            exerciseCount: counts[lesson.id] ?? 0,
+            masteredCount: mastery?.masteredExercises ?? 0,
+            attemptedCount: mastery?.attemptedExercises ?? 0,
+            accuracy: mastery?.accuracy ?? 0,
+            lastAttemptAt: mastery?.lastAttemptAt,
+            recommendation: rec?.reason,
+            recommendationPriority: rec?.priority,
+          };
+        });
 
-    load();
-    return () => {
-      active = false;
-    };
+        const uniqueLevels = Array.from(new Set(lessonItems.map((lesson) => lesson.level)));
+        uniqueLevels.sort((a, b) => {
+          const indexA = levelOrder.indexOf(a);
+          const indexB = levelOrder.indexOf(b);
+          if (indexA === -1 && indexB === -1) return a.localeCompare(b);
+          if (indexA === -1) return 1;
+          if (indexB === -1) return -1;
+          return indexA - indexB;
+        });
+
+        const masteredExercises = analytics.lessonMastery.reduce(
+          (total, entry) => total + entry.masteredExercises,
+          0
+        );
+        const totalExercises = exercises.length;
+        const progress = totalExercises ? (masteredExercises / totalExercises) * 100 : 0;
+
+        const tagCounts = new Map<string, number>();
+        lessonItems.forEach((lesson) => {
+          lesson.tags.forEach((tag) => {
+            tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+          });
+        });
+
+        const tagList = Array.from(tagCounts.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 12);
+
+        const dueDecks = analytics.srs.deckBreakdown
+          .map((entry) => {
+            const deckCards = flashcards.filter((card) => card.deck === entry.deck);
+            const dueCard = deckCards.find((card) => isDue(card));
+            const upcomingCard = deckCards.reduce<typeof deckCards[number] | undefined>((closest, card) => {
+              if (!card.srs?.nextDue) return closest;
+              if (!closest?.srs?.nextDue) return card;
+              return new Date(card.srs.nextDue) < new Date(closest.srs.nextDue) ? card : closest;
+            }, undefined);
+            const referenceCard = dueCard ?? upcomingCard;
+            const status = referenceCard ? describeDueStatus(referenceCard) : 'No cards scheduled';
+            return {
+              deck: entry.deck,
+              due: entry.due,
+              status,
+            };
+          })
+          .sort((a, b) => b.due - a.due);
+
+        setLessons(lessonItems);
+        setItems(derivedItems);
+        setLevelOptions(uniqueLevels);
+        setTopTags(tagList);
+        setRecommendations(
+          analytics.studyPlan.slice(0, 3).map((entry) => ({
+            lessonId: entry.lessonId,
+            lessonSlug: entry.lessonSlug,
+            title: entry.lessonTitle,
+            reason: entry.reason,
+            priority: entry.priority,
+          }))
+        );
+        setDeckDue(dueDecks);
+        setStats({
+          totalLessons: lessonItems.length,
+          totalExercises,
+          dueCards: analytics.srs.dueNow,
+          progress,
+          streak: analytics.streak.current,
+          bestStreak: analytics.streak.best,
+        });
+        setLoading(false);
+      },
+      error: (error) => {
+        console.error('Failed to load home overview', error);
+      },
+    });
+
+    return () => subscription.unsubscribe();
   }, []);
 
-  const levelGroups = useMemo(
-    () =>
-      levelBlueprint.map((section) => ({
-        ...section,
-        lessons: lessons.filter((lesson) => lesson.level === section.level),
-      })),
-    [lessons]
-  );
+  useEffect(() => {
+    setLevelFilter(searchParams.get('level') ?? 'all');
+    setSearchTerm(searchParams.get('q') ?? '');
+    setSortOrder((searchParams.get('sort') as SortOrder) ?? 'recommended');
+    setTagFilter(searchParams.get('tag') ?? 'all');
+  }, [searchParams]);
 
-  const filteredGroups = useMemo(
-    () =>
-      libraryFilter === 'all'
-        ? levelGroups
-        : levelGroups.filter((group) => group.level === libraryFilter),
-    [levelGroups, libraryFilter]
-  );
+  const updateParam = (key: string, value: string | null) => {
+    const next = new URLSearchParams(searchParams);
+    if (!value) next.delete(key);
+    else next.set(key, value);
+    setSearchParams(next, { replace: true });
+  };
 
-  const topTags = useMemo(() => {
-    const counts = new Map<string, number>();
-    lessons.forEach((lesson) => {
-      lesson.tags.forEach((tag) => {
-        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  const filteredLessons = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    const tag = tagFilter === 'all' ? null : tagFilter;
+    return items
+      .filter((item) => {
+        if (levelFilter !== 'all' && item.lesson.level !== levelFilter) return false;
+        if (tag && !item.lesson.tags.includes(tag)) return false;
+        if (normalizedSearch) {
+          const haystack = [
+            item.lesson.title.toLowerCase(),
+            item.lesson.tags.join(' ').toLowerCase(),
+          ];
+          if (!haystack.some((entry) => entry.includes(normalizedSearch))) return false;
+        }
+        return true;
+      })
+      .sort((a, b) => {
+        if (sortOrder === 'alphabetical') {
+          return a.lesson.title.localeCompare(b.lesson.title);
+        }
+        if (sortOrder === 'mastery') {
+          return a.accuracy - b.accuracy;
+        }
+        if (sortOrder === 'recent') {
+          const aTime = a.lastAttemptAt ? new Date(a.lastAttemptAt).getTime() : 0;
+          const bTime = b.lastAttemptAt ? new Date(b.lastAttemptAt).getTime() : 0;
+          return bTime - aTime;
+        }
+        // recommended
+        const aPriority = a.recommendationPriority ?? Number.POSITIVE_INFINITY;
+        const bPriority = b.recommendationPriority ?? Number.POSITIVE_INFINITY;
+        if (aPriority !== bPriority) return aPriority - bPriority;
+        const aReason = a.recommendation ? 0 : 1;
+        const bReason = b.recommendation ? 0 : 1;
+        if (aReason !== bReason) return aReason - bReason;
+        const aTime = a.lastAttemptAt ? new Date(a.lastAttemptAt).getTime() : 0;
+        const bTime = b.lastAttemptAt ? new Date(b.lastAttemptAt).getTime() : 0;
+        return bTime - aTime;
       });
+  }, [items, levelFilter, tagFilter, searchTerm, sortOrder]);
+
+  const levelGroups = useMemo(() => {
+    const grouped = new Map<string, LessonLibraryItem[]>();
+    filteredLessons.forEach((item) => {
+      const list = grouped.get(item.lesson.level) ?? [];
+      list.push(item);
+      grouped.set(item.lesson.level, list);
     });
-    return Array.from(counts.entries())
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 8);
-  }, [lessons]);
+    const order = levelFilter === 'all' ? levelOptions : [levelFilter];
+    return order.map((level) => ({
+      level,
+      lessons: grouped.get(level) ?? [],
+    }));
+  }, [filteredLessons, levelFilter, levelOptions]);
 
   const roundedProgress = Math.round(stats.progress);
 
@@ -151,23 +353,23 @@ export const HomePage: React.FC = () => {
           <div className={styles.heroChips}>
             <span className="ui-chip">Study smarter</span>
             <span className="ui-chip">Offline ready</span>
-            <span className="ui-chip">B1 · C1</span>
+            <span className="ui-chip">Streak {stats.streak} 🔥</span>
           </div>
         </div>
         <dl className={styles.heroStats} aria-label="Study stats">
-          <div className={styles.heroStatsItem}>
+          <div className={styles.heroStatsItem} title="Total lessons currently available in your offline library">
             <dt>Lessons imported</dt>
             <dd aria-live="polite">{stats.totalLessons}</dd>
           </div>
-          <div className={styles.heroStatsItem}>
+          <div className={styles.heroStatsItem} title="Exercises available across all lessons">
             <dt>Practice items</dt>
             <dd aria-live="polite">{stats.totalExercises}</dd>
           </div>
-          <div className={styles.heroStatsItem}>
+          <div className={styles.heroStatsItem} title="Percentage of exercises where the latest attempt was correct">
             <dt>Mastery progress</dt>
             <dd aria-live="polite">{roundedProgress}%</dd>
           </div>
-          <div className={styles.heroStatsItem}>
+          <div className={styles.heroStatsItem} title="Cards currently ready for review">
             <dt>Due flashcards</dt>
             <dd aria-live="polite">{stats.dueCards}</dd>
           </div>
@@ -205,6 +407,55 @@ export const HomePage: React.FC = () => {
         </div>
       </section>
 
+      {recommendations.length > 0 && (
+        <section className="ui-card" aria-labelledby="recommendations-heading">
+          <div className="ui-section">
+            <div>
+              <p className="ui-section__tag">Suggested next steps</p>
+              <h2 id="recommendations-heading" className="ui-section__title">
+                Resume exactly where analytics left off
+              </h2>
+              <p className="ui-section__subtitle">
+                These exercises bubble up from your latest dashboard snapshot — tackle the first card to keep momentum.
+              </p>
+            </div>
+          </div>
+          <ol className={styles.recommendations}>
+            {recommendations.map((item) => (
+              <li key={item.lessonId}>
+                <Link to={item.lessonSlug ? `/lessons/${item.lessonSlug}` : '#'}>
+                  <span className={styles.recommendationTitle}>{item.title}</span>
+                  <span className={styles.recommendationReason}>{item.reason}</span>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      {deckDue.length > 0 && (
+        <section className="ui-card" aria-labelledby="deck-heading">
+          <div className="ui-section">
+            <div>
+              <p className="ui-section__tag">Flashcard readiness</p>
+              <h2 id="deck-heading" className="ui-section__title">Due decks at a glance</h2>
+              <p className="ui-section__subtitle">
+                Start with the deck that has the highest due count, or pick a deck whose due date matches your available time.
+              </p>
+            </div>
+          </div>
+          <div className={styles.deckGrid}>
+            {deckDue.map((entry) => (
+              <div key={entry.deck} className={styles.deckCard}>
+                <p className={styles.deckTitle}>{entry.deck}</p>
+                <p className={styles.deckDue}>{entry.due} due</p>
+                <p className={styles.deckHint}>{entry.status}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       <section id="lesson-library" className="ui-card" aria-labelledby="library-heading">
         <div className={styles.libraryHeader}>
           <div>
@@ -213,75 +464,138 @@ export const HomePage: React.FC = () => {
               Match today’s focus with the right material
             </h2>
             <p className="ui-section__subtitle">
-              Organised by CEFR level so you can pick the objective that fits your next conversation or presentation.
+              Organised by level and powered by your latest mastery data so you can pick the objective that fits your next conversation or presentation.
             </p>
           </div>
-          <div className={styles.filterGroup}>
-            {(['all', 'B1', 'C1'] as const).map((filter) => (
-              <button
-                key={filter}
-                type="button"
-                onClick={() => setLibraryFilter(filter)}
-                className={styles.filterButton}
-                data-active={libraryFilter === filter}
+          <div className={styles.libraryControls}>
+            <div className={styles.searchControl}>
+              <label htmlFor="library-search" className="sr-only">
+                Search lessons
+              </label>
+              <input
+                id="library-search"
+                type="search"
+                value={searchTerm}
+                onChange={(event) => updateParam('q', event.target.value || null)}
+                placeholder="Search titles or tags…"
+              />
+            </div>
+            <div className={styles.filterGroup}>
+              <label htmlFor="sort-order" className="sr-only">
+                Sort order
+              </label>
+              <select
+                id="sort-order"
+                value={sortOrder}
+                onChange={(event) => updateParam('sort', event.target.value as SortOrder)}
+                className={styles.sortSelect}
               >
-                {filter === 'all' ? 'All levels' : `Level ${filter}`}
-              </button>
-            ))}
+                {sortOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <div className={styles.filterButtons}>
+                <button
+                  type="button"
+                  onClick={() => updateParam('level', 'all')}
+                  className={styles.filterButton}
+                  data-active={levelFilter === 'all'}
+                >
+                  All levels
+                </button>
+                {levelOptions.map((level) => (
+                  <button
+                    key={level}
+                    type="button"
+                    onClick={() => updateParam('level', level)}
+                    className={styles.filterButton}
+                    data-active={levelFilter === level}
+                  >
+                    Level {level}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
-        {lessons.length === 0 ? (
+        {loading ? (
+          <p className={styles.emptyState} aria-live="polite">
+            Loading library…
+          </p>
+        ) : lessons.length === 0 ? (
           <p className={styles.emptyState} aria-live="polite">
             No lessons imported yet. Use the Content manager to add the latest content drop.
           </p>
         ) : (
-          filteredGroups.map(({ level, title, description, lessons: groupLessons }) => (
-            <article key={level} className={styles.lessonGroup}>
-              <header className={styles.groupHeader}>
-                <div>
-                  <h3 className={styles.groupTitle}>{title}</h3>
-                  <p className={styles.groupDescription}>{description}</p>
-                </div>
-                <span className={styles.groupCount}>
-                  {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
-                </span>
-              </header>
-              {groupLessons.length > 0 ? (
-                <div className={styles.lessonGrid}>
-                  {groupLessons.map((lesson) => {
-                    const count = exerciseCounts[lesson.id] ?? 0;
-                    return (
-                      <Link key={lesson.id} to={`/lessons/${lesson.slug}`} className={styles.lessonCard}>
-                        <div className={styles.lessonMeta}>
-                          <span>Level {lesson.level}</span>
-                          <span>{count} practice {count === 1 ? 'item' : 'items'}</span>
-                        </div>
-                        <div>
-                          <h4 className={styles.lessonTitle}>{lesson.title}</h4>
-                          <div className={styles.lessonTags} aria-label={`Tags for ${lesson.title}`}>
-                            {lesson.tags.slice(0, 3).map((tag) => (
-                              <span key={tag} className={styles.lessonTag}>
-                                {tag}
-                              </span>
-                            ))}
-                            {lesson.tags.length === 0 && <span className={styles.lessonTag}>No tags yet</span>}
-                            {lesson.tags.length > 3 && (
-                              <span className={styles.lessonTag}>+{lesson.tags.length - 3}</span>
+          levelGroups.map(({ level, lessons: groupLessons }) => {
+            const copy = levelCopy[level] ?? {
+              title: `Level ${level}`,
+              description: 'Build a customised progression even if this is a custom level.',
+            };
+            return (
+              <article key={level} className={styles.lessonGroup}>
+                <header className={styles.groupHeader}>
+                  <div>
+                    <h3 className={styles.groupTitle}>{copy.title}</h3>
+                    <p className={styles.groupDescription}>{copy.description}</p>
+                  </div>
+                  <span className={styles.groupCount}>
+                    {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
+                  </span>
+                </header>
+                {groupLessons.length > 0 ? (
+                  <div className={styles.lessonGrid}>
+                    {groupLessons.map((item) => {
+                      const { lesson } = item;
+                      const masteryPercent = item.exerciseCount
+                        ? Math.round((item.masteredCount / item.exerciseCount) * 100)
+                        : 0;
+                      return (
+                        <Link
+                          key={lesson.id}
+                          to={`/lessons/${lesson.slug}`}
+                          className={styles.lessonCard}
+                        >
+                          <div className={styles.lessonMeta}>
+                            <span>Level {lesson.level}</span>
+                            <span>
+                              {item.exerciseCount} practice {item.exerciseCount === 1 ? 'item' : 'items'}
+                            </span>
+                          </div>
+                          <div>
+                            <h4 className={styles.lessonTitle}>{lesson.title}</h4>
+                            <div className={styles.lessonTags} aria-label={`Tags for ${lesson.title}`}>
+                              {lesson.tags.slice(0, 3).map((tag) => (
+                                <span key={tag} className={styles.lessonTag}>
+                                  {tag}
+                                </span>
+                              ))}
+                              {lesson.tags.length === 0 && <span className={styles.lessonTag}>No tags yet</span>}
+                              {lesson.tags.length > 3 && (
+                                <span className={styles.lessonTag}>+{lesson.tags.length - 3}</span>
+                              )}
+                            </div>
+                          </div>
+                          <div className={styles.lessonFooter}>
+                            <span>{masteryPercent}% mastered</span>
+                            <span>{formatRelativeTime(item.lastAttemptAt)}</span>
+                            {item.recommendation && (
+                              <span className={styles.lessonRecommendation}>{item.recommendation}</span>
                             )}
                           </div>
-                        </div>
-                        <span className={styles.lessonLink}>
-                          Open lesson →
-                        </span>
-                      </Link>
-                    );
-                  })}
-                </div>
-              ) : (
-                <p className={styles.emptyState}>No lessons imported for this level yet.</p>
-              )}
-            </article>
-          ))
+                          <span className={styles.lessonLink}>Open lesson →</span>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className={styles.emptyState}>No lessons imported for this level yet.</p>
+                )}
+              </article>
+            );
+          })
         )}
       </section>
 
@@ -297,15 +611,21 @@ export const HomePage: React.FC = () => {
         {topTags.length > 0 ? (
           <div className={styles.topicsCloud}>
             {topTags.map(([tag, count]) => (
-              <span key={tag} className={styles.topicTag} title={`${count} lesson${count === 1 ? '' : 's'}`}>
+              <button
+                key={tag}
+                type="button"
+                className={`${styles.topicTag} ${tagFilter === tag ? styles.topicTagActive : ''}`}
+                title={`${count} lesson${count === 1 ? '' : 's'}`}
+                onClick={() => updateParam('tag', tagFilter === tag ? null : tag)}
+              >
                 <span>{tag}</span>
                 <span className={styles.topicCount}>×{count}</span>
-              </span>
+              </button>
             ))}
           </div>
         ) : (
           <p className={styles.emptyState}>
-            Tags will appear once you import lessons.{' '}
+            Tags will appear once you import lessons.{" "}
             <Link to="/content-manager">Add a content bundle to get started.</Link>
           </p>
         )}

--- a/src/pages/LessonPage.module.css
+++ b/src/pages/LessonPage.module.css
@@ -83,6 +83,35 @@
   gap: 18px;
 }
 
+.lessonMetrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: 16px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-muted);
+}
+
+.lessonMetric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lessonMetricLabel {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ui-text-secondary);
+}
+
+.lessonMetricValue {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ui-text-primary);
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;
@@ -104,6 +133,95 @@
   flex-direction: column;
   gap: 8px;
   font-size: 0.95rem;
+}
+
+.exerciseSummary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.exerciseMastery {
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-weight: 600;
+}
+
+.sidebarEmpty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ui-text-secondary);
+}
+
+.sessionMeta {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.sessionList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sessionItem {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+}
+
+.sessionBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.sessionBadge[data-correct='true'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.sessionBadge[data-correct='false'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.sessionScore {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ui-text-primary);
+}
+
+.sessionTime {
+  justify-self: end;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.sessionPrompt {
+  grid-column: 1 / -1;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
 }
 
 @media (max-width: 960px) {

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -1,20 +1,70 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { db } from '../db';
-import { Exercise, Lesson } from '../lib/schemas';
+import { Exercise, Grade, Lesson } from '../lib/schemas';
 import { LessonViewer } from '../components/LessonViewer';
 import { ExerciseEngine } from '../components/ExerciseEngine';
 import styles from './LessonPage.module.css';
+
+const formatRelativeTime = (value?: string) => {
+  if (!value) return 'Not yet started';
+  const date = new Date(value);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  if (diffMs < 0) return 'Scheduled';
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) {
+    return diffMinutes === 1 ? '1 minute ago' : `${diffMinutes} minutes ago`;
+  }
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    return diffHours === 1 ? '1 hour ago' : `${diffHours} hours ago`;
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) {
+    return diffDays === 1 ? 'Yesterday' : `${diffDays} days ago`;
+  }
+  return date.toLocaleDateString();
+};
+
+const formatDuration = (ms: number) => {
+  if (!ms) return '0s';
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) {
+    return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  return `${seconds}s`;
+};
+
+const getPromptPreview = (markdown: string) => {
+  const stripped = markdown
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/[*_>#-]/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return stripped[0] ?? 'Exercise prompt';
+};
 
 const LessonPage: React.FC = () => {
   const { slug } = useParams();
   const [lesson, setLesson] = useState<Lesson | null>(null);
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [status, setStatus] = useState<'loading' | 'ready' | 'missing'>('loading');
+  const [gradeHistory, setGradeHistory] = useState<Record<string, Grade[]>>({});
+  const [sessionLog, setSessionLog] = useState<Grade[]>([]);
 
   useEffect(() => {
     if (!slug) return;
     let active = true;
+    setStatus('loading');
+    setLesson(null);
+    setExercises([]);
+    setGradeHistory({});
+    setSessionLog([]);
     const load = async () => {
       const found = await db.lessons.where('slug').equals(slug).first();
       if (!active) return;
@@ -22,10 +72,25 @@ const LessonPage: React.FC = () => {
         setStatus('missing');
         return;
       }
-      setLesson(found);
       const lessonExercises = await db.exercises.where('lessonId').equals(found.id).toArray();
+      const exerciseIds = lessonExercises.map((exercise) => exercise.id);
+      let grades: Grade[] = [];
+      if (exerciseIds.length > 0) {
+        grades = await db.grades.where('exerciseId').anyOf(exerciseIds).toArray();
+      }
       if (!active) return;
+      const grouped: Record<string, Grade[]> = {};
+      grades.forEach((grade) => {
+        const list = grouped[grade.exerciseId] ?? [];
+        list.push(grade);
+        grouped[grade.exerciseId] = list;
+      });
+      Object.values(grouped).forEach((list) =>
+        list.sort((a, b) => new Date(a.gradedAt).getTime() - new Date(b.gradedAt).getTime())
+      );
+      setLesson(found);
       setExercises(lessonExercises);
+      setGradeHistory(grouped);
       setStatus('ready');
     };
     load();
@@ -33,6 +98,80 @@ const LessonPage: React.FC = () => {
       active = false;
     };
   }, [slug]);
+
+  const exerciseMap = useMemo(
+    () => new Map(exercises.map((exercise) => [exercise.id, exercise])),
+    [exercises]
+  );
+
+  const lessonSummary = useMemo(() => {
+    const totalExercises = exercises.length;
+    let attempted = 0;
+    let mastered = 0;
+    let totalResponses = 0;
+    let correctResponses = 0;
+    let lastAttemptAt: string | undefined;
+
+    exercises.forEach((exercise) => {
+      const history = gradeHistory[exercise.id] ?? [];
+      if (history.length > 0) {
+        attempted += 1;
+        const last = history[history.length - 1];
+        if (!lastAttemptAt || new Date(last.gradedAt) > new Date(lastAttemptAt)) {
+          lastAttemptAt = last.gradedAt;
+        }
+        if (last.isCorrect) mastered += 1;
+        history.forEach((grade) => {
+          totalResponses += 1;
+          if (grade.isCorrect) correctResponses += 1;
+        });
+      }
+    });
+
+    const accuracy = totalResponses ? Math.round((correctResponses / totalResponses) * 100) : 0;
+
+    return { totalExercises, attempted, mastered, accuracy, lastAttemptAt };
+  }, [exercises, gradeHistory]);
+
+  const exerciseSummaries = useMemo(() => {
+    const map = new Map<
+      string,
+      { attempts: number; accuracy: number; lastAttemptAt?: string; mastered: boolean }
+    >();
+    exercises.forEach((exercise) => {
+      const history = gradeHistory[exercise.id] ?? [];
+      const attempts = history.length;
+      const correct = history.filter((grade) => grade.isCorrect).length;
+      const last = history[history.length - 1];
+      map.set(exercise.id, {
+        attempts,
+        accuracy: attempts ? Math.round((correct / attempts) * 100) : 0,
+        lastAttemptAt: last?.gradedAt,
+        mastered: Boolean(last?.isCorrect),
+      });
+    });
+    return map;
+  }, [exercises, gradeHistory]);
+
+  const sessionSummary = useMemo(() => {
+    const attempts = sessionLog.length;
+    const correct = sessionLog.filter((grade) => grade.isCorrect).length;
+    const totalTime = sessionLog.reduce((total, grade) => total + (grade.timeMs ?? 0), 0);
+    return { attempts, correct, totalTime };
+  }, [sessionLog]);
+
+  const recentSessionLog = useMemo(() => sessionLog.slice(0, 8), [sessionLog]);
+
+  const handleGrade = (grade: Grade) => {
+    setSessionLog((prev) => [grade, ...prev].slice(0, 12));
+    setGradeHistory((prev) => {
+      const next = { ...prev };
+      const history = [...(next[grade.exerciseId] ?? []), grade];
+      history.sort((a, b) => new Date(a.gradedAt).getTime() - new Date(b.gradedAt).getTime());
+      next[grade.exerciseId] = history;
+      return next;
+    });
+  };
 
   if (status === 'loading') {
     return (
@@ -65,8 +204,8 @@ const LessonPage: React.FC = () => {
               {lesson.title}
             </h1>
             <p className="ui-section__subtitle" style={{ color: 'rgba(241, 245, 249, 0.85)' }}>
-              {exercises.length > 0
-                ? `${exercises.length} practice activit${exercises.length === 1 ? 'y' : 'ies'} ready to log.`
+              {lessonSummary.totalExercises > 0
+                ? `${lessonSummary.totalExercises} practice activit${lessonSummary.totalExercises === 1 ? 'y' : 'ies'} ready · ${lessonSummary.mastered}/${lessonSummary.totalExercises} mastered on the latest attempt · Last reviewed ${formatRelativeTime(lessonSummary.lastAttemptAt)}.`
                 : 'Review the notes, then import a practice set to track mastery.'}
             </p>
           </div>
@@ -110,11 +249,53 @@ const LessonPage: React.FC = () => {
                 Work through each prompt to log attempts and unlock mastery progress.
               </p>
             </div>
-            {exercises.map((exercise) => (
-              <div key={exercise.id} aria-label={`Exercise ${exercise.id}`}>
-                <ExerciseEngine exercise={exercise} />
+            {lessonSummary.totalExercises > 0 && (
+              <div className={styles.lessonMetrics} aria-label="Lesson progress summary">
+                <div className={styles.lessonMetric}>
+                  <span className={styles.lessonMetricLabel}>Mastered</span>
+                  <span className={styles.lessonMetricValue}>
+                    {lessonSummary.mastered}/{lessonSummary.totalExercises}
+                  </span>
+                </div>
+                <div className={styles.lessonMetric}>
+                  <span className={styles.lessonMetricLabel}>Attempted</span>
+                  <span className={styles.lessonMetricValue}>
+                    {lessonSummary.attempted}/{lessonSummary.totalExercises}
+                  </span>
+                </div>
+                <div className={styles.lessonMetric}>
+                  <span className={styles.lessonMetricLabel}>Accuracy</span>
+                  <span className={styles.lessonMetricValue}>{lessonSummary.accuracy}%</span>
+                </div>
+                <div className={styles.lessonMetric}>
+                  <span className={styles.lessonMetricLabel}>Last reviewed</span>
+                  <span className={styles.lessonMetricValue}>
+                    {formatRelativeTime(lessonSummary.lastAttemptAt)}
+                  </span>
+                </div>
               </div>
-            ))}
+            )}
+            {exercises.map((exercise) => {
+              const summary = exerciseSummaries.get(exercise.id);
+              const attempts = summary?.attempts ?? 0;
+              const accuracy = summary ? `${summary.accuracy}% accuracy` : '0% accuracy';
+              const lastReviewed = formatRelativeTime(summary?.lastAttemptAt);
+              return (
+                <div key={exercise.id} aria-label={`Exercise ${exercise.id}`}>
+                  <div className={styles.exerciseSummary}>
+                    <span>
+                      {attempts} attempt{attempts === 1 ? '' : 's'} logged
+                    </span>
+                    <span>{accuracy}</span>
+                    <span>{lastReviewed}</span>
+                    {summary?.mastered ? (
+                      <span className={styles.exerciseMastery}>Mastered</span>
+                    ) : null}
+                  </div>
+                  <ExerciseEngine exercise={exercise} onGrade={handleGrade} />
+                </div>
+              );
+            })}
             {exercises.length === 0 && (
               <p role="status" className="ui-alert ui-alert--info">
                 No exercises found for this lesson yet.
@@ -124,6 +305,35 @@ const LessonPage: React.FC = () => {
         </div>
 
         <aside className={styles.sidebar} aria-label="Study guidance">
+          <section className={styles.sidebarSection}>
+            <span className="ui-section__tag">Session log</span>
+            {recentSessionLog.length === 0 ? (
+              <p className={styles.sidebarEmpty}>No attempts logged this session yet.</p>
+            ) : (
+              <>
+                <p className={styles.sessionMeta}>
+                  {sessionSummary.correct}/{sessionSummary.attempts} correct ·{' '}
+                  {formatDuration(sessionSummary.totalTime)} on task
+                </p>
+                <ol className={styles.sessionList} aria-label="Latest attempts">
+                  {recentSessionLog.map((entry) => {
+                    const exercise = exerciseMap.get(entry.exerciseId);
+                    const preview = exercise ? getPromptPreview(exercise.promptMd) : 'Exercise';
+                    return (
+                      <li key={entry.id} className={styles.sessionItem}>
+                        <span className={styles.sessionBadge} data-correct={entry.isCorrect ? 'true' : 'false'}>
+                          {entry.isCorrect ? 'Correct' : 'Retry'}
+                        </span>
+                        <span className={styles.sessionScore}>{Math.round(entry.score)}%</span>
+                        <span className={styles.sessionTime}>{formatRelativeTime(entry.gradedAt)}</span>
+                        <span className={styles.sessionPrompt}>{preview}</span>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </>
+            )}
+          </section>
           <section className={styles.sidebarSection}>
             <span className="ui-section__tag">Study roadmap</span>
             <ol className={styles.sidebarList}>

--- a/src/seed/seedTypes.ts
+++ b/src/seed/seedTypes.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 export const LessonSchema = z.object({
   id: z.string(),
-  level: z.enum(['B1', 'C1']),
+  level: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
   title: z.string(),
   slug: z.string(),
   tags: z.array(z.string()),
@@ -43,7 +43,7 @@ export const ExerciseSchema = z.object({
     .optional(),
   meta: z
     .object({
-      difficulty: z.enum(['A2', 'B1', 'B2', 'C1']),
+      difficulty: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
       skills: z.array(z.enum(['read', 'write', 'listen', 'speak'])),
       topic: z.string().optional(),
     })
@@ -75,6 +75,8 @@ export const FlashcardSchema = z.object({
       bucket: z.number(),
       lastReview: z.string().optional(), // ISO
       nextDue: z.string().optional(), // ISO
+      streak: z.number().optional(),
+      lastGrade: z.enum(['again', 'hard', 'good', 'easy']).optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary
- wire the app shell, dashboard, and home overview to live workspace analytics with search, quick actions, and focus toggles
- enrich the lesson workflow with mastery summaries, session logs, and stronger exercise metadata alongside updated flashcard trainer options
- expand the content manager, service worker, schemas, and documentation to handle flashcards, remote bundles, and new study playbook guidance

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef5de6de08324aa484db0b456100a