### PR TITLE
Add advanced B2 lesson bundle

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-06-20 — B2 content expansion
+- Added three advanced lessons on subjunctive triggers, reported speech, and high-register connectors with exercises and flashcards.
+- Updated the learning outline to surface the new B2 units in the mood & discourse track.
+
 ## 2024-06-14 — Workspace refresh
 - Rebuilt the home overview with search, level filters, recommendations, and flashcard readiness panels.
 - Expanded the dashboard with streak insights, SRS summaries, export buttons, and sortable mastery tables.

--- a/src/seed/b2-contrast-connectors.json
+++ b/src/seed/b2-contrast-connectors.json
@@ -1,0 +1,208 @@
+{
+  "lessons": [
+    {
+      "id": "b2-contrast-connectors",
+      "level": "B2",
+      "title": "B2 — Contrast & Concession Connectors",
+      "slug": "b2-contrast-connectors",
+      "tags": [
+        "connectors",
+        "discourse",
+        "b2",
+        "writing"
+      ],
+      "markdown": "# 🔗 B2 — Contrast & Concession Connectors\n\n**Goal:** Upgrade beyond *pero* to connectors that nuance contrast, concession, and unexpected results in speeches and reports.\n\n---\n\n## 1. Neutral contrast vs turnarounds\n- **pero** introduces a simple contrast in the same sentence.\n- **sin embargo / no obstante** break the sentence and reframe expectations; prefer them in formal or written registers.\n- **en cambio / por el contrario** highlight an alternative feature: *El plan es caro; en cambio, garantiza resultados.*\n\n## 2. Concession and persistence\n- **a pesar de (que), pese a (que)** concede an obstacle yet shows the action happens anyway.\n- **aun así, con todo, así y todo** stress resilience: *Estaba cansado; aun así terminó el informe.*\n- Combine with nouns or infinitives: *A pesar de los costes / A pesar de haber llegado tarde.*\n\n## 3. Intensified concession\n- **por más/mucho que + subjuntivo** emphasises futility: *Por más que lo expliques, no lo entenderán.*\n- **aunque + subjuntivo** signals hypothetical difficulty; **aunque + indicativo** states a known fact.\n- **si bien** introduces a partial agreement before the contrast: *Si bien es complejo, aporta flexibilidad.*\n\n## 4. Register & punctuation\n- Use a semicolon or period before heavier pivots (*; sin embargo,*).\n- Avoid doubling connectors (*pero sin embargo* ❌).\n- Choose according to tone: **no obstante** (formal), **aun así** (neutral), **con todo** (literary).\n\n---\n\n> 📝 **Summary:** Pick formal pivots (*sin embargo, no obstante*), concessive frames (*a pesar de que, aun así*), or intensified obstacles (*por más que, si bien*) to control nuance beyond *pero*.",
+      "references": [
+        "FundéuRAE. Sin embargo / no obstante.",
+        "Instituto Cervantes. Conectores del discurso (nivel B2)."
+      ]
+    }
+  ],
+  "exercises": [
+    {
+      "id": "b2-contrast-connectors-ex1",
+      "lessonId": "b2-contrast-connectors",
+      "type": "cloze",
+      "promptMd": "Tenía todo preparado; ___, cancelaron el evento a última hora.",
+      "answer": "sin embargo",
+      "accepted": [
+        "re:^sin\\s+embargo$"
+      ],
+      "feedback": {
+        "correct": "Correcto: *sin embargo* marca el giro inesperado.",
+        "wrong": "Necesitas un conector que rompa la expectativa: *sin embargo*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "sin embargo"
+      }
+    },
+    {
+      "id": "b2-contrast-connectors-ex2",
+      "lessonId": "b2-contrast-connectors",
+      "type": "mcq",
+      "promptMd": "Elige el conector más adecuado para un informe formal: **El presupuesto es elevado. ___, la inversión se recupera en dos años.**",
+      "options": [
+        "No obstante",
+        "Además",
+        "Por eso",
+        "Ya que"
+      ],
+      "answer": "No obstante",
+      "feedback": {
+        "correct": "Bien: *no obstante* aporta contraste elegante y formal.",
+        "wrong": "Busca un giro concesivo formal: *no obstante*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "registro formal"
+      }
+    },
+    {
+      "id": "b2-contrast-connectors-ex3",
+      "lessonId": "b2-contrast-connectors",
+      "type": "translate",
+      "promptMd": "Translate: **Despite the delays, the team delivered on time.**",
+      "answer": "A pesar de los retrasos, el equipo entregó a tiempo",
+      "accepted": [
+        "re:^A\\s+pesar\\s+de\\s+los\\s+retrasos,?\\s+el\\s+equipo\\s+entreg[oó]\\s+a\\s+tiempo\\.?$"
+      ],
+      "feedback": {
+        "correct": "Exacto: *A pesar de los retrasos* concede el obstáculo.",
+        "wrong": "Usa *a pesar de* para ceder el obstáculo y mostrar que aun así se logró."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write",
+          "read"
+        ],
+        "topic": "a pesar de"
+      }
+    },
+    {
+      "id": "b2-contrast-connectors-ex4",
+      "lessonId": "b2-contrast-connectors",
+      "type": "multi",
+      "promptMd": "Selecciona los conectores que expresan concesión (se reconoce una dificultad pero la acción continúa).",
+      "options": [
+        "a pesar de que",
+        "pese a que",
+        "aun así",
+        "por lo tanto"
+      ],
+      "answer": [
+        "a pesar de que",
+        "pese a que",
+        "aun así"
+      ],
+      "feedback": {
+        "correct": "Correcto: esos conectores aceptan el obstáculo y muestran continuidad.",
+        "wrong": "Recuerda: *a pesar de que, pese a que, aun así* conceden; *por lo tanto* indica consecuencia, no concesión."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "concesión"
+      }
+    },
+    {
+      "id": "b2-contrast-connectors-ex5",
+      "lessonId": "b2-contrast-connectors",
+      "type": "cloze",
+      "promptMd": "No comparto su propuesta; ___, reconozco que trabajó duro.",
+      "answer": "aun así",
+      "accepted": [
+        "re:^aun\\s+as[ií]$",
+        "re:^a[uú]n\\s+as[ií]$"
+      ],
+      "feedback": {
+        "correct": "Bien: *aun así* introduce reconocimiento tras un desacuerdo.",
+        "wrong": "Necesitas un conector concesivo: *aun así*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "aun así"
+      }
+    },
+    {
+      "id": "b2-contrast-connectors-ex6",
+      "lessonId": "b2-contrast-connectors",
+      "type": "mcq",
+      "promptMd": "Completa: **Por más que ___ (insistir), no cambiarán el calendario.**",
+      "options": [
+        "insistan",
+        "insisten",
+        "insistirán",
+        "insistían"
+      ],
+      "answer": "insistan",
+      "feedback": {
+        "correct": "Correcto: *por más que* pide subjuntivo para marcar esfuerzo inútil.",
+        "wrong": "Tras *por más que* usa subjuntivo: *por más que insistan*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "por más que + subjuntivo"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "b2-contrast-connectors-fc1",
+      "front": "sin embargo / no obstante",
+      "back": "Pivote formal para contraste fuerte entre oraciones.",
+      "tag": "connectors",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-contrast-connectors-fc2",
+      "front": "en cambio",
+      "back": "Introduce comparación alternativa: *Es caro; en cambio, dura más.*",
+      "tag": "connectors",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-contrast-connectors-fc3",
+      "front": "a pesar de (que)",
+      "back": "Concede obstáculo → acción se cumple: *A pesar de la lluvia, salimos.*",
+      "tag": "connectors",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-contrast-connectors-fc4",
+      "front": "aun así / con todo",
+      "back": "Expresan \"even so\": perseverancia pese al obstáculo.",
+      "tag": "connectors",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-contrast-connectors-fc5",
+      "front": "por más/mucho que",
+      "back": "+ subjuntivo → esfuerzo inútil: *Por más que estudien, seguirán dudando.*",
+      "tag": "connectors",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-contrast-connectors-fc6",
+      "front": "si bien",
+      "back": "Cede parcialmente antes de contraargumentar: *Si bien es complejo, aporta valor.*",
+      "tag": "connectors",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/b2-reported-speech.json
+++ b/src/seed/b2-reported-speech.json
@@ -1,0 +1,230 @@
+{
+  "lessons": [
+    {
+      "id": "b2-reported-speech",
+      "level": "B2",
+      "title": "B2 — Reported Speech & Sequence of Tenses",
+      "slug": "b2-reported-speech",
+      "tags": [
+        "reported speech",
+        "grammar",
+        "b2",
+        "discourse"
+      ],
+      "markdown": "# 🗣️ B2 — Reported Speech & Sequence of Tenses\n\n**Goal:** Shift direct quotations into natural reported speech, updating tense, pronouns, and time markers without losing nuance.\n\n---\n\n## 1. Core tense shifts\n- Present → imperfect: *\"Llego tarde\" → Dijo que llegaba tarde.*\n- Preterite → pluscuamperfecto when the action precedes reporting: *\"Fui al banco\" → Contó que había ido al banco.*\n- Futuro → condicional: *\"Mañana vendré\" → Prometió que vendría al día siguiente.*\n\n## 2. When the tense stays\n- If the situation is still true, keep the present: *Dice que vive en Valencia.*\n- Reporting universal truths or scheduled events keeps indicative present/future.\n- Verbs of perception or knowledge (**ver, saber, recordar**) may keep the original tense to stress immediacy.\n\n## 3. Commands, requests, advice\n- Use **que + subjuntivo** for mandates: *\"No abráis la puerta\" → Ordenó que no abriéramos la puerta.*\n- For instructions with infinitives, keep **infinitivo**: *\"Tenéis que salir\" → Dijo que teníamos que salir.*\n- **Pedir + que + subjuntivo** for polite requests: *Nos pidió que llegáramos temprano.*\n\n## 4. Questions, pronouns, and time markers\n- Replace question marks with statements using interrogative pronouns: *\"¿Dónde vives?\" → Preguntó dónde vivía.*\n- Adjust deictic adverbs: *hoy → ese día*, *mañana → al día siguiente*, *aquí → allí*.\n- Pronouns shift to match the reporter’s perspective: *\"Te llamaré\" → Me dijo que me llamaría.*\n\n---\n\n> 📝 **Summary:** In reported speech, slide tenses one step back, move commands into subjunctive, and realign time/pronoun references to the narrator’s point of view.",
+      "references": [
+        "Seco, Manuel. Gramática esencial del español. Reported speech.",
+        "RAE. Diccionario panhispánico de dudas, 'estilo indirecto'"
+      ]
+    }
+  ],
+  "exercises": [
+    {
+      "id": "b2-reported-speech-ex1",
+      "lessonId": "b2-reported-speech",
+      "type": "cloze",
+      "promptMd": "Ana dijo: \"Vendré mañana\". → Ana dijo que ___ al día siguiente.",
+      "answer": "vendría",
+      "accepted": [
+        "re:^vendr[íi]a$"
+      ],
+      "feedback": {
+        "correct": "Correcto: futuro directo → condicional en estilo indirecto.",
+        "wrong": "Futuro directo pasa a condicional: *dijo que vendría*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "futuro → condicional"
+      }
+    },
+    {
+      "id": "b2-reported-speech-ex2",
+      "lessonId": "b2-reported-speech",
+      "type": "mcq",
+      "promptMd": "Selecciona la mejor transformación: **\"No puedo asistir\", comentó Marta.**",
+      "options": [
+        "Marta comentó que no podía asistir.",
+        "Marta comenta que no pudo asistir.",
+        "Marta comentó que no pueda asistir.",
+        "Marta comentó que no asistiría."
+      ],
+      "answer": "Marta comentó que no podía asistir.",
+      "feedback": {
+        "correct": "Bien: presente → imperfecto en reported speech.",
+        "wrong": "Necesitas mover el presente a imperfecto: *no podía asistir*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "presente → imperfecto"
+      }
+    },
+    {
+      "id": "b2-reported-speech-ex3",
+      "lessonId": "b2-reported-speech",
+      "type": "translate",
+      "promptMd": "Translate: **He told us not to open the door.**",
+      "answer": "Nos dijo que no abriéramos la puerta",
+      "accepted": [
+        "re:^Nos\\s+dijo\\s+que\\s+no\\s+abri[ée]ramos\\s+la\\s+puerta\\.?$"
+      ],
+      "feedback": {
+        "correct": "Exacto: mandato → que + subjuntivo (no abriéramos).",
+        "wrong": "Usa **que + subjuntivo** para órdenes: *que no abriéramos la puerta*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write",
+          "read"
+        ],
+        "topic": "mandato → subjuntivo"
+      }
+    },
+    {
+      "id": "b2-reported-speech-ex4",
+      "lessonId": "b2-reported-speech",
+      "type": "cloze",
+      "promptMd": "Nos pidieron que ___ (entregar) el informe ese mismo día.",
+      "answer": "entregáramos",
+      "accepted": [
+        "re:^entreg[áa]ramos$"
+      ],
+      "feedback": {
+        "correct": "Correcto: petición → subjuntivo imperfecto (entregáramos).",
+        "wrong": "Tras *pedir que* usa subjuntivo: *que entregáramos*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "pedir que + subjuntivo"
+      }
+    },
+    {
+      "id": "b2-reported-speech-ex5",
+      "lessonId": "b2-reported-speech",
+      "type": "multi",
+      "promptMd": "Selecciona los ajustes deícticos correctos al pasar a estilo indirecto.",
+      "options": [
+        "ayer → el día anterior",
+        "mañana → el día siguiente",
+        "hoy → ayer",
+        "aquí → allí"
+      ],
+      "answer": [
+        "ayer → el día anterior",
+        "mañana → el día siguiente",
+        "aquí → allí"
+      ],
+      "feedback": {
+        "correct": "Exacto: esos son los desplazamientos habituales de tiempo/lugar.",
+        "wrong": "Recuerda: ayer → el día anterior, mañana → el día siguiente, aquí → allí. *Hoy* pasa a *ese día*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "deixis indirecta"
+      }
+    },
+    {
+      "id": "b2-reported-speech-ex6",
+      "lessonId": "b2-reported-speech",
+      "type": "short",
+      "promptMd": "Convierte la pregunta **\"¿Dónde vives?\"** a estilo indirecto (sin sujeto explícito).",
+      "answer": "Preguntó dónde vivía",
+      "accepted": [
+        "re:^Pregunt[oó]\\s+d[oó]nde\\s+viv[ií]a\\.?$",
+        "re:^Me\\s+pregunt[oó]\\s+d[oó]nde\\s+viv[ií]a\\.?$",
+        "re:^Nos\\s+pregunt[oó]\\s+d[oó]nde\\s+viv[ií]amos\\.?$"
+      ],
+      "feedback": {
+        "correct": "Bien: la pregunta indirecta usa verbo en imperfecto y pierde signos interrogativos.",
+        "wrong": "Introduce *que* solo en preguntas totales; aquí usa *preguntó dónde vivía*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "preguntas indirectas"
+      }
+    },
+    {
+      "id": "b2-reported-speech-ex7",
+      "lessonId": "b2-reported-speech",
+      "type": "mcq",
+      "promptMd": "¿Cuál mantiene correctamente la perspectiva? **\"Te llamaré esta tarde\", me dijo.**",
+      "options": [
+        "Me dijo que me llamaría esa tarde.",
+        "Me dijo que te llamaría esa tarde.",
+        "Me dijo que lo llamaría esa tarde.",
+        "Me dijo que llamaría esa tarde."
+      ],
+      "answer": "Me dijo que me llamaría esa tarde.",
+      "feedback": {
+        "correct": "Correcto: pronombre y adverbio cambian desde mi perspectiva → *me llamaría esa tarde*.",
+        "wrong": "Ajusta pronombres y tiempo: *te* pasa a *me*, *esta tarde* → *esa tarde*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "pronombres y tiempo"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "b2-reported-speech-fc1",
+      "front": "Futuro directo",
+      "back": "→ Condicional: *\"Iré\" → dijo que iría*.",
+      "tag": "reported speech",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-reported-speech-fc2",
+      "front": "Mandato negativo",
+      "back": "→ Que + subjuntivo: *Ordenó que no abriéramos*.",
+      "tag": "reported speech",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-reported-speech-fc3",
+      "front": "Preguntas parciales",
+      "back": "Usan pronombre interrogativo + verbo en imperfecto: *Preguntó dónde vivía*.",
+      "tag": "reported speech",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-reported-speech-fc4",
+      "front": "Deixis temporal",
+      "back": "hoy → ese día, mañana → al día siguiente, ayer → el día anterior.",
+      "tag": "reported speech",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-reported-speech-fc5",
+      "front": "Seguimos usando presente",
+      "back": "Para verdades generales: *Dice que el agua hierve a 100 °C*.",
+      "tag": "reported speech",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-reported-speech-fc6",
+      "front": "Pronombres",
+      "back": "Ajusta a la perspectiva del narrador: *Te llamaré* → *me llamaría*.",
+      "tag": "reported speech",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/b2-subjunctive-triggers.json
+++ b/src/seed/b2-subjunctive-triggers.json
@@ -1,0 +1,228 @@
+{
+  "lessons": [
+    {
+      "id": "b2-subjunctive-triggers",
+      "level": "B2",
+      "title": "B2 — Subjunctive Triggers for Future & Uncertainty",
+      "slug": "b2-subjunctive-triggers",
+      "tags": [
+        "subjunctive",
+        "grammar",
+        "b2",
+        "mood"
+      ],
+      "markdown": "# 🌙 B2 — Subjunctive Triggers for Future & Uncertainty\n\n**Goal:** Decide when Spanish uses the subjunctive after connectors that project into the future or describe something that may not exist.\n\n---\n\n## 1. Future-facing time clauses\n- Use subjunctive after **cuando, en cuanto, hasta que, tan pronto como, antes de que** when the event is pending: *Te avisaré cuando llegues.*\n- Keep the indicative when the action is habitual or completed: *Cuando llego temprano, desayuno con calma.*\n- With **antes de que** the subjunctive is obligatory because the second action is unrealised at the moment of speaking.\n\n## 2. Conditional or uncertain results\n- Expressions of aim or condition (**para que, a menos que, con tal de que, en caso de que**) trigger the subjunctive because the result is not guaranteed.\n- Contrast with the indicative after **porque, ya que** when giving facts; they assert reality.\n- Use **aunque + subjuntivo** when the speaker entertains a possibility: *Aunque sea caro, lo compraré.*\n\n## 3. Nonexistent or indefinite antecedents\n- After verbs like **buscar, necesitar, querer** use subjunctive if the referent is unknown or hypothetical: *Busco un piso que tenga luz.*\n- Switch back to indicative when the speaker identifies a specific, real referent: *Conozco a un profesor que habla alemán.*\n- Negative antecedents almost always take the subjunctive: *No hay nadie que pueda hacerlo.*\n\n## 4. Attitude and evaluation frames\n- Judgement phrases (**es posible que, me alegra que, dudo que**) set the scene for the subjunctive.\n- Verbs of perception and certainty keep the indicative unless negated: *Creo que viene* vs *No creo que venga.*\n- Remember that the subjunctive signals subjectivity—doubt, desire, or projection—rather than tense.\n\n---\n\n> 📝 **Summary:** Choose the subjunctive when the outcome is pending, uncertain, or unreal; the indicative when the speaker confirms reality or routine.",
+      "references": [
+        "RAE. Nueva gramática de la lengua española, §25",
+        "Real Academia Española. Diccionario panhispánico de dudas, 'subjuntivo'"
+      ]
+    }
+  ],
+  "exercises": [
+    {
+      "id": "b2-subjunctive-triggers-ex1",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "cloze",
+      "promptMd": "**Esperaré aquí hasta que ___ (llegar) tú.**",
+      "answer": "llegues",
+      "accepted": [
+        "re:^llegues$"
+      ],
+      "feedback": {
+        "correct": "Correcto: acción futura pendiente → subjuntivo (llegues).",
+        "wrong": "Cuando la acción no se ha realizado aún, usa subjuntivo: *hasta que llegues*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "hasta que + subjuntivo"
+      }
+    },
+    {
+      "id": "b2-subjunctive-triggers-ex2",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "mcq",
+      "promptMd": "Selecciona la opción correcta: **Cuando ___ tiempo, te llamaré.**",
+      "options": [
+        "tenga",
+        "tengo",
+        "tuve",
+        "tendré"
+      ],
+      "answer": "tenga",
+      "feedback": {
+        "correct": "Bien: futura contingencia → subjuntivo: *cuando tenga*.",
+        "wrong": "La acción es futura e incierta, por eso va en subjuntivo: *tenga*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "cuando futuro"
+      }
+    },
+    {
+      "id": "b2-subjunctive-triggers-ex3",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "cloze",
+      "promptMd": "**No conozco a nadie que ___ (ofrecer) ese servicio.**",
+      "answer": "ofrezca",
+      "accepted": [
+        "re:^ofrezca$"
+      ],
+      "feedback": {
+        "correct": "Correcto: antecedente negativo → subjuntivo (ofrezca).",
+        "wrong": "Con antecedente inexistente/negado se usa subjuntivo: *que ofrezca*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "antecedente negativo"
+      }
+    },
+    {
+      "id": "b2-subjunctive-triggers-ex4",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "multi",
+      "promptMd": "Selecciona las conjunciones que exigen subjuntivo cuando refieren a una acción futura aún no realizada.",
+      "options": [
+        "antes de que",
+        "porque",
+        "en cuanto",
+        "a condición de que"
+      ],
+      "answer": [
+        "antes de que",
+        "en cuanto",
+        "a condición de que"
+      ],
+      "feedback": {
+        "correct": "Bien: esas conjunciones proyectan una acción futura o condicionada y llevan subjuntivo.",
+        "wrong": "Recuerda: **antes de que, en cuanto, a condición de que** → subjuntivo; **porque** enuncia hechos y va con indicativo."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "conectores de futuro"
+      }
+    },
+    {
+      "id": "b2-subjunctive-triggers-ex5",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "translate",
+      "promptMd": "Translate: **Even if it is expensive, we'll buy it.**",
+      "answer": "Aunque sea caro, lo compraremos",
+      "accepted": [
+        "re:^Aunque\\s+sea\\s+caro,?\\s+lo\\s+compraremos\\.?$"
+      ],
+      "feedback": {
+        "correct": "Exacto: posibilidad → *aunque sea caro*.",
+        "wrong": "Usa subjuntivo con *aunque* para una situación hipotética: *aunque sea caro*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write",
+          "read"
+        ],
+        "topic": "aunque hipotético"
+      }
+    },
+    {
+      "id": "b2-subjunctive-triggers-ex6",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "cloze",
+      "promptMd": "**Es posible que ___ (haber) retrasos por la huelga.**",
+      "answer": "haya",
+      "accepted": [
+        "re:^haya$"
+      ],
+      "feedback": {
+        "correct": "Correcto: expresiones de probabilidad → subjuntivo (haya).",
+        "wrong": "Tras *es posible que* se usa subjuntivo: *haya*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "write"
+        ],
+        "topic": "es posible que"
+      }
+    },
+    {
+      "id": "b2-subjunctive-triggers-ex7",
+      "lessonId": "b2-subjunctive-triggers",
+      "type": "mcq",
+      "promptMd": "Elige la opción que mantiene el sentido: **No creo que ___ la verdad.**",
+      "options": [
+        "diga",
+        "dice",
+        "dirá",
+        "ha dicho"
+      ],
+      "answer": "diga",
+      "feedback": {
+        "correct": "Bien: negación de creencia → subjuntivo (diga).",
+        "wrong": "Con *no creer que* va subjuntivo: *no creo que diga la verdad*."
+      },
+      "meta": {
+        "difficulty": "B2",
+        "skills": [
+          "read"
+        ],
+        "topic": "negación de creencia"
+      }
+    }
+  ],
+  "flashcards": [
+    {
+      "id": "b2-subjunctive-triggers-fc1",
+      "front": "cuando / en cuanto + evento futuro",
+      "back": "Usa subjuntivo: *Te avisaré cuando llegues*.",
+      "tag": "subjunctive",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-subjunctive-triggers-fc2",
+      "front": "antes de que",
+      "back": "Siempre requiere subjuntivo porque la acción aún no ocurre.",
+      "tag": "subjunctive",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-subjunctive-triggers-fc3",
+      "front": "para que / a condición de que",
+      "back": "Expresan finalidad/condición → subjuntivo.",
+      "tag": "subjunctive",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-subjunctive-triggers-fc4",
+      "front": "antecedente desconocido",
+      "back": "*Busco a alguien que hable japonés* → subjuntivo.",
+      "tag": "subjunctive",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-subjunctive-triggers-fc5",
+      "front": "negación + que",
+      "back": "*No creo que sea cierto* → subjuntivo tras negación.",
+      "tag": "subjunctive",
+      "deck": "grammar"
+    },
+    {
+      "id": "b2-subjunctive-triggers-fc6",
+      "front": "aunque + posibilidad",
+      "back": "Para escenarios hipotéticos: *Aunque sea difícil...*",
+      "tag": "subjunctive",
+      "deck": "grammar"
+    }
+  ]
+}

--- a/src/seed/sections.json
+++ b/src/seed/sections.json
@@ -16,6 +16,15 @@
         { "slug": "b1-gender-number", "label": "[B1]", "estMinutes": 40, "prereq": ["b1-articles-basics"] },
         { "slug": "c1-neuter-lo", "label": "[C1]", "estMinutes": 30, "prereq": ["b1-articles-basics"] }
       ]
+    },
+    {
+      "id": "b2-mood-discourse",
+      "title": "B2 · Mood & Discourse Control",
+      "lessons": [
+        { "slug": "b2-subjunctive-triggers", "label": "[B2]", "estMinutes": 45, "prereq": ["b1-present-regulars", "b1-por-para-a-time"] },
+        { "slug": "b2-reported-speech", "label": "[B2]", "estMinutes": 40, "prereq": ["b1-preterito-indefinido", "b1-imperfecto-vs-indefinido"] },
+        { "slug": "b2-contrast-connectors", "label": "[B2]", "estMinutes": 35, "prereq": ["b1-connectors-adverbials"] }
+      ]
     }
     // ... (rest of the master outline JSON exactly as given earlier)
   ]


### PR DESCRIPTION
## Summary
- add three detailed B2 lesson bundles covering subjunctive triggers, reported speech, and contrast connectors
- register the new lessons in the section outline for the mood & discourse track
- log the content expansion in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d062c9ec00832482233515976650b1