### PR TITLE
Add ambient declarations for GFM dependencies

### DIFF
--- a/src/types/gfm.d.ts
+++ b/src/types/gfm.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Ambient declarations for the GitHub-flavored markdown utilities used by
+ * react-markdown. The upstream packages ship ESM-only bundles, which can trip
+ * up TypeScript's module resolution in some tooling setups.
+ */
+declare module 'micromark-extension-gfm' {
+  export type Options = Record<string, unknown>;
+  export function gfm(options?: Options | null): unknown;
+}
+
+declare module 'mdast-util-gfm' {
+  export type Options = Record<string, unknown>;
+  export function gfmFromMarkdown(): unknown;
+  export function gfmToMarkdown(options?: Options | null): unknown;
+}


### PR DESCRIPTION
## Summary
- declare ambient modules for the GitHub-flavored markdown utilities so TypeScript resolves them reliably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf16af0fec83248299b47536e09b2e