### PR TITLE
Replace remark-gfm dependency with local plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "dexie": "^3.2.4",
+        "mdast-util-gfm": "^2.0.2",
+        "micromark-extension-gfm": "^2.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.7",
         "react-router-dom": "^6.22.3",
-        "remark-gfm": "^3.0.1",
+        "unified": "^10.1.2",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -5436,22 +5438,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
-      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-gfm": "^2.0.0",
-        "micromark-extension-gfm": "^2.0.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
     "react-router-dom": "^6.22.3",
-    "remark-gfm": "^3.0.1",
+    "mdast-util-gfm": "^2.0.2",
+    "micromark-extension-gfm": "^2.0.3",
+    "unified": "^10.1.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/components/ExerciseEngine.tsx
+++ b/src/components/ExerciseEngine.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import remarkGfmPlugin from '../lib/remarkGfmPlugin';
 import { Exercise, Grade } from '../lib/schemas';
 import { gradeAnswer } from '../lib/grader';
 import { db } from '../db';
@@ -177,7 +177,7 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise, onGrad
       </div>
       <div className={styles.prompt}>
         <div className="prose">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{exercise.promptMd}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfmPlugin]}>{exercise.promptMd}</ReactMarkdown>
         </div>
       </div>
       {renderInput()}
@@ -219,7 +219,7 @@ export const ExerciseEngine: React.FC<ExerciseEngineProps> = ({ exercise, onGrad
       )}
       {showRubric && exercise.rubric && (
         <div className={styles.rubric} aria-label="Rubric">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{exercise.rubric}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfmPlugin]}>{exercise.rubric}</ReactMarkdown>
         </div>
       )}
     </div>

--- a/src/components/LessonViewer.tsx
+++ b/src/components/LessonViewer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import remarkGfmPlugin from '../lib/remarkGfmPlugin';
 
 export const LessonViewer: React.FC<{ markdown: string }> = ({ markdown }) => {
   return (
     <div className="prose">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfmPlugin]}>{markdown}</ReactMarkdown>
     </div>
   );
 };

--- a/src/lib/remarkGfmPlugin.ts
+++ b/src/lib/remarkGfmPlugin.ts
@@ -1,0 +1,29 @@
+import type { Root } from 'mdast';
+import type { Plugin } from 'unified';
+import type { Options as MicromarkOptions } from 'micromark-extension-gfm';
+import type { Options as MdastOptions } from 'mdast-util-gfm';
+import { gfm } from 'micromark-extension-gfm';
+import { gfmFromMarkdown, gfmToMarkdown } from 'mdast-util-gfm';
+
+/**
+ * Lightweight local replica of the `remark-gfm` plugin.
+ * Based on the MIT-licensed implementation at https://github.com/remarkjs/remark-gfm.
+ */
+export type RemarkGfmOptions = Partial<MicromarkOptions & MdastOptions>;
+
+export const remarkGfmPlugin: Plugin<[RemarkGfmOptions?], Root> = function remarkGfm(
+  options: RemarkGfmOptions = {}
+) {
+  const data = this.data();
+
+  const add = (field: string, value: unknown) => {
+    const list = (data[field] as unknown[]) ?? (data[field] = []);
+    list.push(value);
+  };
+
+  add('micromarkExtensions', gfm(options));
+  add('fromMarkdownExtensions', gfmFromMarkdown());
+  add('toMarkdownExtensions', gfmToMarkdown(options));
+};
+
+export default remarkGfmPlugin;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,1 @@
 /// <reference types="vite/client" />
-
-declare module 'remark-gfm';


### PR DESCRIPTION
## Summary
- add an internal markdown plugin that mirrors remark-gfm so the build no longer depends on resolving the external package
- point LessonViewer and ExerciseEngine to the new plugin when rendering markdown
- replace the remark-gfm dependency with the underlying unified/micromark/mdast utilities that are bundled with the project

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf140e57308324b605740854a00782