### PR TITLE
Redesign planner shell and home experience

### DIFF
--- a/src/components/layout/AppShell.module.css
+++ b/src/components/layout/AppShell.module.css
@@ -1,687 +1,366 @@
 .appShell {
   position: relative;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   color: var(--ui-text-primary);
 }
 
-.background {
+.backdrop {
   pointer-events: none;
   position: fixed;
   inset: 0;
   z-index: -1;
-  overflow: hidden;
+  background: var(--ui-bg);
 }
 
-.background::before,
-.background::after {
-  content: '';
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(120px);
-  opacity: 0.55;
-}
-
-.background::before {
-  width: 560px;
-  height: 560px;
-  left: -120px;
-  top: -160px;
-  background: radial-gradient(circle, rgba(125, 211, 252, 0.55), transparent 70%);
-}
-
-.background::after {
-  width: 520px;
-  height: 520px;
-  right: -140px;
-  bottom: -200px;
-  background: radial-gradient(circle, rgba(16, 185, 129, 0.45), transparent 70%);
-}
-
-.shellLayout {
-  display: grid;
-  grid-template-columns: 320px minmax(0, 1fr);
-  gap: 32px;
-  padding: 48px clamp(18px, 6vw, 56px) 64px;
-  margin: 0 auto;
-  max-width: 1440px;
-  box-sizing: border-box;
-}
-
-.primaryColumn {
+.header {
   position: sticky;
-  top: 40px;
-  align-self: start;
+  top: 0;
+  z-index: 10;
   display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 28px;
-  border-radius: 32px;
-  background: var(--ui-surface-strong);
-  border: 1px solid var(--ui-border-strong);
-  box-shadow: var(--ui-shadow-strong);
-  max-height: calc(100vh - 80px);
-  overflow-y: auto;
-  scrollbar-width: thin;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  padding: 18px clamp(18px, 6vw, 48px);
+  background: rgba(255, 255, 255, 0.88);
+  border-bottom: 1px solid var(--ui-border);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 60px -48px rgba(15, 23, 42, 0.25);
 }
 
-.primaryColumn[data-collapsed='true'] {
-  display: none;
+body.high-contrast .header {
+  background: rgba(15, 23, 42, 0.9);
 }
 
-.primaryColumn::-webkit-scrollbar {
-  width: 6px;
-}
-
-.primaryColumn::-webkit-scrollbar-thumb {
-  background: rgba(148, 163, 184, 0.4);
-  border-radius: 999px;
-}
-
-.brandBlock {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.logo {
+.brand {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   text-decoration: none;
   color: inherit;
+  flex: 0 0 auto;
 }
 
-.logoMark {
+.brandMark {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.9), rgba(16, 185, 129, 0.9));
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, #f97316, #facc15);
+  color: #0f172a;
   font-family: var(--ui-font-display);
+  font-size: 1.05rem;
   font-weight: 800;
-  font-size: 1rem;
   letter-spacing: 0.08em;
-  color: var(--ui-text-inverse);
 }
 
-.logoText {
+body.high-contrast .brandMark {
+  color: #020617;
+  background: linear-gradient(145deg, #facc15, #f97316);
+}
+
+.brandText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brandName {
   font-family: var(--ui-font-display);
   font-size: 1.4rem;
   font-weight: 800;
   letter-spacing: -0.01em;
 }
 
-.tagline {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--ui-text-secondary);
-}
-
-.primaryNav {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.sectionLabel {
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
+.brandTagline {
+  font-size: 0.85rem;
   text-transform: uppercase;
-  font-weight: 700;
+  letter-spacing: 0.2em;
   color: var(--ui-text-secondary);
 }
 
-.navList {
+.nav {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 12px;
-  list-style: none;
-  padding: 0;
-  margin: 0;
+  flex: 1 1 auto;
+  min-width: 240px;
 }
 
 .navLink {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
-  padding: 16px 18px;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.85);
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: var(--ui-radius-pill);
   border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.7);
+  color: inherit;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   text-decoration: none;
-  color: var(--ui-text-primary);
-  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.45);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+body.high-contrast .navLink {
+  background: rgba(15, 23, 42, 0.6);
 }
 
 .navLink:hover,
 .navLink:focus-visible {
-  transform: translateX(4px);
+  transform: translateY(-2px);
   border-color: var(--ui-accent);
+  box-shadow: 0 18px 40px -32px rgba(34, 197, 94, 0.6);
 }
 
 .navLinkActive {
-  background: linear-gradient(140deg, rgba(34, 197, 94, 0.18), rgba(96, 165, 250, 0.2));
-  border-color: var(--ui-accent);
-  box-shadow: 0 24px 60px -40px rgba(34, 197, 94, 0.45);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.25), rgba(248, 113, 113, 0.25));
+  border-color: rgba(248, 113, 113, 0.45);
+  box-shadow: 0 24px 60px -46px rgba(249, 115, 22, 0.55);
+}
+
+body.high-contrast .navLinkActive {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.25), rgba(250, 204, 21, 0.3));
+  border-color: rgba(250, 204, 21, 0.6);
 }
 
 .navIcon {
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  background: var(--ui-accent-soft);
+  font-size: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: rgba(255, 255, 255, 0.72);
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+body.high-contrast .actionButton {
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.actionButton:hover,
+.actionButton:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--ui-accent);
+}
+
+.actionButtonActive {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.25), rgba(248, 113, 113, 0.25));
+  border-color: rgba(244, 114, 182, 0.4);
+}
+
+.actionIcon {
+  font-size: 1.1rem;
+}
+
+.actionLabel {
+  font-size: 0.9rem;
+}
+
+.commandBar {
+  width: min(1120px, calc(100% - 32px));
+  margin: 32px auto 0;
+  padding: 22px 26px;
+  border-radius: var(--ui-radius-xl);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  background: linear-gradient(145deg, rgba(248, 113, 113, 0.2), rgba(250, 204, 21, 0.18));
+  box-shadow: 0 32px 90px -64px rgba(249, 115, 22, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+body.high-contrast .commandBar {
+  border-color: rgba(250, 204, 21, 0.45);
+  background: linear-gradient(145deg, rgba(250, 204, 21, 0.25), rgba(248, 113, 113, 0.2));
+  box-shadow: 0 30px 80px -60px rgba(250, 204, 21, 0.45);
+}
+
+.commandHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.commandTitle {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 700;
+}
+
+.commandSubtitle {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--ui-text-secondary);
+}
+
+.commandList {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.commandCard {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  color: inherit;
+  box-shadow: 0 16px 38px -32px rgba(15, 23, 42, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.commandCard:hover,
+.commandCard:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(248, 113, 113, 0.65);
+  box-shadow: 0 22px 50px -40px rgba(248, 113, 113, 0.55);
+}
+
+.commandCardDisabled {
+  opacity: 0.75;
+  cursor: default;
+}
+
+.commandIcon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 1.4rem;
-  color: var(--ui-accent-strong);
-  flex-shrink: 0;
 }
 
-.navText {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.navLabel {
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.navHint {
-  font-size: 0.85rem;
-  color: var(--ui-text-secondary);
-}
-
-.quickSection,
-.guideSection {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 24px;
-  border-radius: 28px;
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-  box-shadow: var(--ui-shadow);
-}
-
-.sectionHeader {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.sectionHint {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--ui-text-secondary);
-}
-
-.quickActions {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.quickLink {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  border-radius: 22px;
-  padding: 14px 18px;
-  border: 1px solid var(--ui-border);
-  background: rgba(255, 255, 255, 0.85);
-  text-decoration: none;
-  color: inherit;
-  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
-}
-
-.quickLink:hover,
-.quickLink:focus-visible {
-  transform: translateX(4px);
-  border-color: var(--ui-accent);
-}
-
-.quickLinkText {
+.commandText {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.quickLinkLabel {
+.commandLabel {
   font-weight: 700;
-  font-size: 0.95rem;
+  letter-spacing: -0.01em;
 }
 
-.quickLinkDescription {
-  font-size: 0.8rem;
+.commandHint {
+  font-size: 0.9rem;
   color: var(--ui-text-secondary);
 }
 
-.quickLinkMeta {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
+.commandMeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  margin-left: auto;
 }
 
-.quickLinkBadge {
+.commandBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 32px;
   padding: 4px 10px;
   border-radius: var(--ui-radius-pill);
-  background: var(--ui-accent-soft);
-  color: var(--ui-accent-strong);
+  background: rgba(248, 113, 113, 0.18);
   font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
-.quickLinkIcon {
-  font-size: 1.2rem;
-  color: var(--ui-accent-strong);
-  transition: transform 0.2s ease;
-}
-
-.quickLink:hover .quickLinkIcon,
-.quickLink:focus-visible .quickLinkIcon {
-  transform: translateX(4px);
-}
-
-.guideList {
-  margin: 0;
-  padding-left: 1.2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-size: 0.95rem;
-}
-
-.mainColumn {
-  display: flex;
-  flex-direction: column;
-  gap: 28px;
-  min-width: 0;
-}
-
-.toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 22px 28px;
-  border-radius: 30px;
-  background: var(--ui-surface-strong);
-  border: 1px solid var(--ui-border-strong);
-  box-shadow: var(--ui-shadow-strong);
-}
-
-.toolbarIntro {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  min-width: 280px;
-  flex: 1;
-}
-
-.navToggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 14px;
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-  color: var(--ui-text-secondary);
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  cursor: pointer;
-}
-
-.navToggle[aria-pressed='true'] {
-  background: rgba(34, 197, 94, 0.12);
-  color: var(--ui-accent-strong);
-  border-color: var(--ui-accent);
-}
-
-.flowPill {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface-muted);
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-weight: 700;
-  color: var(--ui-text-secondary);
-}
-
-.flowPill span:first-child {
-  background: var(--ui-accent);
-  color: var(--ui-text-inverse);
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-}
-
-.toolbarText {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.toolbarTitle {
-  margin: 0;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.toolbarSubtitle {
-  margin: 0;
-  font-size: 0.9rem;
-  color: var(--ui-text-secondary);
-}
-
-.toolbarActions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.toolbarSearch {
-  display: inline-flex;
-  align-items: stretch;
-  gap: 8px;
-  padding: 4px;
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-}
-
-.searchInput {
-  border: none;
-  background: transparent;
-  padding: 6px 12px;
-  border-radius: var(--ui-radius-pill);
-  font-size: 0.9rem;
-  min-width: 220px;
-  outline: none;
-  color: var(--ui-text-primary);
-}
-
-.searchInput::placeholder {
-  color: var(--ui-text-muted);
-}
-
-.searchButton {
-  border: none;
-  border-radius: var(--ui-radius-pill);
-  padding: 6px 14px;
-  background: var(--ui-accent);
-  color: var(--ui-text-inverse);
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  cursor: pointer;
-}
-
-.searchButton:hover,
-.searchButton:focus-visible {
-  background: var(--ui-accent-strong);
-}
-
-.contrastToggle {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 18px;
-  border-radius: 999px;
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-  color: var(--ui-text-secondary);
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  font-weight: 700;
-  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
-}
-
-.contrastToggle[data-active='true'] {
-  border-color: var(--ui-accent);
-  background: rgba(34, 197, 94, 0.12);
-  color: var(--ui-accent-strong);
-}
-
-.toggleThumb {
-  position: absolute;
-  top: 4px;
-  left: 6px;
-  width: 38px;
-  height: 38px;
-  border-radius: 19px;
-  background: var(--ui-surface-strong);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.65rem;
-  font-weight: 700;
-  color: var(--ui-text-secondary);
-  transition: transform 0.25s ease, background-color 0.25s ease;
-}
-
-.contrastToggle[data-active='true'] .toggleThumb {
-  transform: translateX(44px);
-  background: var(--ui-accent);
-  color: var(--ui-text-inverse);
-}
-
-.toggleLabels {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.focusToggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 18px;
-  border-radius: 999px;
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-  color: var(--ui-text-primary);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.focusToggle[data-active='true'] {
-  background: var(--ui-highlight);
-  color: var(--ui-text-inverse);
-  border-color: transparent;
-  box-shadow: 0 18px 45px -30px rgba(79, 70, 229, 0.55);
-}
-
-.focusToggle[data-active='true'] .focusStatus {
-  color: var(--ui-text-inverse);
-}
-
-.focusStatus {
-  font-size: 0.75rem;
-  color: var(--ui-text-secondary);
-  letter-spacing: 0.08em;
-}
-
-.contentArea {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 280px;
-  gap: 24px;
-  align-items: start;
-  min-width: 0;
-}
-
-.contentArea[data-focus='on'],
-.contentArea[data-sidebar='hidden'] {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.contentArea[data-focus='on'] .sidePanel,
-.contentArea[data-sidebar='hidden'] .sidePanel {
-  display: none;
+.commandArrow {
+  font-size: 1.1rem;
 }
 
 .main {
-  min-width: 0;
+  flex: 1 1 auto;
+  width: 100%;
+  padding: 48px 0 64px;
 }
 
-.mainCanvas {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+.mainFocused {
+  padding-top: 32px;
 }
 
-.mainCanvasWide {
-  gap: clamp(24px, 3vw, 36px);
+.mainLesson {
+  padding-top: 32px;
 }
 
-.mainCanvasFocused {
-  border-radius: var(--ui-radius-xl);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface-strong);
-  box-shadow: var(--ui-shadow-strong);
-  padding: clamp(24px, 3vw, 32px);
-}
-
-.sidePanel {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.sideCard {
-  box-shadow: var(--ui-shadow);
+.mainInner {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
 }
 
 .footer {
-  margin-top: 8px;
-  padding-top: 24px;
-  border-top: 1px solid var(--ui-border);
+  margin-top: auto;
+  padding: 32px clamp(18px, 6vw, 48px) 48px;
+  text-align: center;
   color: var(--ui-text-secondary);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
 }
 
-[data-focus-mode='on'] .footer {
+.footer a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.appShell[data-focus-mode='on'] .commandBar {
   display: none;
 }
 
-@media (max-width: 1200px) {
-  .shellLayout {
-    grid-template-columns: minmax(0, 1fr);
-    padding: 40px clamp(18px, 6vw, 48px) 56px;
-  }
-
-  .primaryColumn {
-    position: static;
-    max-height: none;
-  }
-
-  .contentArea {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-@media (max-width: 900px) {
-  .shellLayout {
-    padding: 32px clamp(16px, 7vw, 44px) 48px;
-    gap: 28px;
-  }
-
-  .toolbar {
-    padding: 20px 22px;
-  }
-
-  .toolbarIntro {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 16px;
-  }
-
-  .navToggle {
-    align-self: flex-end;
-  }
-
-  .flowPill {
-    order: 1;
-  }
-
-  .toolbarText {
-    order: 0;
-  }
-
-  .toolbarActions {
-    width: 100%;
+@media (max-width: 960px) {
+  .nav {
     justify-content: flex-start;
+    overflow-x: auto;
   }
 
-  .toolbarSearch {
-    flex: 1;
-    width: 100%;
+  .commandBar {
+    padding: 20px;
   }
 
-  .searchInput {
-    min-width: 0;
-    flex: 1;
+  .commandList {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 }
 
 @media (max-width: 720px) {
-  .shellLayout {
-    padding: 24px 16px 40px;
+  .header {
+    justify-content: center;
+    text-align: center;
   }
 
-  .primaryColumn {
-    padding: 24px;
-    border-radius: 24px;
-  }
-
-  .navList {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-
-  .toolbar {
-    border-radius: 24px;
-    gap: 16px;
-  }
-
-  .toolbarActions {
-    width: 100%;
-    justify-content: stretch;
-  }
-
-  .contrastToggle,
-  .focusToggle {
-    flex: 1 1 160px;
+  .brand {
     justify-content: center;
   }
 
-  .contentArea {
-    gap: 20px;
+  .headerActions {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
   }
 }

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,489 +1,545 @@
 .page {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 36px;
 }
 
-.hero {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  align-items: center;
-}
-
-.heroContent {
+.sectionHeader {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
 }
 
-.heroTitle {
-  margin: 0;
-  font-size: 2.4rem;
-  line-height: 1.1;
-  font-family: var(--ui-font-display);
-}
-
-.heroDescription {
-  margin: 0;
-  font-size: 1rem;
-  color: rgba(236, 253, 245, 0.9);
-  max-width: 50ch;
-}
-
-.heroActions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.heroNote {
-  margin: 4px 0 0;
-  font-size: 0.9rem;
-  color: rgba(236, 253, 245, 0.75);
-}
-
-.heroStats {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-}
-
-.heroStatsItem {
-  border-radius: var(--ui-radius-md);
-  padding: 16px;
-  backdrop-filter: blur(12px);
-  background: rgba(255, 255, 255, 0.16);
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  color: #ecfdf5;
-}
-
-.heroStatsItem dt {
+.sectionTag {
   font-size: 0.75rem;
   letter-spacing: 0.24em;
   text-transform: uppercase;
+  font-weight: 700;
+  color: var(--ui-text-secondary);
+}
+
+.sectionTitle {
   margin: 0;
-}
-
-.heroStatsItem dd {
-  margin: 10px 0 0;
-  font-size: 2.1rem;
+  font-size: 1.8rem;
   font-family: var(--ui-font-display);
+  letter-spacing: -0.01em;
 }
 
-.nextGrid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  margin-top: 12px;
+.sectionSubtitle {
+  margin: 0;
+  color: var(--ui-text-secondary);
+  font-size: 1rem;
+  max-width: 60ch;
 }
 
-.nextCard {
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  overflow: hidden;
+}
+
+.timelineIntro {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.timelineTitle {
+  margin: 0;
+  font-size: 2.5rem;
+  line-height: 1.05;
+  font-family: var(--ui-font-display);
+}
+
+.timelineSubtitle {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(236, 253, 245, 0.9);
+  max-width: 60ch;
+}
+
+.timelineStats {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.timelineStat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border-radius: var(--ui-radius-md);
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #ecfdf5;
+}
+
+.timelineStatLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+}
+
+.timelineStatValue {
+  font-size: 2rem;
+  font-family: var(--ui-font-display);
+}
+
+.timelineCards {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.timelineCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   padding: 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.16);
+  color: #ecfdf5;
+}
+
+.timelineCardLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.timelineCardTitle {
+  margin: 0;
+  font-size: 1.3rem;
+  font-family: var(--ui-font-display);
+  letter-spacing: -0.01em;
+}
+
+.timelineCardDescription {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(236, 253, 245, 0.85);
+}
+
+.timelineCardAction {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: inherit;
+}
+
+.timelineCardAction:hover,
+.timelineCardAction:focus-visible {
+  color: #fef3c7;
+}
+
+.timelineFootnote {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(236, 253, 245, 0.85);
+}
+
+.focusSection {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.focusGrid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.focusCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
   border-radius: var(--ui-radius-lg);
   border: 1px solid var(--ui-border);
   background: var(--ui-surface-strong);
-  box-shadow: var(--ui-shadow);
-}
-
-.nextCard h3 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.nextLink {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
   text-decoration: none;
-  color: var(--ui-text-primary);
-  font-weight: 600;
-}
-
-.nextLink:hover,
-.nextLink:focus-visible {
-  color: var(--ui-accent-strong);
-}
-
-.nextTitle {
-  font-size: 1.2rem;
-  font-family: var(--ui-font-display);
-}
-
-.nextMeta {
-  color: var(--ui-text-secondary);
-  font-size: 0.9rem;
-}
-
-.nextHint {
-  color: var(--ui-text-secondary);
-  font-size: 0.9rem;
-}
-
-.nextList {
-  margin: 8px 0 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 6px;
-  color: var(--ui-text-secondary);
-}
-
-.nextListLink {
   color: inherit;
-  text-decoration: none;
+  box-shadow: var(--ui-shadow);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
-.nextListLink:hover,
-.nextListLink:focus-visible {
-  color: var(--ui-accent-strong);
-  text-decoration: underline;
+.focusCard:hover,
+.focusCard:focus-visible {
+  transform: translateY(-4px);
+  border-color: var(--ui-accent);
+  box-shadow: var(--ui-shadow-strong);
 }
 
-.nextEmpty {
-  margin: 8px 0 0;
+.focusLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
   color: var(--ui-text-secondary);
 }
 
-.quickActions {
+.focusTitleRow {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 18px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface-muted);
-}
-
-.quickActions h3 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.quickActionsList {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
+  align-items: center;
   gap: 10px;
 }
 
-.quickActionsLink {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  text-decoration: none;
-  font-weight: 600;
-  color: var(--ui-text-primary);
+.focusIcon {
+  font-size: 1.4rem;
 }
 
-.quickActionsLink span:last-child {
-  font-weight: 400;
-  font-size: 0.85rem;
+.focusTitle {
+  margin: 0;
+  font-size: 1.3rem;
+  font-family: var(--ui-font-display);
+  letter-spacing: -0.01em;
+}
+
+.focusDescription {
+  margin: 0;
   color: var(--ui-text-secondary);
+  font-size: 0.95rem;
 }
 
-.quickActionsLink:hover,
-.quickActionsLink:focus-visible {
+.focusBadge {
+  align-self: flex-start;
+  padding: 4px 12px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-accent-soft);
   color: var(--ui-accent-strong);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
-.libraryHeader {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
+.focusCta {
+  margin-top: auto;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 6px;
+  font-weight: 600;
 }
 
-.libraryControls {
+.library {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  align-items: flex-end;
+  gap: 24px;
 }
 
-.searchControl {
+.searchForm {
   display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+}
+
+.searchInput {
+  flex: 1 1 220px;
+  min-width: 220px;
+  padding: 0.65rem 1rem;
   border-radius: var(--ui-radius-pill);
   border: 1px solid var(--ui-border);
   background: var(--ui-surface);
 }
 
-.searchControl input {
-  border: none;
-  background: transparent;
-  font-size: 0.95rem;
-  outline: none;
-  min-width: 220px;
+.searchButton {
+  padding: 0.65rem 1.4rem;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid transparent;
+  background: var(--ui-accent);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.searchButton:hover,
+.searchButton:focus-visible {
+  background: var(--ui-accent-strong);
+}
+
+.filterRow {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
 .filterGroup {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  align-items: flex-end;
 }
 
-.sortSelect {
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid var(--ui-border);
-  padding: 8px 14px;
-  background: var(--ui-surface);
-  color: var(--ui-text-secondary);
-  font-weight: 600;
-}
-
-.filterButtons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: flex-end;
-}
-
-.filterButton {
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid var(--ui-border);
-  background: transparent;
-  color: var(--ui-text-secondary);
-  font-weight: 600;
-  padding: 10px 18px;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
-}
-
-.filterButton[data-active='true'] {
-  background: var(--ui-highlight);
-  color: var(--ui-text-inverse);
-  border-color: transparent;
-  box-shadow: 0 16px 45px -28px rgba(79, 70, 229, 0.55);
-}
-
-.collectionFilters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: flex-end;
-  margin-top: 4px;
-}
-
-.collectionButton {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
-  min-width: 160px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-  color: var(--ui-text-secondary);
-  font-weight: 600;
-  padding: 12px 16px;
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, background-color 0.2s ease;
-}
-
-.collectionButton[data-active='true'] {
-  background: var(--ui-accent-soft);
-  color: var(--ui-accent-strong);
-  border-color: transparent;
-  box-shadow: 0 16px 45px -28px rgba(79, 70, 229, 0.55);
-}
-
-.collectionButton[data-active='true'] .collectionCount {
-  color: var(--ui-accent-strong);
-}
-
-.collectionButton:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  box-shadow: none;
-  background: var(--ui-surface-muted);
-  color: var(--ui-text-muted);
-}
-
-.collectionLabel {
-  font-weight: 700;
-}
-
-.collectionCount {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  color: var(--ui-text-muted);
-}
-
-.lessonGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 20px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface-strong);
-}
-
-.groupHeader {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.groupTitle {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.groupDescription {
-  margin: 6px 0 0;
-  color: var(--ui-text-secondary);
-}
-
-.groupCount {
-  border-radius: var(--ui-radius-pill);
-  padding: 8px 18px;
-  background: var(--ui-surface-muted);
-  border: 1px solid var(--ui-border);
-  font-size: 0.75rem;
+.filterLabel {
+  font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  font-weight: 700;
+  color: var(--ui-text-secondary);
 }
 
-.lessonGrid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.lessonCard {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 18px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid var(--ui-border);
-  background: var(--ui-surface);
-  text-decoration: none;
-  box-shadow: var(--ui-shadow);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.lessonCard:hover,
-.lessonCard:focus-visible {
-  transform: translateY(-3px);
-  border-color: var(--ui-accent);
-  box-shadow: var(--ui-shadow-strong);
-}
-
-.lessonMeta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-weight: 700;
-  color: var(--ui-text-muted);
-}
-
-.lessonTitle {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--ui-text-primary);
-}
-
-.lessonTags {
+.pillGroup {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.lessonTag {
-  display: inline-flex;
+.pill {
+  padding: 0.45rem 1.1rem;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pillActive {
+  border-color: var(--ui-accent);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+}
+
+.collectionScroller {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.collectionCard {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.collectionCard:hover,
+.collectionCard:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--ui-accent);
+  box-shadow: var(--ui-shadow);
+}
+
+.collectionCardActive {
+  border-color: var(--ui-accent);
+  background: var(--ui-accent-soft);
+}
+
+.collectionLabel {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.collectionCount {
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.activeFilters {
+  display: flex;
   align-items: center;
-  padding: 6px 12px;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--ui-accent-strong);
+  font-weight: 600;
+}
+
+.clearFilters {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.lessonGrid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.lessonCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-strong);
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--ui-shadow);
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.lessonCard:hover,
+.lessonCard:focus-visible {
+  transform: translateY(-4px);
+  border-color: var(--ui-accent);
+  box-shadow: var(--ui-shadow-strong);
+}
+
+.lessonHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.lessonLevel {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ui-text-secondary);
+}
+
+.lessonBadge {
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.lessonTitle {
+  margin: 0;
+  font-size: 1.2rem;
+  font-family: var(--ui-font-display);
+  letter-spacing: -0.01em;
+}
+
+.lessonMeta {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--ui-text-secondary);
+}
+
+.lessonTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.lessonTag {
+  padding: 4px 10px;
   border-radius: var(--ui-radius-pill);
   background: rgba(148, 163, 184, 0.2);
-  color: var(--ui-text-secondary);
   font-size: 0.8rem;
   font-weight: 600;
 }
 
 .lessonFooter {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  font-size: 0.85rem;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
   color: var(--ui-text-secondary);
+  font-size: 0.9rem;
 }
 
-.lessonRecommendation {
+.lessonCta {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  background: var(--ui-accent-soft);
-  color: var(--ui-accent-strong);
-  font-weight: 600;
-}
-
-.lessonLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--ui-accent-strong);
   font-weight: 600;
 }
 
 .emptyState {
-  border: 1px dashed var(--ui-border);
-  padding: 18px;
-  border-radius: var(--ui-radius-lg);
-  background: rgba(15, 23, 42, 0.03);
+  margin: 0;
   color: var(--ui-text-secondary);
 }
 
-.topicsCloud {
+.inspiration {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 12px;
+  flex-direction: column;
+  gap: 20px;
 }
 
-.topicTag {
-  display: inline-flex;
+.wheelActions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+}
+
+.spinButton {
+  padding: 0.6rem 1.4rem;
   border-radius: var(--ui-radius-pill);
-  border: 1px solid rgba(14, 165, 233, 0.35);
-  background: rgba(14, 165, 233, 0.12);
-  color: #0e7490;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #f97316, #fb7185);
+  color: white;
   font-weight: 600;
   cursor: pointer;
 }
 
-.topicTag:hover,
-.topicTag:focus-visible {
-  border-color: var(--ui-accent);
-  color: var(--ui-accent-strong);
+.spinButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.spinButton:not(:disabled):hover,
+.spinButton:not(:disabled):focus-visible {
+  background: linear-gradient(135deg, #fb7185, #facc15);
+}
+
+.themeSpotlight {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  font-weight: 600;
+}
+
+.themeLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--ui-text-secondary);
+}
+
+.themeValue {
+  font-family: var(--ui-font-display);
+  font-size: 1.1rem;
+}
+
+.themeCount {
+  color: var(--ui-text-secondary);
+}
+
+.themeGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.topicTag {
+  padding: 0.5rem 1.1rem;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
 }
 
 .topicTagActive {
@@ -493,70 +549,29 @@
 }
 
 .topicCount {
-  display: inline-block;
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(14, 165, 233, 0.22);
-  font-size: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
 }
 
-@media (max-width: 1100px) {
-  .hero {
-    grid-template-columns: minmax(0, 1fr);
+@media (max-width: 768px) {
+  .timelineTitle {
+    font-size: 2rem;
   }
 
-  .heroStats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .timelineStats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
-}
 
-@media (max-width: 900px) {
-  .libraryControls {
-    width: 100%;
+  .searchForm {
+    flex-direction: column;
     align-items: stretch;
   }
 
-  .searchControl {
+  .searchInput {
     width: 100%;
   }
 
-  .searchControl input {
-    min-width: 0;
-    flex: 1;
-  }
-
-  .filterGroup {
-    align-items: stretch;
-  }
-
-  .filterButtons {
-    justify-content: flex-start;
-  }
-
-  .collectionFilters {
-    justify-content: flex-start;
-    width: 100%;
-  }
-
-  .collectionButton {
-    flex: 1 1 160px;
-  }
-}
-
-@media (max-width: 720px) {
-  .heroTitle {
-    font-size: 2.1rem;
-  }
-
-  .heroStats {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .focusGrid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .lessonGrid {
-    grid-template-columns: minmax(0, 1fr);
+  .collectionScroller {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import React, { FormEvent, useEffect, useMemo, useState } from 'react';
+import { Link, To, useSearchParams } from 'react-router-dom';
 import { liveQuery } from 'dexie';
 import { db } from '../db';
 import { Lesson } from '../lib/schemas';
@@ -26,9 +26,6 @@ interface LessonLibraryItem {
   recommendation?: string;
   recommendationPriority?: number;
 }
-
-const compareLessonsByTitle = (a: LessonLibraryItem, b: LessonLibraryItem) =>
-  a.lesson.title.localeCompare(b.lesson.title, undefined, { numeric: true, sensitivity: 'base' });
 
 interface RecommendationCard {
   lessonId: string;
@@ -66,15 +63,6 @@ const levelCopy: Record<string, { title: string; description: string }> = {
 };
 
 const levelOrder = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
-
-type SortOrder = 'recommended' | 'recent' | 'alphabetical' | 'mastery';
-
-const sortOptions: { value: SortOrder; label: string }[] = [
-  { value: 'recommended', label: 'Recommended first' },
-  { value: 'recent', label: 'Recently studied' },
-  { value: 'alphabetical', label: 'A → Z' },
-  { value: 'mastery', label: 'Lowest mastery' },
-];
 
 type CollectionMatcher = (lesson: Lesson) => boolean;
 
@@ -142,6 +130,20 @@ const collectionOptions: CollectionOption[] = [
   },
 ];
 
+const deckLabel = (deck: string) => {
+  switch (deck) {
+    case 'verbs':
+      return 'Verb drills';
+    case 'vocab':
+      return 'Vocabulary';
+    case 'presentations':
+      return 'Presentation phrases';
+    case 'grammar':
+    default:
+      return 'Grammar focus';
+  }
+};
+
 const formatRelativeTime = (value?: string) => {
   if (!value) return 'Unseen';
   const date = new Date(value);
@@ -163,36 +165,6 @@ const formatRelativeTime = (value?: string) => {
   return date.toLocaleDateString();
 };
 
-interface QuickShortcut {
-  label: string;
-  description: string;
-  to?: string;
-  href?: string;
-}
-
-const quickShortcuts: QuickShortcut[] = [
-  {
-    label: 'Browse lessons',
-    description: 'Jump straight to the full library view.',
-    href: '#lesson-library',
-  },
-  {
-    label: 'Review dashboard',
-    description: 'Check streaks and mastery trends.',
-    to: '/dashboard',
-  },
-  {
-    label: 'Flashcard trainer',
-    description: 'Clear today’s review queue.',
-    to: '/flashcards',
-  },
-  {
-    label: 'Content manager',
-    description: 'Sync the latest lessons to your device.',
-    to: '/content-manager',
-  },
-];
-
 export const HomePage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [items, setItems] = useState<LessonLibraryItem[]>([]);
@@ -207,17 +179,15 @@ export const HomePage: React.FC = () => {
   });
   const [levelFilter, setLevelFilter] = useState<string>(searchParams.get('level') ?? 'all');
   const [searchTerm, setSearchTerm] = useState(searchParams.get('q') ?? '');
-  const [sortOrder, setSortOrder] = useState<SortOrder>(
-    (searchParams.get('sort') as SortOrder) ?? 'recommended'
-  );
   const [tagFilter, setTagFilter] = useState<string>(searchParams.get('tag') ?? 'all');
-  const [collectionFilter, setCollectionFilter] = useState<string>(
-    searchParams.get('collection') ?? 'all'
-  );
+  const [collectionFilter, setCollectionFilter] = useState<string>(searchParams.get('collection') ?? 'all');
   const [topTags, setTopTags] = useState<[string, number][]>([]);
   const [levelOptions, setLevelOptions] = useState<string[]>([]);
   const [recommendations, setRecommendations] = useState<RecommendationCard[]>([]);
   const [deckDue, setDeckDue] = useState<{ deck: string; due: number; status: string }[]>([]);
+  const [weakestTag, setWeakestTag] = useState<{ tag: string; accuracy: number } | undefined>();
+  const [lastStudiedOn, setLastStudiedOn] = useState<string | undefined>();
+  const [inspirationTag, setInspirationTag] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -237,9 +207,7 @@ export const HomePage: React.FC = () => {
           return acc;
         }, {});
         const masteryMap = new Map(analytics.lessonMastery.map((entry) => [entry.lessonId, entry]));
-        const recommendationMap = new Map(
-          analytics.studyPlan.map((entry) => [entry.lessonId, entry])
-        );
+        const recommendationMap = new Map(analytics.studyPlan.map((entry) => [entry.lessonId, entry]));
 
         const derivedItems: LessonLibraryItem[] = lessonItems.map((lesson) => {
           const mastery = masteryMap.get(lesson.id);
@@ -317,6 +285,11 @@ export const HomePage: React.FC = () => {
           }))
         );
         setDeckDue(dueDecks);
+        setWeakestTag(
+          analytics.weakestTags[0]
+            ? { tag: analytics.weakestTags[0].tag, accuracy: analytics.weakestTags[0].accuracy }
+            : undefined
+        );
         setStats({
           totalLessons: lessonItems.length,
           totalExercises,
@@ -325,6 +298,7 @@ export const HomePage: React.FC = () => {
           streak: analytics.streak.current,
           bestStreak: analytics.streak.best,
         });
+        setLastStudiedOn(analytics.streak.lastStudiedOn);
         setLoading(false);
       },
       error: (error) => {
@@ -338,16 +312,33 @@ export const HomePage: React.FC = () => {
   useEffect(() => {
     setLevelFilter(searchParams.get('level') ?? 'all');
     setSearchTerm(searchParams.get('q') ?? '');
-    setSortOrder((searchParams.get('sort') as SortOrder) ?? 'recommended');
     setTagFilter(searchParams.get('tag') ?? 'all');
     setCollectionFilter(searchParams.get('collection') ?? 'all');
   }, [searchParams]);
+
+  useEffect(() => {
+    if (tagFilter !== 'all') {
+      setInspirationTag(tagFilter);
+    }
+  }, [tagFilter]);
+
+  useEffect(() => {
+    if (!inspirationTag && topTags[0]) {
+      setInspirationTag(topTags[0][0]);
+    }
+  }, [topTags, inspirationTag]);
 
   const updateParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(searchParams);
     if (!value) next.delete(key);
     else next.set(key, value);
     setSearchParams(next, { replace: true });
+  };
+
+  const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = searchTerm.trim();
+    updateParam('q', trimmed ? trimmed : null);
   };
 
   const collectionCounts = useMemo(() => {
@@ -381,22 +372,6 @@ export const HomePage: React.FC = () => {
         return true;
       })
       .sort((a, b) => {
-        if (sortOrder === 'alphabetical') {
-          return compareLessonsByTitle(a, b);
-        }
-        if (sortOrder === 'mastery') {
-          const accuracyDiff = a.accuracy - b.accuracy;
-          if (accuracyDiff !== 0) return accuracyDiff;
-          return compareLessonsByTitle(a, b);
-        }
-        if (sortOrder === 'recent') {
-          const aTime = a.lastAttemptAt ? new Date(a.lastAttemptAt).getTime() : 0;
-          const bTime = b.lastAttemptAt ? new Date(b.lastAttemptAt).getTime() : 0;
-          const recentDiff = bTime - aTime;
-          if (recentDiff !== 0) return recentDiff;
-          return compareLessonsByTitle(a, b);
-        }
-        // recommended
         const aPriority = a.recommendationPriority ?? Number.POSITIVE_INFINITY;
         const bPriority = b.recommendationPriority ?? Number.POSITIVE_INFINITY;
         if (aPriority !== bPriority) return aPriority - bPriority;
@@ -405,243 +380,275 @@ export const HomePage: React.FC = () => {
         if (aReason !== bReason) return aReason - bReason;
         const aTime = a.lastAttemptAt ? new Date(a.lastAttemptAt).getTime() : 0;
         const bTime = b.lastAttemptAt ? new Date(b.lastAttemptAt).getTime() : 0;
-        const recommendedDiff = bTime - aTime;
-        if (recommendedDiff !== 0) return recommendedDiff;
-        return compareLessonsByTitle(a, b);
+        const recentDiff = bTime - aTime;
+        if (recentDiff !== 0) return recentDiff;
+        return a.lesson.title.localeCompare(b.lesson.title, undefined, { numeric: true, sensitivity: 'base' });
       });
-  }, [items, levelFilter, tagFilter, searchTerm, sortOrder, activeCollection]);
+  }, [items, levelFilter, tagFilter, searchTerm, activeCollection]);
 
-  const levelGroups = useMemo(() => {
-    const grouped = new Map<string, LessonLibraryItem[]>();
-    filteredLessons.forEach((item) => {
-      const list = grouped.get(item.lesson.level) ?? [];
-      list.push(item);
-      grouped.set(item.lesson.level, list);
-    });
-    const order = levelFilter === 'all' ? levelOptions : [levelFilter];
-    return order.map((level) => ({
-      level,
-      lessons: grouped.get(level) ?? [],
-    }));
-  }, [filteredLessons, levelFilter, levelOptions]);
+  const plannerAnchor: To = { pathname: '/', hash: '#lesson-library' };
 
-  const roundedProgress = Math.round(stats.progress);
   const primaryRecommendation = recommendations[0];
-  const secondaryRecommendations = recommendations.slice(1, 3);
   const primaryDeck = deckDue[0];
-  const secondaryDecks = deckDue.slice(1, 3);
+  const focusBlocks = useMemo(
+    () => [
+      {
+        id: 'lesson',
+        label: 'Deep dive lesson',
+        title: primaryRecommendation ? primaryRecommendation.title : 'Choose a lesson that excites you',
+        description: primaryRecommendation
+          ? primaryRecommendation.reason
+          : 'Browse the library to build a focus block for today.',
+        to: primaryRecommendation?.lessonSlug ? `/lessons/${primaryRecommendation.lessonSlug}` : plannerAnchor,
+        icon: '📘',
+        badge: primaryRecommendation ? 'Recommended' : undefined,
+      },
+      {
+        id: 'review',
+        label: 'Flashcard sprint',
+        title: primaryDeck ? `${deckLabel(primaryDeck.deck)} deck` : 'Flashcards',
+        description: primaryDeck
+          ? `${primaryDeck.due} card${primaryDeck.due === 1 ? '' : 's'} ready · ${primaryDeck.status}`
+          : stats.dueCards > 0
+          ? `${stats.dueCards} card${stats.dueCards === 1 ? '' : 's'} waiting across decks.`
+          : 'No cards due — run a freestyle warm-up to stay sharp.',
+        to: '/flashcards',
+        icon: '⚡️',
+        badge: stats.dueCards > 0 ? `${stats.dueCards} due` : undefined,
+      },
+      {
+        id: 'skill',
+        label: 'Skill spotlight',
+        title: weakestTag ? weakestTag.tag : 'Pick a theme',
+        description: weakestTag
+          ? `Accuracy ${Math.round(weakestTag.accuracy)}% — boost this focus area with a review.`
+          : 'Complete a lesson to surface the skill that needs attention.',
+        to: weakestTag ? `/dashboard?focus=${encodeURIComponent(weakestTag.tag)}` : '/dashboard',
+        icon: '🎯',
+        badge: weakestTag ? 'Needs love' : undefined,
+      },
+    ],
+    [plannerAnchor, primaryDeck, primaryRecommendation, stats.dueCards, weakestTag]
+  );
+
+  const timelineCards = useMemo(
+    () => [
+      {
+        id: 'yesterday',
+        label: 'Yesterday',
+        title: stats.streak > 0 ? `Streak day ${stats.streak}` : 'Restart your streak',
+        description: lastStudiedOn
+          ? `Last session ${formatRelativeTime(lastStudiedOn)}`
+          : 'No activity logged yet — today is a great day to begin.',
+        to: stats.streak > 0 ? '/dashboard' : plannerAnchor,
+        action: stats.streak > 0 ? 'View insights' : 'Plan a session',
+      },
+      {
+        id: 'today',
+        label: 'Today',
+        title: primaryRecommendation ? primaryRecommendation.title : 'Choose your focus',
+        description: primaryRecommendation
+          ? primaryRecommendation.reason
+          : 'Pick a focus block below to jump into practice.',
+        to: primaryRecommendation?.lessonSlug ? `/lessons/${primaryRecommendation.lessonSlug}` : plannerAnchor,
+        action: primaryRecommendation ? 'Resume lesson' : 'Browse lessons',
+      },
+      {
+        id: 'tomorrow',
+        label: 'Tomorrow',
+        title: primaryDeck ? `${deckLabel(primaryDeck.deck)} deck` : 'Schedule a review',
+        description: primaryDeck
+          ? `${primaryDeck.due} due · ${primaryDeck.status}`
+          : 'Stay ahead by pencilling in a short flashcard sprint.',
+        to: '/flashcards',
+        action: 'Open flashcards',
+      },
+    ],
+    [plannerAnchor, primaryDeck, primaryRecommendation, stats.streak, lastStudiedOn]
+  );
+
+  const hasActiveFilters =
+    levelFilter !== 'all' ||
+    tagFilter !== 'all' ||
+    collectionFilter !== 'all' ||
+    Boolean(searchTerm.trim());
+
+  const handleClearFilters = () => {
+    setLevelFilter('all');
+    setTagFilter('all');
+    setCollectionFilter('all');
+    setSearchTerm('');
+    setSearchParams(new URLSearchParams(), { replace: true });
+  };
+
+  const activeTheme = tagFilter !== 'all' ? tagFilter : inspirationTag ?? topTags[0]?.[0];
+  const activeThemeCount = activeTheme
+    ? topTags.find(([tag]) => tag === activeTheme)?.[1]
+    : undefined;
+
+  const handleSpinTheme = () => {
+    if (topTags.length === 0) return;
+    const random = topTags[Math.floor(Math.random() * topTags.length)][0];
+    setInspirationTag(random);
+    updateParam('tag', random);
+  };
+
+  const handleThemeClick = (tag: string) => {
+    if (tagFilter === tag) {
+      updateParam('tag', null);
+    } else {
+      updateParam('tag', tag);
+    }
+  };
+
+  const activeLevelCopy = levelFilter === 'all' ? null : levelCopy[levelFilter];
 
   return (
-    <div className={styles.page} aria-labelledby="home-heading">
-      <section className={`ui-card ui-card--accent ${styles.hero}`} aria-labelledby="home-heading">
-        <div className={styles.heroContent}>
-          <h1 id="home-heading" className={styles.heroTitle}>
-            Plan your next Spanish session
+    <div className={styles.page} aria-labelledby="planner-heading">
+      <section className={`ui-card ui-card--accent ${styles.timeline}`} aria-labelledby="planner-heading">
+        <div className={styles.timelineIntro}>
+          <p className={styles.sectionTag}>Planner</p>
+          <h1 id="planner-heading" className={styles.timelineTitle}>
+            Plan your next Spanish win
           </h1>
-          <p className={styles.heroDescription} aria-live="polite">
-            Keep tabs on progress and jump back into focused study in just a few clicks.
-          </p>
-          <div className={styles.heroActions}>
-            <a href="#lesson-library" className="ui-button ui-button--primary">
-              Browse lesson library ↗
-            </a>
-            <Link to="/dashboard" className="ui-button ui-button--ghost">
-              Review dashboard →
-            </Link>
-          </div>
-          <p className={styles.heroNote} aria-live="polite">
-            Streak {stats.streak} day{stats.streak === 1 ? '' : 's'} · Best {stats.bestStreak}
+          <p className={styles.timelineSubtitle}>
+            A calm place to see progress and jump into the next best action.
           </p>
         </div>
-        <dl className={styles.heroStats} aria-label="Key progress stats">
-          <div className={styles.heroStatsItem} title="Total lessons currently available in your offline library">
-            <dt>Lessons imported</dt>
-            <dd aria-live="polite">{stats.totalLessons}</dd>
+        <div className={styles.timelineStats} aria-label="Key progress stats">
+          <div className={styles.timelineStat}>
+            <span className={styles.timelineStatLabel}>Lessons imported</span>
+            <span className={styles.timelineStatValue}>{stats.totalLessons}</span>
           </div>
-          <div className={styles.heroStatsItem} title="Percentage of exercises where the latest attempt was correct">
-            <dt>Mastery progress</dt>
-            <dd aria-live="polite">{roundedProgress}%</dd>
+          <div className={styles.timelineStat}>
+            <span className={styles.timelineStatLabel}>Mastery progress</span>
+            <span className={styles.timelineStatValue}>{Math.round(stats.progress)}%</span>
           </div>
-          <div className={styles.heroStatsItem} title="Cards currently ready for review">
-            <dt>Due flashcards</dt>
-            <dd aria-live="polite">{stats.dueCards}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section className="ui-card" aria-labelledby="overview-heading">
-        <div className="ui-section">
-          <div>
-            <p className="ui-section__tag">Today</p>
-            <h2 id="overview-heading" className="ui-section__title">
-              Focus for this session
-            </h2>
-            <p className="ui-section__subtitle">
-              Start with the highlighted lesson or clear your review queue.
-            </p>
+          <div className={styles.timelineStat}>
+            <span className={styles.timelineStatLabel}>Flashcards due</span>
+            <span className={styles.timelineStatValue}>{stats.dueCards}</span>
           </div>
         </div>
-        <div className={styles.nextGrid}>
-          <article className={styles.nextCard}>
-            <h3>Recommended lesson</h3>
-            {primaryRecommendation ? (
-              <>
-                <Link
-                  to={
-                    primaryRecommendation.lessonSlug
-                      ? `/lessons/${primaryRecommendation.lessonSlug}`
-                      : '#'
-                  }
-                  className={styles.nextLink}
-                >
-                  <span className={styles.nextTitle}>{primaryRecommendation.title}</span>
-                  <span className={styles.nextMeta}>{primaryRecommendation.reason}</span>
-                </Link>
-                {secondaryRecommendations.length > 0 && (
-                  <ul className={styles.nextList}>
-                    {secondaryRecommendations.map((item) => (
-                      <li key={item.lessonId}>
-                        <Link
-                          to={item.lessonSlug ? `/lessons/${item.lessonSlug}` : '#'}
-                          className={styles.nextListLink}
-                        >
-                          {item.title}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </>
-            ) : (
-              <p className={styles.nextEmpty}>Recommendations appear once you complete a lesson.</p>
-            )}
-          </article>
-          <article className={styles.nextCard}>
-            <h3>Review queue</h3>
-            {primaryDeck ? (
-              <>
-                <p className={styles.nextTitle}>{primaryDeck.deck}</p>
-                <p className={styles.nextMeta}>
-                  {primaryDeck.due} card{primaryDeck.due === 1 ? '' : 's'} due
-                </p>
-                <p className={styles.nextHint}>{primaryDeck.status}</p>
-                {secondaryDecks.length > 0 && (
-                  <ul className={styles.nextList}>
-                    {secondaryDecks.map((entry) => (
-                      <li key={entry.deck}>
-                        {entry.deck} · {entry.due} due
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </>
-            ) : (
-              <p className={styles.nextEmpty}>You're all caught up on reviews.</p>
-            )}
-          </article>
-          <div className={styles.quickActions}>
-            <h3>Shortcuts</h3>
-            <ul className={styles.quickActionsList}>
-              {quickShortcuts.map((shortcut) => {
-                const ActionComponent = (shortcut.to ? Link : 'a') as React.ElementType;
-                const actionProps = shortcut.to ? { to: shortcut.to } : { href: shortcut.href ?? '#' };
-                return (
-                  <li key={shortcut.label}>
-                    <ActionComponent className={styles.quickActionsLink} {...actionProps}>
-                      <span>{shortcut.label}</span>
-                      <span>{shortcut.description}</span>
-                    </ActionComponent>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+        <div className={styles.timelineCards} role="list">
+          {timelineCards.map((card) => (
+            <article key={card.id} className={styles.timelineCard} role="listitem">
+              <span className={styles.timelineCardLabel}>{card.label}</span>
+              <h2 className={styles.timelineCardTitle}>{card.title}</h2>
+              <p className={styles.timelineCardDescription}>{card.description}</p>
+              <Link to={card.to} className={styles.timelineCardAction}>
+                {card.action} <span aria-hidden="true">→</span>
+              </Link>
+            </article>
+          ))}
         </div>
+        <p className={styles.timelineFootnote} aria-live="polite">
+          Current streak {stats.streak} day{stats.streak === 1 ? '' : 's'} · Best {stats.bestStreak}
+        </p>
       </section>
 
-      <section id="lesson-library" className="ui-card" aria-labelledby="library-heading">
-        <div className={styles.libraryHeader}>
+      <section className={`ui-card ${styles.focusSection}`} aria-labelledby="focus-heading">
+        <header className={styles.sectionHeader}>
           <div>
-            <p className="ui-section__tag">Lesson library</p>
-            <h2 id="library-heading" className="ui-section__title">
-              Browse your lessons
+            <p className={styles.sectionTag}>Focus blocks</p>
+            <h2 id="focus-heading" className={styles.sectionTitle}>
+              Start with one quick win
             </h2>
-            <p className="ui-section__subtitle">
-              Filter by level, tags, and mastery data to line up the right objective.
+            <p className={styles.sectionSubtitle}>
+              These cards adapt as you complete lessons, reviews, and drills.
             </p>
           </div>
-          <div className={styles.libraryControls}>
-            <div className={styles.searchControl}>
-              <label htmlFor="library-search" className="sr-only">
-                Search lessons
-              </label>
-              <input
-                id="library-search"
-                type="search"
-                value={searchTerm}
-                onChange={(event) => updateParam('q', event.target.value || null)}
-                placeholder="Search titles or tags…"
-              />
-            </div>
-            <div className={styles.filterGroup}>
-              <label htmlFor="sort-order" className="sr-only">
-                Sort order
-              </label>
-              <select
-                id="sort-order"
-                value={sortOrder}
-                onChange={(event) => updateParam('sort', event.target.value as SortOrder)}
-                className={styles.sortSelect}
-              >
-                {sortOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              <div className={styles.filterButtons}>
-                <button
-                  type="button"
-                  onClick={() => updateParam('level', 'all')}
-                  className={styles.filterButton}
-                  data-active={levelFilter === 'all'}
-                >
-                  All levels
-                </button>
-                {levelOptions.map((level) => (
-                  <button
-                    key={level}
-                    type="button"
-                    onClick={() => updateParam('level', level)}
-                    className={styles.filterButton}
-                    data-active={levelFilter === level}
-                  >
-                    Level {level}
-                  </button>
-                ))}
+        </header>
+        <div className={styles.focusGrid} role="list">
+          {focusBlocks.map((block) => (
+            <Link key={block.id} to={block.to} className={styles.focusCard} role="listitem">
+              <span className={styles.focusLabel}>{block.label}</span>
+              <div className={styles.focusTitleRow}>
+                <span className={styles.focusIcon} aria-hidden="true">
+                  {block.icon}
+                </span>
+                <h3 className={styles.focusTitle}>{block.title}</h3>
               </div>
+              <p className={styles.focusDescription}>{block.description}</p>
+              {block.badge && <span className={styles.focusBadge}>{block.badge}</span>}
+              <span className={styles.focusCta}>
+                Open {block.label.toLowerCase()} <span aria-hidden="true">→</span>
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="lesson-library"
+        className={`ui-card ${styles.library}`}
+        aria-labelledby="library-heading"
+      >
+        <header className={styles.sectionHeader}>
+          <div>
+            <p className={styles.sectionTag}>Lesson library</p>
+            <h2 id="library-heading" className={styles.sectionTitle}>
+              Build your study lane
+            </h2>
+            <p className={styles.sectionSubtitle}>
+              {activeLevelCopy?.description ?? 'Filter by level, collection, or theme to personalise your plan.'}
+            </p>
+          </div>
+          <form className={styles.searchForm} role="search" onSubmit={handleSearchSubmit}>
+            <label htmlFor="lesson-search" className="sr-only">
+              Search lessons
+            </label>
+            <input
+              id="lesson-search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search titles or tags"
+              className={styles.searchInput}
+              type="search"
+            />
+            <button type="submit" className={styles.searchButton}>
+              Search
+            </button>
+          </form>
+        </header>
+
+        <div className={styles.filterRow}>
+          <div className={styles.filterGroup}>
+            <span className={styles.filterLabel}>Level</span>
+            <div className={styles.pillGroup}>
+              <button
+                type="button"
+                className={`${styles.pill} ${levelFilter === 'all' ? styles.pillActive : ''}`}
+                onClick={() => updateParam('level', null)}
+              >
+                All levels
+              </button>
+              {levelOptions.map((level) => (
+                <button
+                  key={level}
+                  type="button"
+                  className={`${styles.pill} ${levelFilter === level ? styles.pillActive : ''}`}
+                  onClick={() => updateParam('level', level)}
+                >
+                  {level}
+                </button>
+              ))}
             </div>
-            <div
-              className={styles.collectionFilters}
-              role="group"
-              aria-label="Browse lesson collections"
-            >
+          </div>
+          <div className={styles.filterGroup}>
+            <span className={styles.filterLabel}>Curated tracks</span>
+            <div className={styles.collectionScroller}>
               {collectionOptions.map((option) => {
                 const count = collectionCounts[option.value] ?? 0;
                 const isActive = collectionFilter === option.value;
-                const disableOption = option.value !== 'all' && !count;
                 return (
                   <button
                     key={option.value}
                     type="button"
-                    className={styles.collectionButton}
-                    data-active={isActive}
-                    aria-pressed={isActive}
-                    title={option.description}
+                    className={`${styles.collectionCard} ${isActive ? styles.collectionCardActive : ''}`}
                     onClick={() =>
-                      updateParam('collection', option.value === 'all' ? null : option.value)
+                      isActive ? updateParam('collection', null) : updateParam('collection', option.value)
                     }
-                    disabled={disableOption}
+                    title={option.description}
                   >
                     <span className={styles.collectionLabel}>{option.label}</span>
                     <span className={styles.collectionCount}>
@@ -653,6 +660,16 @@ export const HomePage: React.FC = () => {
             </div>
           </div>
         </div>
+
+        {hasActiveFilters && (
+          <div className={styles.activeFilters}>
+            <span>Filters applied.</span>
+            <button type="button" onClick={handleClearFilters} className={styles.clearFilters}>
+              Clear all
+            </button>
+          </div>
+        )}
+
         {loading ? (
           <p className={styles.emptyState} aria-live="polite">
             Loading library…
@@ -661,104 +678,109 @@ export const HomePage: React.FC = () => {
           <p className={styles.emptyState} aria-live="polite">
             No lessons imported yet. Use the Content manager to add the latest content drop.
           </p>
+        ) : filteredLessons.length === 0 ? (
+          <p className={styles.emptyState} aria-live="polite">
+            No lessons match your filters. Try adjusting the level, collection, or search term.
+          </p>
         ) : (
-          levelGroups.map(({ level, lessons: groupLessons }) => {
-            const copy = levelCopy[level] ?? {
-              title: `Level ${level}`,
-              description: 'Build a customised progression even if this is a custom level.',
-            };
-            return (
-              <article key={level} className={styles.lessonGroup}>
-                <header className={styles.groupHeader}>
-                  <div>
-                    <h3 className={styles.groupTitle}>{copy.title}</h3>
-                    <p className={styles.groupDescription}>{copy.description}</p>
+          <div className={styles.lessonGrid}>
+            {filteredLessons.map((item) => {
+              const { lesson } = item;
+              const masteryPercent = item.exerciseCount
+                ? Math.round((item.masteredCount / item.exerciseCount) * 100)
+                : 0;
+              return (
+                <Link key={lesson.id} to={`/lessons/${lesson.slug}`} className={styles.lessonCard}>
+                  <div className={styles.lessonHeader}>
+                    <span className={styles.lessonLevel}>Level {lesson.level}</span>
+                    {item.recommendation && <span className={styles.lessonBadge}>Suggested</span>}
                   </div>
-                  <span className={styles.groupCount}>
-                    {groupLessons.length} lesson{groupLessons.length === 1 ? '' : 's'}
-                  </span>
-                </header>
-                {groupLessons.length > 0 ? (
-                  <div className={styles.lessonGrid}>
-                    {groupLessons.map((item) => {
-                      const { lesson } = item;
-                      const masteryPercent = item.exerciseCount
-                        ? Math.round((item.masteredCount / item.exerciseCount) * 100)
-                        : 0;
-                      return (
-                        <Link
-                          key={lesson.id}
-                          to={`/lessons/${lesson.slug}`}
-                          className={styles.lessonCard}
-                        >
-                          <div className={styles.lessonMeta}>
-                            <span>Level {lesson.level}</span>
-                            <span>
-                              {item.exerciseCount} practice {item.exerciseCount === 1 ? 'item' : 'items'}
-                            </span>
-                          </div>
-                          <div>
-                            <h4 className={styles.lessonTitle}>{lesson.title}</h4>
-                            <div className={styles.lessonTags} aria-label={`Tags for ${lesson.title}`}>
-                              {lesson.tags.slice(0, 3).map((tag) => (
-                                <span key={tag} className={styles.lessonTag}>
-                                  {tag}
-                                </span>
-                              ))}
-                              {lesson.tags.length === 0 && <span className={styles.lessonTag}>No tags yet</span>}
-                              {lesson.tags.length > 3 && (
-                                <span className={styles.lessonTag}>+{lesson.tags.length - 3}</span>
-                              )}
-                            </div>
-                          </div>
-                          <div className={styles.lessonFooter}>
-                            <span>{masteryPercent}% mastered</span>
-                            <span>{formatRelativeTime(item.lastAttemptAt)}</span>
-                            {item.recommendation && (
-                              <span className={styles.lessonRecommendation}>{item.recommendation}</span>
-                            )}
-                          </div>
-                          <span className={styles.lessonLink}>Open lesson →</span>
-                        </Link>
-                      );
-                    })}
+                  <h3 className={styles.lessonTitle}>{lesson.title}</h3>
+                  <p className={styles.lessonMeta}>
+                    {item.exerciseCount} practice item{item.exerciseCount === 1 ? '' : 's'} · {masteryPercent}% mastered
+                  </p>
+                  <div className={styles.lessonTags} aria-label={`Tags for ${lesson.title}`}>
+                    {lesson.tags.length === 0 && <span className={styles.lessonTag}>No tags yet</span>}
+                    {lesson.tags.slice(0, 3).map((tag) => (
+                      <span key={tag} className={styles.lessonTag}>
+                        {tag}
+                      </span>
+                    ))}
+                    {lesson.tags.length > 3 && (
+                      <span className={styles.lessonTag}>+{lesson.tags.length - 3}</span>
+                    )}
                   </div>
-                ) : (
-                  <p className={styles.emptyState}>No lessons imported for this level yet.</p>
-                )}
-              </article>
-            );
-          })
+                  <div className={styles.lessonFooter}>
+                    <span>{formatRelativeTime(item.lastAttemptAt)}</span>
+                    <span className={styles.lessonCta}>
+                      Open lesson <span aria-hidden="true">→</span>
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
         )}
       </section>
 
-      <section className="ui-card" aria-labelledby="tag-heading">
-        <div className="ui-section">
+      <section className={`ui-card ${styles.inspiration}`} aria-labelledby="inspiration-heading">
+        <header className={styles.sectionHeader}>
           <div>
-            <p className="ui-section__tag">Topics on your radar</p>
-            <h2 id="tag-heading" className="ui-section__title">
-              Mix your sessions
+            <p className={styles.sectionTag}>Need variety?</p>
+            <h2 id="inspiration-heading" className={styles.sectionTitle}>
+              Spin a new theme
             </h2>
+            <p className={styles.sectionSubtitle}>
+              Switch things up with a quick prompt pulled from your library tags.
+            </p>
           </div>
-        </div>
-        {topTags.length > 0 ? (
-          <div className={styles.topicsCloud}>
-            {topTags.map(([tag, count]) => (
-              <button
-                key={tag}
-                type="button"
-                className={`${styles.topicTag} ${tagFilter === tag ? styles.topicTagActive : ''}`}
-                title={`${count} lesson${count === 1 ? '' : 's'}`}
-                onClick={() => updateParam('tag', tagFilter === tag ? null : tag)}
-              >
-                <span>{tag}</span>
-                <span className={styles.topicCount}>×{count}</span>
+          <div className={styles.wheelActions}>
+            <button
+              type="button"
+              className={styles.spinButton}
+              onClick={handleSpinTheme}
+              disabled={topTags.length === 0}
+            >
+              Spin theme
+            </button>
+            {tagFilter !== 'all' && (
+              <button type="button" className={styles.clearFilters} onClick={() => updateParam('tag', null)}>
+                Clear theme
               </button>
-            ))}
+            )}
           </div>
+        </header>
+        {topTags.length > 0 ? (
+          <>
+            {activeTheme && (
+              <div className={styles.themeSpotlight} aria-live="polite">
+                <span className={styles.themeLabel}>Spotlight</span>
+                <strong className={styles.themeValue}>{activeTheme}</strong>
+                {typeof activeThemeCount === 'number' && (
+                  <span className={styles.themeCount}>
+                    {activeThemeCount} lesson{activeThemeCount === 1 ? '' : 's'}
+                  </span>
+                )}
+              </div>
+            )}
+            <div className={styles.themeGrid}>
+              {topTags.map(([tag, count]) => (
+                <button
+                  key={tag}
+                  type="button"
+                  className={`${styles.topicTag} ${tagFilter === tag ? styles.topicTagActive : ''}`}
+                  onClick={() => handleThemeClick(tag)}
+                  title={`${count} lesson${count === 1 ? '' : 's'}`}
+                >
+                  <span>{tag}</span>
+                  <span className={styles.topicCount}>×{count}</span>
+                </button>
+              ))}
+            </div>
+          </>
         ) : (
           <p className={styles.emptyState}>
-            Tags will appear once you import lessons.{" "}
+            Tags will appear once you import lessons.{' '}
             <Link to="/content-manager">Add a content bundle to get started.</Link>
           </p>
         )}


### PR DESCRIPTION
## Summary
- replace the side-rail shell with a streamlined top navigation, contextual command bar, and focus toggle that prioritise the next actions
- refresh the global shell styling to match the new warm "Spanish daylight" palette and responsive layout while keeping accessibility controls up front
- rebuild the planner home page into a narrative timeline, focus-block cards, simplified lesson filters, and a playful theme spinner for inspiration

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d070a4ea248324a91cca307075d017