### PR TITLE
Handle missing micromark GFM dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.7",
         "react-router-dom": "^6.22.3",
+        "remark-parse": "^10.0.2",
         "unified": "^10.1.2",
         "zod": "^3.22.4"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
     "react-router-dom": "^6.22.3",
+    "remark-parse": "^10.0.2",
     "unified": "^10.1.2",
     "zod": "^3.22.4"
   },

--- a/src/lib/remarkGfm.ts
+++ b/src/lib/remarkGfm.ts
@@ -1,9 +1,20 @@
-import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
+import remarkParse from 'remark-parse';
+import type {
+  AlignType,
+  Paragraph,
+  PhrasingContent,
+  Root,
+  Table,
+  TableCell,
+  TableRow,
+  Text,
+} from 'mdast';
 import type { Options as MicromarkGfmOptions } from 'micromark-extension-gfm';
 import type { Options as MdastGfmOptions } from 'mdast-util-gfm';
 import { gfm as micromarkGfm } from 'micromark-extension-gfm';
 import { gfmFromMarkdown, gfmToMarkdown } from 'mdast-util-gfm';
+import { unified, type Plugin } from 'unified';
+import type { Parent } from 'unist';
 
 interface RemarkData {
   micromarkExtensions?: unknown[];
@@ -31,9 +42,252 @@ const remarkGfm: Plugin<[RemarkGfmOptions?], Root> = function remarkGfm(options)
   const fromMarkdownExtensions = data.fromMarkdownExtensions ?? (data.fromMarkdownExtensions = []);
   const toMarkdownExtensions = data.toMarkdownExtensions ?? (data.toMarkdownExtensions = []);
 
-  micromarkExtensions.push(micromarkGfm(settings));
-  fromMarkdownExtensions.push(gfmFromMarkdown());
-  toMarkdownExtensions.push(gfmToMarkdown(settings));
+  const extension = invokeMicromark(settings);
+
+  if (extension) {
+    micromarkExtensions.push(extension);
+    fromMarkdownExtensions.push(gfmFromMarkdown());
+    toMarkdownExtensions.push(gfmToMarkdown(settings));
+    return;
+  }
+
+  logFallbackWarning();
+
+  return (tree) => {
+    applyFallbackTables(tree);
+  };
 };
 
 export default remarkGfm;
+
+let inlineParser: ReturnType<typeof unified> | undefined;
+let loggedFallbackWarning = false;
+
+function invokeMicromark(options: CombinedOptions) {
+  try {
+    return micromarkGfm(options as MicromarkGfmOptions);
+  } catch (error) {
+    logFallbackWarning(error instanceof Error ? error : undefined);
+    return null;
+  }
+}
+
+function logFallbackWarning(error?: Error) {
+  if (loggedFallbackWarning || typeof console === 'undefined') {
+    return;
+  }
+
+  loggedFallbackWarning = true;
+  const message =
+    'micromark-extension-gfm is unavailable. Falling back to a limited table parser. Install the package to restore full GitHub-flavored Markdown support.';
+
+  if (error) {
+    console.warn(message, error);
+  } else {
+    console.warn(message);
+  }
+}
+
+function applyFallbackTables(tree: Root) {
+  transformNode(tree as Parent);
+}
+
+function transformNode(node: Parent): void {
+  const { children } = node as Parent & { children: unknown[] };
+  if (!Array.isArray(children)) {
+    return;
+  }
+
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    if (!child || typeof child !== 'object') {
+      continue;
+    }
+
+    if ((child as { type?: string }).type === 'paragraph') {
+      const table = convertParagraphToTable(child as Paragraph);
+      if (table) {
+        children.splice(index, 1, table);
+        continue;
+      }
+    }
+
+    if ('children' in (child as Parent)) {
+      transformNode(child as Parent);
+    }
+  }
+}
+
+function convertParagraphToTable(paragraph: Paragraph): Table | null {
+  if (paragraph.children.length !== 1) {
+    return null;
+  }
+
+  const [firstChild] = paragraph.children;
+  if (!firstChild || firstChild.type !== 'text') {
+    return null;
+  }
+
+  return parseTableBlock((firstChild as Text).value);
+}
+
+function parseTableBlock(value: string): Table | null {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length < 2) {
+    return null;
+  }
+
+  const [headerLine, delimiterLine, ...bodyLines] = lines;
+
+  if (!/\|/.test(headerLine) || !/^[:\-\s|]+$/.test(delimiterLine)) {
+    return null;
+  }
+
+  const headerCells = splitRow(headerLine);
+  const alignmentCells = splitRow(delimiterLine);
+
+  if (!headerCells.length || !alignmentCells.length) {
+    return null;
+  }
+
+  const alignmentInfo = alignmentCells.map(parseAlignmentCell);
+  if (alignmentInfo.some((align) => align === undefined)) {
+    return null;
+  }
+
+  const dataRows = bodyLines.map(splitRow);
+  const columnCount = Math.max(
+    headerCells.length,
+    alignmentInfo.length,
+    ...dataRows.map((row) => row.length)
+  );
+
+  if (!Number.isFinite(columnCount) || columnCount <= 0) {
+    return null;
+  }
+
+  const align = Array.from({ length: columnCount }, (_, index) => alignmentInfo[index] ?? null) as AlignType[];
+
+  const headerRow = createTableRow(headerCells, columnCount);
+  const rows = dataRows.map((row) => createTableRow(row, columnCount));
+
+  return {
+    type: 'table',
+    align,
+    children: [headerRow, ...rows],
+  };
+}
+
+function splitRow(line: string): string[] {
+  const cells: string[] = [];
+  let current = '';
+  let escaping = false;
+
+  for (const char of line) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaping = true;
+      continue;
+    }
+
+    if (char === '|') {
+      cells.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  cells.push(current.trim());
+
+  if (cells.length > 1 && cells[0] === '') {
+    cells.shift();
+  }
+
+  if (cells.length > 1 && cells[cells.length - 1] === '') {
+    cells.pop();
+  }
+
+  return cells;
+}
+
+function parseAlignmentCell(cell: string): AlignType | null | undefined {
+  const trimmed = cell.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const alignLeft = trimmed.startsWith(':');
+  const alignRight = trimmed.endsWith(':');
+  const core = trimmed.slice(alignLeft ? 1 : 0, alignRight ? -1 : undefined).trim();
+
+  if (!/^-+$/.test(core)) {
+    return undefined;
+  }
+
+  if (alignLeft && alignRight) {
+    return 'center';
+  }
+
+  if (alignRight) {
+    return 'right';
+  }
+
+  if (alignLeft) {
+    return 'left';
+  }
+
+  return null;
+}
+
+function createTableRow(cells: string[], columnCount: number): TableRow {
+  const normalized = Array.from({ length: columnCount }, (_, index) => cells[index] ?? '');
+
+  const children: TableCell[] = normalized.map((cell) => ({
+    type: 'tableCell',
+    children: parseInlineContent(cell),
+  }));
+
+  return {
+    type: 'tableRow',
+    children,
+  };
+}
+
+function parseInlineContent(value: string): PhrasingContent[] {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (!inlineParser) {
+    inlineParser = unified().use(remarkParse);
+  }
+
+  const tree = inlineParser.parse(trimmed) as Root;
+  const result: PhrasingContent[] = [];
+
+  for (const node of tree.children) {
+    if ((node as Paragraph).children && node.type === 'paragraph') {
+      result.push(...((node as Paragraph).children as PhrasingContent[]));
+    } else {
+      result.push(node as PhrasingContent);
+    }
+  }
+
+  if (result.length === 0) {
+    result.push({ type: 'text', value: trimmed } as Text);
+  }
+
+  return result;
+}

--- a/src/lib/shims/micromarkExtensionGfm.ts
+++ b/src/lib/shims/micromarkExtensionGfm.ts
@@ -1,0 +1,17 @@
+export type Options = Record<string, unknown>;
+
+/**
+ * Stub implementation used when `micromark-extension-gfm` is unavailable.
+ *
+ * The stub intentionally returns `null` so the Remark plugin can fall back to
+ * a lightweight table parser instead of failing the build. Consumers should
+ * install the real dependency to retain the full GitHub-flavored Markdown
+ * feature set.
+ */
+export function gfm(_: Options | null | undefined) {
+  return null;
+}
+
+export function gfmHtml(_: Options | null | undefined) {
+  return null;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,33 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+let micromarkExtensionPath: string | undefined;
+
+try {
+  require.resolve('micromark-extension-gfm');
+} catch (error) {
+  micromarkExtensionPath = path.resolve(
+    __dirname,
+    'src/lib/shims/micromarkExtensionGfm.ts'
+  );
+}
+
+const alias: Record<string, string> = {
+  '@': path.resolve(__dirname, 'src'),
+};
+
+if (micromarkExtensionPath) {
+  alias['micromark-extension-gfm'] = micromarkExtensionPath;
+}
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
-    },
+    alias,
   },
   server: {
     headers: {


### PR DESCRIPTION
## Summary
- alias micromark-extension-gfm to a local stub when the package is missing so builds keep working
- extend the remarkGfm helper to detect missing GFM support, warn once, and convert simple pipe tables via a fallback parser
- add a lightweight stub module and include remark-parse for inline cell parsing

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf231f88a48324abe63c3d90dec481