### PR TITLE
fix: add remark-gfm ambient types

### DIFF
--- a/src/types/gfm.d.ts
+++ b/src/types/gfm.d.ts
@@ -13,3 +13,8 @@ declare module 'mdast-util-gfm' {
   export function gfmFromMarkdown(): unknown;
   export function gfmToMarkdown(options?: Options | null): unknown;
 }
+
+declare module 'remark-gfm' {
+  export { default } from 'remark-gfm/lib/index.js';
+  export * from 'remark-gfm/lib/index.js';
+}


### PR DESCRIPTION
## Summary
- add a local module declaration for `remark-gfm` that re-exports its packaged type definitions so TypeScript can resolve the plugin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf19fba7048324b6c86b22bc18408f