### PR TITLE
Enhance planner scheduling and speaking practice

### DIFF
--- a/src/components/Dashboard.module.css
+++ b/src/components/Dashboard.module.css
@@ -156,6 +156,8 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  cursor: pointer;
+  text-align: left;
 }
 
 .srsLabel {
@@ -186,4 +188,58 @@
   color: #0e7490;
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.metricLink {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--ui-accent-strong);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.metricLink:hover,
+.metricLink:focus-visible {
+  text-decoration: none;
+}
+
+.weekPlan {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.weekPlanItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.weekPlanRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.weekPlanDay {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: var(--ui-text-secondary);
+}
+
+.weekPlanTitle {
+  font-weight: 600;
+}
+
+.weekPlanDescription {
+  margin: 0;
+  color: var(--ui-text-secondary);
+  font-size: 0.9rem;
 }

--- a/src/components/ExerciseEngine.module.css
+++ b/src/components/ExerciseEngine.module.css
@@ -190,3 +190,121 @@
   padding: 16px;
   color: var(--ui-text-secondary);
 }
+
+.speakingSection {
+  margin-top: 24px;
+  padding: 20px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  display: grid;
+  gap: 18px;
+}
+
+.speakingHeader {
+  display: grid;
+  gap: 6px;
+}
+
+.speakingSubtitle {
+  margin: 0;
+  color: var(--ui-text-secondary);
+  font-size: 0.95rem;
+}
+
+.speakingControls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.recordButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid transparent;
+  background: #dc2626;
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.recordButton[data-recording='true'] {
+  background: #991b1b;
+  box-shadow: 0 12px 24px -18px rgba(220, 38, 38, 0.8);
+}
+
+.recordButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.recordingStatus {
+  font-weight: 600;
+  color: #dc2626;
+}
+
+.recordingError {
+  margin: 0;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.previewBlock {
+  display: grid;
+  gap: 8px;
+}
+
+.previewLabel {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ui-text-secondary);
+}
+
+.audioPlayer {
+  width: 100%;
+}
+
+.historyBlock {
+  display: grid;
+  gap: 12px;
+}
+
+.historyTitle {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.historyList {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.historyItem {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-muted);
+}
+
+.historyMeta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+}
+
+.historyDownload {
+  font-weight: 600;
+  color: var(--ui-accent-strong);
+}

--- a/src/components/FlashcardTrainer.module.css
+++ b/src/components/FlashcardTrainer.module.css
@@ -91,6 +91,77 @@
   color: var(--ui-text-secondary);
 }
 
+.audioRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.audioButton {
+  border: 1px solid var(--ui-border-strong);
+  border-radius: var(--ui-radius-pill);
+  padding: 6px 14px;
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  color: white;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.audioButton[data-playing='true'] {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+.audioButton:hover,
+.audioButton:focus-visible {
+  transform: translateY(-1px);
+}
+
+.audioHint {
+  font-size: 0.75rem;
+  color: var(--ui-text-secondary);
+}
+
+.contextImage {
+  width: 100%;
+  max-height: 220px;
+  object-fit: cover;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.contextExample {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--ui-text-secondary);
+}
+
+.contextExample blockquote {
+  margin: 0;
+  padding-left: 12px;
+  border-left: 3px solid rgba(59, 130, 246, 0.35);
+  color: var(--ui-text-primary);
+}
+
+.answerHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.answerText {
+  margin: 0;
+}
+
 .promptLabel {
   font-size: 0.75rem;
   letter-spacing: 0.18em;
@@ -115,6 +186,9 @@
   color: #047857;
   font-size: 1.1rem;
   font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .controls {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,6 @@
 import Dexie, { Table } from 'dexie';
 import { Lesson, Exercise, Grade, Flashcard } from './lib/schemas';
+import { SpeakingCheckpoint } from './types/speaking';
 
 class AppDB extends Dexie {
   lessons!: Table<Lesson, string>;
@@ -7,6 +8,7 @@ class AppDB extends Dexie {
   grades!: Table<Grade, string>;
   flashcards!: Table<Flashcard, string>;
   settings!: Table<{ key: string; value: any }, string>;
+  speaking!: Table<SpeakingCheckpoint, string>;
 
   constructor() {
     super('spanishAppDB');
@@ -15,7 +17,7 @@ class AppDB extends Dexie {
       exercises: 'id,lessonId,type',
       grades: 'id,exerciseId,isCorrect,score',
       flashcards: 'id,tag,deck',
-      settings: 'key'
+      settings: 'key',
     });
 
     this.version(2).stores({
@@ -23,7 +25,16 @@ class AppDB extends Dexie {
       exercises: 'id,lessonId,type',
       grades: 'id,exerciseId,isCorrect,score',
       flashcards: 'id,tag,deck',
-      settings: 'key'
+      settings: 'key',
+    });
+
+    this.version(3).stores({
+      lessons: 'id,slug,level,tags',
+      exercises: 'id,lessonId,type',
+      grades: 'id,exerciseId,isCorrect,score',
+      flashcards: 'id,tag,deck',
+      settings: 'key',
+      speaking: 'id,exerciseId',
     });
   }
 }

--- a/src/hooks/usePlannerActions.ts
+++ b/src/hooks/usePlannerActions.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { To } from 'react-router-dom';
+import { useWorkspaceSnapshot } from './useWorkspaceSnapshot';
+import { db } from '../db';
+import { PlannerQuickAction, PlannerTimelineCard } from '../types/planner';
+import { deckLabel, formatRelativeTime } from '../lib/plannerUtils';
+
+const STORAGE_KEY = 'planner-goals';
+
+export type PlannerGoal = {
+  id: PlannerTimelineCard['id'];
+  note: string;
+  scheduledFor?: string | null;
+  reminder?: string | null;
+};
+
+type GoalMap = Record<PlannerTimelineCard['id'], PlannerGoal | undefined>;
+
+const defaultGoalMap: GoalMap = {
+  yesterday: undefined,
+  today: undefined,
+  tomorrow: undefined,
+};
+
+const plannerAnchor: To = { pathname: '/', hash: '#lesson-library' };
+
+const loadStoredGoals = async (): Promise<GoalMap> => {
+  try {
+    const record = await db.settings.get(STORAGE_KEY);
+    if (!record?.value) return defaultGoalMap;
+    const value = record.value as GoalMap;
+    return {
+      yesterday: value.yesterday,
+      today: value.today,
+      tomorrow: value.tomorrow,
+    };
+  } catch (error) {
+    console.warn('Unable to load planner goals', error);
+    return defaultGoalMap;
+  }
+};
+
+const persistGoals = async (goals: GoalMap) => {
+  try {
+    await db.settings.put({ key: STORAGE_KEY, value: goals });
+  } catch (error) {
+    console.warn('Unable to persist planner goals', error);
+  }
+};
+
+export const usePlannerActions = () => {
+  const workspace = useWorkspaceSnapshot();
+  const [goalMap, setGoalMap] = useState<GoalMap>(defaultGoalMap);
+
+  useEffect(() => {
+    let mounted = true;
+    loadStoredGoals().then((goals) => {
+      if (mounted) {
+        setGoalMap(goals);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const updateGoal = useCallback((goal: PlannerGoal | undefined) => {
+    if (!goal) return;
+    setGoalMap((prev) => {
+      const next: GoalMap = {
+        ...prev,
+        [goal.id]: goal.note || goal.scheduledFor || goal.reminder ? goal : undefined,
+      };
+      persistGoals(next);
+      return next;
+    });
+  }, []);
+
+  const clearGoal = useCallback((id: PlannerTimelineCard['id']) => {
+    setGoalMap((prev) => {
+      const next: GoalMap = { ...prev, [id]: undefined };
+      persistGoals(next);
+      return next;
+    });
+  }, []);
+
+  const commandItems: PlannerQuickAction[] = useMemo(() => {
+    if (workspace.loading) {
+      return [
+        {
+          key: 'loading',
+          label: 'Syncing your workspace…',
+          hint: 'We’re gathering lessons, flashcards and analytics.',
+          icon: '⏳',
+          disabled: true,
+        },
+      ];
+    }
+
+    const items: PlannerQuickAction[] = [];
+
+    if (workspace.resumeLesson) {
+      items.push({
+        key: 'resume',
+        to: workspace.resumeLesson.lessonSlug
+          ? `/lessons/${workspace.resumeLesson.lessonSlug}`
+          : plannerAnchor,
+        label: `Resume ${workspace.resumeLesson.lessonTitle}`,
+        hint: workspace.resumeLesson.lastAttemptAt
+          ? `Last review ${formatRelativeTime(workspace.resumeLesson.lastAttemptAt)}`
+          : 'Pick up right where you left off.',
+        icon: '🎯',
+        badge: `${workspace.resumeLesson.masteredCount}/${workspace.resumeLesson.totalExercises}`,
+      });
+    }
+
+    if (workspace.studyPlan[0]) {
+      const next = workspace.studyPlan[0];
+      if (!workspace.resumeLesson || workspace.resumeLesson.lessonId !== next.lessonId) {
+        items.push({
+          key: 'plan',
+          to: next.lessonSlug ? `/lessons/${next.lessonSlug}` : plannerAnchor,
+          label: `Start ${next.lessonTitle}`,
+          hint: next.reason,
+          icon: '🗂️',
+        });
+      }
+    }
+
+    const dueDeck = workspace.deckDue.find((entry) => entry.due > 0);
+    items.push({
+      key: 'flashcards',
+      to: '/flashcards',
+      label: dueDeck ? `Review ${deckLabel(dueDeck.deck)}` : 'Flashcard sprint',
+      hint: dueDeck
+        ? `${dueDeck.due} card${dueDeck.due === 1 ? '' : 's'} due now`
+        : 'All caught up — run a freestyle warm-up.',
+      icon: '🧠',
+      badge: workspace.dueFlashcards ? `${workspace.dueFlashcards}` : undefined,
+    });
+
+    if (workspace.weakestTag) {
+      items.push({
+        key: 'weakest-tag',
+        to: `/dashboard?focus=${encodeURIComponent(workspace.weakestTag.tag)}`,
+        label: `Boost ${workspace.weakestTag.tag}`,
+        hint: `${workspace.weakestTag.accuracy.toFixed(0)}% accuracy`,
+        icon: '🎯',
+      });
+    }
+
+    const celebration = workspace.milestone;
+    if (celebration) {
+      items.unshift({
+        key: 'milestone',
+        to: '/dashboard',
+        label: celebration.title,
+        hint: celebration.subtitle,
+        icon: '🏅',
+        badge: celebration.badge,
+      });
+    }
+
+    return items.slice(0, 3);
+  }, [workspace]);
+
+  const timelineCards: PlannerTimelineCard[] = useMemo(() => {
+    const lastStudiedOn = workspace.resumeLesson?.lastAttemptAt ?? workspace.lastStudiedOn;
+    const primaryRecommendation = workspace.studyPlan[0];
+    const primaryDeck = workspace.deckDue.find((entry) => entry.due > 0);
+    return [
+      {
+        id: 'yesterday',
+        label: 'Yesterday',
+        title: workspace.streak.current > 0 ? `Streak day ${workspace.streak.current}` : 'Restart your streak',
+        description: lastStudiedOn
+          ? `Last session ${formatRelativeTime(lastStudiedOn)}`
+          : 'No activity logged yet — today is a great day to begin.',
+        actionTo: workspace.streak.current > 0 ? '/dashboard' : plannerAnchor,
+        actionLabel: workspace.streak.current > 0 ? 'View insights' : 'Plan a session',
+        goal: goalMap.yesterday,
+      },
+      {
+        id: 'today',
+        label: 'Today',
+        title: primaryRecommendation ? primaryRecommendation.lessonTitle : 'Choose your focus',
+        description: primaryRecommendation
+          ? primaryRecommendation.reason
+          : 'Pick a focus block below to jump into practice.',
+        actionTo: primaryRecommendation?.lessonSlug ? `/lessons/${primaryRecommendation.lessonSlug}` : plannerAnchor,
+        actionLabel: primaryRecommendation ? 'Resume lesson' : 'Browse lessons',
+        goal: goalMap.today,
+      },
+      {
+        id: 'tomorrow',
+        label: 'Tomorrow',
+        title: primaryDeck ? `${deckLabel(primaryDeck.deck)} deck` : 'Schedule a review',
+        description: primaryDeck
+          ? `${primaryDeck.due} due · ${primaryDeck.total} total`
+          : 'Stay ahead by pencilling in a short flashcard sprint.',
+        actionTo: '/flashcards',
+        actionLabel: 'Open flashcards',
+        goal: goalMap.tomorrow,
+      },
+    ];
+  }, [goalMap, workspace]);
+
+  return {
+    commandItems,
+    timelineCards,
+    plannerAnchor,
+    goalMap,
+    updateGoal,
+    clearGoal,
+    workspace,
+  };
+};
+
+export type PlannerActionsHook = ReturnType<typeof usePlannerActions>;

--- a/src/hooks/useWorkspaceSnapshot.ts
+++ b/src/hooks/useWorkspaceSnapshot.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { liveQuery } from 'dexie';
 import { db } from '../db';
-import { computeAnalytics, StudyRecommendation } from '../lib/analytics';
+import { computeAnalytics, StudyRecommendation, StudyStreak, SRSDashboardSummary } from '../lib/analytics';
 import { Lesson } from '../lib/schemas';
 
 export interface ResumeLesson {
@@ -21,6 +21,9 @@ export interface WorkspaceSnapshot {
   deckDue: { deck: string; due: number; total: number }[];
   weakestTag?: { tag: string; accuracy: number };
   studyPlan: StudyRecommendation[];
+  streak: StudyStreak;
+  lastStudiedOn?: string;
+  milestone?: MilestoneCelebration;
 }
 
 const initialState: WorkspaceSnapshot = {
@@ -29,6 +32,42 @@ const initialState: WorkspaceSnapshot = {
   dueFlashcards: 0,
   deckDue: [],
   studyPlan: [],
+  streak: { current: 0, best: 0 },
+};
+
+export interface MilestoneCelebration {
+  title: string;
+  subtitle: string;
+  badge: string;
+}
+
+const determineMilestone = (
+  analytics: ReturnType<typeof computeAnalytics>,
+  progressPercent: number,
+  srs: SRSDashboardSummary
+): MilestoneCelebration | undefined => {
+  if (analytics.streak.current >= 7 && analytics.streak.current % 7 === 0) {
+    return {
+      title: `Streak hero: ${analytics.streak.current} days!`,
+      subtitle: 'Consistency unlocks comprehension. Celebrate your dedication.',
+      badge: `${analytics.streak.current}d streak`,
+    };
+  }
+  if (progressPercent >= 75) {
+    return {
+      title: 'Mastery milestone unlocked',
+      subtitle: `You have mastered ${progressPercent.toFixed(0)}% of tracked exercises. Time to celebrate!`,
+      badge: 'Mastery 75%',
+    };
+  }
+  if (srs.dueNow === 0 && progressPercent > 0) {
+    return {
+      title: 'Deck zeroed out',
+      subtitle: 'All flashcards cleared — perfect moment for a cultural bonus.',
+      badge: 'SRS clean sweep',
+    };
+  }
+  return undefined;
 };
 
 export const useWorkspaceSnapshot = () => {
@@ -64,6 +103,17 @@ export const useWorkspaceSnapshot = () => {
           ? { tag: analytics.weakestTags[0].tag, accuracy: analytics.weakestTags[0].accuracy }
           : undefined;
 
+        const totals = analytics.lessonMastery.reduce(
+          (acc, entry) => {
+            acc.mastered += entry.masteredExercises;
+            acc.total += entry.totalExercises;
+            return acc;
+          },
+          { mastered: 0, total: 0 }
+        );
+        const progressPercent = totals.total ? (totals.mastered / totals.total) * 100 : 0;
+        const milestone = determineMilestone(analytics, progressPercent, analytics.srs);
+
         setSnapshot({
           loading: false,
           lessons,
@@ -72,6 +122,9 @@ export const useWorkspaceSnapshot = () => {
           deckDue: analytics.srs.deckBreakdown,
           weakestTag,
           studyPlan: analytics.studyPlan,
+          streak: analytics.streak,
+          lastStudiedOn: analytics.streak.lastStudiedOn,
+          milestone,
         });
       },
       error: (error) => {

--- a/src/lib/plannerUtils.ts
+++ b/src/lib/plannerUtils.ts
@@ -1,0 +1,36 @@
+export const deckLabel = (deck: string) => {
+  switch (deck) {
+    case 'verbs':
+      return 'Verb drills';
+    case 'vocab':
+      return 'Vocabulary';
+    case 'presentations':
+      return 'Presentation phrases';
+    case 'culture':
+      return 'Culture & register';
+    case 'grammar':
+    default:
+      return 'Grammar focus';
+  }
+};
+
+export const formatRelativeTime = (value?: string) => {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  if (diffMs <= 0) return 'Just now';
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  if (diffMinutes < 60) {
+    return diffMinutes === 1 ? '1 minute ago' : `${diffMinutes} minutes ago`;
+  }
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    return diffHours === 1 ? '1 hour ago' : `${diffHours} hours ago`;
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) {
+    return diffDays === 1 ? 'Yesterday' : `${diffDays} days ago`;
+  }
+  return date.toLocaleDateString();
+};

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,7 +52,12 @@ export const FlashcardSchema = z.object({
   front: z.string(),
   back: z.string(),
   tag: z.string(),
-  deck: z.enum(['grammar','verbs','vocab','presentations']),
+  deck: z.enum(['grammar','verbs','vocab','presentations','culture']),
+  exampleFront: z.string().optional(),
+  exampleBack: z.string().optional(),
+  imageUrl: z.string().url().optional(),
+  audioFrontUrl: z.string().url().optional(),
+  audioBackUrl: z.string().url().optional(),
   srs: z.object({
     bucket: z.number(),
     lastReview: z.string().optional(),

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -90,7 +90,7 @@
 .timelineCards {
   display: grid;
   gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .timelineCard {
@@ -102,6 +102,66 @@
   border: 1px solid rgba(255, 255, 255, 0.24);
   background: rgba(255, 255, 255, 0.16);
   color: #ecfdf5;
+}
+
+.timelineForm {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed rgba(255, 255, 255, 0.28);
+}
+
+.timelineFormLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(236, 253, 245, 0.75);
+}
+
+.timelineFormNote {
+  width: 100%;
+  resize: vertical;
+  min-height: 70px;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid rgba(236, 253, 245, 0.35);
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+}
+
+.timelineFormRow {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: end;
+}
+
+.timelineFormInput {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: var(--ui-radius-md);
+  border: 1px solid rgba(236, 253, 245, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+}
+
+.timelineFormNote:focus-visible,
+.timelineFormInput:focus-visible {
+  outline: 2px solid #fef3c7;
+  outline-offset: 1px;
+}
+
+.timelineFormActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.timelinePlanSummary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(236, 253, 245, 0.85);
 }
 
 .timelineCardLabel {
@@ -459,6 +519,13 @@
   font-weight: 600;
 }
 
+.loadHint {
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: var(--ui-text-secondary);
+  text-align: center;
+}
+
 .emptyState {
   margin: 0;
   color: var(--ui-text-secondary);
@@ -560,6 +627,14 @@
 
   .timelineStats {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .timelineCards {
+    grid-template-columns: 1fr;
+  }
+
+  .timelineFormRow {
+    grid-template-columns: 1fr;
   }
 
   .searchForm {

--- a/src/seed/seedTypes.ts
+++ b/src/seed/seedTypes.ts
@@ -69,7 +69,12 @@ export const FlashcardSchema = z.object({
   front: z.string(),
   back: z.string(),
   tag: z.string(),
-  deck: z.enum(['grammar', 'verbs', 'vocab', 'presentations']),
+  deck: z.enum(['grammar', 'verbs', 'vocab', 'presentations', 'culture']),
+  exampleFront: z.string().optional(),
+  exampleBack: z.string().optional(),
+  imageUrl: z.string().url().optional(),
+  audioFrontUrl: z.string().url().optional(),
+  audioBackUrl: z.string().url().optional(),
   srs: z
     .object({
       bucket: z.number(),

--- a/src/types/planner.ts
+++ b/src/types/planner.ts
@@ -1,0 +1,26 @@
+import { To } from 'react-router-dom';
+
+export type PlannerQuickAction = {
+  key: string;
+  to?: To;
+  label: string;
+  hint: string;
+  icon: string;
+  badge?: string;
+  disabled?: boolean;
+};
+
+export type PlannerTimelineCard = {
+  id: 'yesterday' | 'today' | 'tomorrow';
+  label: string;
+  title: string;
+  description: string;
+  actionTo: To;
+  actionLabel: string;
+  goal?: {
+    id: PlannerTimelineCard['id'];
+    note: string;
+    scheduledFor?: string | null;
+    reminder?: string | null;
+  };
+};

--- a/src/types/speaking.ts
+++ b/src/types/speaking.ts
@@ -1,0 +1,7 @@
+export interface SpeakingCheckpoint {
+  id: string;
+  exerciseId: string;
+  recordedAt: string;
+  durationMs: number;
+  blob: Blob;
+}


### PR DESCRIPTION
## Summary
- introduce a shared planner actions hook powering quick actions and goal scheduling cards
- expand analytics with weekly plan data, dashboard exports, and milestone celebrations
- add flashcard audio/context fields and inline speaking checkpoints persisted in Dexie

## Testing
- npm run build
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d8089874f08324a1d30dc59a2ca077