### PR TITLE
Add bilingual cheat papers to subjects hub

### DIFF
--- a/docs/cheat-papers/admeav-lab-cheat.md
+++ b/docs/cheat-papers/admeav-lab-cheat.md
@@ -1,0 +1,35 @@
+# Advanced Machine Learning — MLOps Implementation Clinics Cheat Paper
+
+> Operational dossier for ADML-455 labs with English explanations and Spanish callouts.
+
+## Clinic outline
+- **Focus:** pipeline automation, monitoring, drift response, ethical deployment.
+- **Deliverables:** runbooks, dashboards, executive briefs, bilingual glossaries.
+
+## Pipeline setup & automation
+- **Infrastructure checklist:** repositories, CI/CD pipelines, container registry, secrets vault. Document each step with English instructions and Spanish notes.
+- **Experiment management:** configure MLflow tracking URI, experiment naming, artifact storage. Include screenshot references.
+- **Automation tips:** Git hooks for linting, pipeline stages (build, test, deploy). Provide translation for key statuses (`Deployment succeeded / Despliegue exitoso`).
+- **RACI table:** define responsibilities for data scientists, MLOps engineers, product owners, compliance officers.
+
+## Monitoring & drift response
+- **Metrics catalogue:** data drift, prediction drift, latency, cost. Provide formulas and thresholds.
+- **Alerting:** set up Evidently dashboards, webhook notifications, Slack/Teams bilingual templates.
+- **Incident playbook:** detection → triage → mitigation → post-mortem. Include bilingual incident log template.
+- **Documentation:** maintain English incident reports with appended Spanish summaries for local teams.
+
+## Ethical deployment playbook
+- **Fairness checklist:** dataset audit, bias metrics, mitigation strategies. Translate each checklist item.
+- **Privacy & compliance:** data retention, consent tracking, audit logs. Provide bilingual bullet points for board review.
+- **Executive briefing:** 2-page English overview with Spanish executive summary; include KPIs (accuracy, drift rate, fairness score).
+- **Control dashboard:** recommended widgets (model health, incidents, actions). Provide screenshot placeholders.
+
+## Study practices
+- Run the full runbook before each clinic session to confirm instructions remain accurate.
+- Share dashboards with mentors for early feedback and note Spanish terminology they prefer.
+- Convert tricky Spanish annotations into flashcards to reinforce vocabulary.
+
+## Appendices
+- **Appendix A:** runbook template with bilingual sections.
+- **Appendix B:** incident log sample.
+- **Appendix C:** ethical review checklist.

--- a/docs/cheat-papers/admeav-seminar-cheat.md
+++ b/docs/cheat-papers/admeav-seminar-cheat.md
@@ -1,0 +1,34 @@
+# Advanced Machine Learning — Research Seminar Series Cheat Paper
+
+> Comprehensive bilingual digest for ADML-401 seminar discussions.
+
+## Seminar coverage
+- **Themes:** Gaussian processes, Bayesian inference, continual learning, ethics & governance, research communication.
+- **Artifacts included:** theorem summaries, debate prompts, vocabulary glossaries, note-taking templates.
+
+## Gaussian processes & Bayesian inference
+- **Key concepts:** kernel design, inducing points, constrained optimisation, sparse approximations. Translate keywords (`kernel`, `puntos inductores`, `restricciones`).
+- **Derivation highlights:** posterior mean/variance formulas, covariance updates under constraints. Provide annotated example.
+- **Discussion prompts:** trade-offs between exact inference and sparse methods, applications in real systems.
+- **Takeaway summary:** bullet list of practical implications for deployment, with Spanish synopsis.
+
+## Continual learning & ethics
+- **Method families:** regularisation (EWC, SI), rehearsal (experience replay), architectural approaches (dynamic expansion). Provide bilingual explanation for each.
+- **Evaluation:** metrics for forgetting (`Δ accuracy`), transfer, resource cost. Include translation of evaluation terms.
+- **Ethical considerations:** fairness drift, transparency, human oversight. Provide question bank for panel sessions.
+- **Debate prep:** sample arguments and counter-arguments with bilingual phrasing.
+
+## Seminar facilitation toolkit
+- **Agenda template:** intro, paper walkthrough, critique, open Q&A, wrap-up. Include time allocations.
+- **Question bank:** clarifying, probing, reflective, closing questions with English/Spanish pairs.
+- **Deliverables checklist:** summary note, vocabulary update, action items. Provide bilingual format.
+
+## Study cycle
+- Draft a one-page English brief after each paper, then translate the abstract and key insights into Spanish.
+- Record unfamiliar vocabulary and add Spanish equivalents to the glossary.
+- Rehearse debate contributions aloud; use the question bank to self-interrogate.
+
+## Appendices
+- **Appendix A:** glossary of advanced ML terminology.
+- **Appendix B:** sample seminar summary template.
+- **Appendix C:** ethics checklist for research discussions.

--- a/docs/cheat-papers/dbd-lab-cheat.md
+++ b/docs/cheat-papers/dbd-lab-cheat.md
@@ -1,0 +1,41 @@
+# Diseño de Bases de Datos — Laboratorio SQL Performance Cheat Paper
+
+> English-first optimisation playbook for DBD-204 with Spanish cues for reporting.
+
+## Lab summary
+- **Focus areas:** baseline capture, indexing strategies, query tuning, benchmarking, bilingual reporting.
+- **Outcomes:** consistent lab submissions, reproducible experiments, clear communication with Spanish-speaking evaluators.
+
+## Preparation & baselines
+- **Environment checklist:** PostgreSQL 15, `pg_stat_statements`, query visualiser. Document installation commands in English, add Spanish annotation for labs.
+- **Baseline capture:**
+  - Run provided `baseline.sql` script and export metrics table (execution time, buffers hit, CPU ms).
+  - Store results in the bilingual log (`logs/baseline.csv` + `registros/baseline-es.csv`).
+  - Screenshot execution plans, label sections (Seq Scan / Escaneo Secuencial).
+- **Data integrity:** verify row counts, constraints, and indexes before modifications. Note Spanish translation for constraint errors.
+
+## Indexing & tuning drills
+- **Index cookbook:**
+  - B-tree composite indexes for high-selectivity filters.
+  - Partial indexes for status columns; include `WHERE status = 'ACTIVE'` + Spanish comment.
+  - Covering indexes using `INCLUDE` clause.
+- **Plan analysis:**
+  - Use `EXPLAIN (ANALYZE, BUFFERS)` to compare before/after metrics.
+  - Track changes in `cost`, `rows`, `loops`. Translate key metrics (`buffers`) in notes.
+- **Query rewrites:** leverage CTEs, window functions, and query refactoring (e.g., `EXISTS` vs `IN`). Document reasoning in English with Spanish summary line.
+
+## Reporting & bilingual delivery
+- **Lab report template:** introduction, methodology, results table, discussion, appendix with SQL snippets.
+- **Metrics table:** include columns for baseline vs optimised metrics, improvement percentage, commentary. Provide Spanish translation for table headers.
+- **Oral playback:** prepare 3-minute English overview plus 1-minute Spanish summary focusing on KPIs and lessons learned.
+- **Repository hygiene:** commit SQL scripts with English README, add Spanish footnotes explaining dataset context.
+
+## Study guidance
+- Timebox each lab step using the included planner (baseline 30m, indexing 40m, reporting 30m).
+- Rerun baselines weekly to understand drift and highlight improvements.
+- Practice explaining each optimisation to a non-technical stakeholder in Spanish to ensure clarity.
+
+## Appendix
+- **Appendix A:** `metrics-template.xlsx` with bilingual headers.
+- **Appendix B:** sample screenshots with annotations in both languages.
+- **Appendix C:** glossary of performance terms (cache hit ratio, plan stability) with Spanish equivalents.

--- a/docs/cheat-papers/dbd-lecture-cheat.md
+++ b/docs/cheat-papers/dbd-lecture-cheat.md
@@ -1,0 +1,42 @@
+# Diseño de Bases de Datos — Modelado relacional Cheat Paper
+
+> English-oriented relational modelling reference for DBD-110 with Spanish terminology sidebars.
+
+## Coverage
+- **Topics:** requirements gathering, conceptual modelling, logical mapping, normalisation (1NF–BCNF), constraints, SQL patterns.
+- **Use cases:** exam revision, ERD walkthroughs, quick translation when explaining diagrams to Spanish-speaking peers.
+
+## Conceptual & logical design
+- **Requirement capture:** interview notes → business rules → candidate entities/relationships. Document cardinality using both `1..*` and Spanish descriptions (`uno a muchos`).
+- **Entity modelling:** include strong/weak entity examples, associative entities, inheritance patterns (`table per hierarchy`, `tabla por jerarquía`).
+- **Logical mapping:** convert conceptual elements to relational schema, note naming conventions (English singular names with Spanish alias column).
+- **Checklist:**
+  - Validate primary keys (PK) and foreign keys (FK).
+  - Ensure optionality matches business rules.
+  - Prepare English narrative explaining each entity for viva voce.
+
+## Normalisation toolkit
+- **Normal forms cheat table:**
+  - 1NF: atomic attributes, no repeating groups.
+  - 2NF: remove partial dependencies on composite keys.
+  - 3NF: remove transitive dependencies.
+  - BCNF: determinants must be candidate keys.
+- **Diagnostic steps:** identify functional dependencies, create dependency diagrams, test decomposition with lossless join.
+- **Spanish hints:** `dependencia funcional`, `descomposición sin pérdida`, `atributo derivado`.
+- **Exceptions:** document justified denormalisation (reporting tables, caching) with bilingual rationale.
+
+## Constraints & SQL patterns
+- **Constraint inventory:** PK, FK, UNIQUE, CHECK, NOT NULL, DEFAULT, plus trigger-based enforcement. Provide sample syntax with English comments and Spanish inline explanation.
+- **Integrity scripts:** `ALTER TABLE` statements to add constraints post-creation, include translation of error messages.
+- **Query patterns:** join templates, window functions, CTEs, set operations. Map each to Spanish phrasing (`funciones de ventana`).
+- **Exam prep:** practise short-answer questions summarising when to use each constraint and the trade-offs.
+
+## Study recommendations
+- Redraw the library case ERD using the provided template, then explain it in English to ensure clarity.
+- Work through normalisation exercises, annotating each step in Spanish to cement vocabulary.
+- Teach a classmate the constraint section—if they understand it in English and Spanish, you have mastered it.
+
+## Appendices
+- **Appendix A:** sample bilingual ERD legend.
+- **Appendix B:** functional dependency worksheet.
+- **Appendix C:** SQL snippet library with translation notes.

--- a/docs/cheat-papers/ggo-intro-cheat.md
+++ b/docs/cheat-papers/ggo-intro-cheat.md
@@ -1,0 +1,39 @@
+# Gobierno de TI — Introducción al gobierno de TI Cheat Paper
+
+> Executive-ready English briefing with Spanish clarifications for GGO-101. Ideal for preparing bilingual memos and oral defences.
+
+## Course scope
+- **Framework focus:** COBIT 2019, value delivery models, performance measurement, stakeholder alignment.
+- **Deliverables supported:** executive memos, governance scorecards, stakeholder maps, translation glossaries.
+- **How to use:** skim English summaries before meetings, consult Spanish callouts when adapting to local context.
+
+## COBIT 2019 essentials
+- **Principles & governance system:** outline the six COBIT principles and map them to the governance components (processes, organisational structures, information, culture/behaviour, people, services, infrastructure). Provide Spanish equivalents for each term.
+- **Goals cascade:** document enterprise goals → alignment goals → governance/management objectives. Include KPI examples (ROI de TI, satisfacción del cliente) and note measurement cadence.
+- **Design factors:** summarise drivers such as enterprise strategy, risk profile, compliance, and IT adoption strategy. Maintain bilingual glossary (e.g., `apetito de riesgo`, `IT-related goals`).
+
+## Value delivery & performance toolkit
+- **Benefit, risk, cost matrices:** capture evaluation criteria in English, annotate Spanish keywords for board discussions.
+- **Balanced scorecard template:** financial, customer, internal, learning perspectives. Add bilingual KPI suggestions (e.g., *cycle time / tiempo de ciclo*).
+- **Maturity & capability levels:** align with COBIT levels (0–5). Provide sample evidence for each level and translation cues.
+
+## Stakeholder communication
+- **Stakeholder map:** power vs. interest grid with English descriptors; attach Spanish explanation for each quadrant.
+- **Engagement plan:** outline message frequency, medium, owner, call-to-action. Provide bilingual scripts for common touchpoints (steering committee, finance review).
+- **FAQ bank:** prepare answers for typical executive questions about ROI, compliance, resource allocation. Pair each answer with Spanish glossaries.
+
+## Study tips & next actions
+- Practice your executive memo pitch in English, then rewrite the top three paragraphs in Spanish to ensure nuance.
+- Update the scorecard template with live project data to reinforce metric definitions.
+- Share the glossary section with peers and collect additional Spanish equivalents you encounter.
+
+## Reference quick-links
+| Topic | Artifact | Location |
+| --- | --- | --- |
+| Goals cascade worksheet | `docs/cheat-papers/ggo-intro-cheat.md#cobit-2019-essentials` | Duplicate for each governance initiative. |
+| Balanced scorecard template | Appendix A | Attach to executive memo in both languages. |
+| Stakeholder scripts | Appendix B | Keep printed copies for facilitation sessions. |
+
+## Maintenance
+- Update KPIs after each major governance review cycle.
+- Keep track of terminology adjustments introduced by professors or stakeholders in the glossary appendix.

--- a/docs/cheat-papers/ggo-workshop-cheat.md
+++ b/docs/cheat-papers/ggo-workshop-cheat.md
@@ -1,0 +1,49 @@
+# Gobierno de TI — Stakeholder Workshops Cheat Paper
+
+> End-to-end facilitation blueprint with English direction and Spanish cues for GGO-205 workshop labs.
+
+## Session overview
+- **Activities covered:** Bedell method, stakeholder canvases, translation clinic, executive playback.
+- **Purpose:** enable English delivery of workshops while preserving Spanish nuance for local stakeholders.
+- **Preparation time:** 45 minutes setup, 90 minutes facilitation, 30 minutes follow-up.
+
+## Workshop setup
+- **Pre-work checklist:**
+  - Confirm objectives, success metrics, agenda, logistics. Store them in English with Spanish footnotes.
+  - Duplicate stakeholder canvas templates (Miro/PowerPoint) with bilingual headings.
+  - Assign roles: facilitator, scribe, timekeeper, translator. Provide responsibilities in both languages.
+- **Room layout:** U-shape for discussion, breakout tables for scoring, dedicated translation board.
+- **Materials:** printed scorecards, sticky notes (colour-coded per stakeholder), bilingual timers, QR link to digital canvas.
+
+## Execution scripts
+- **Opening script (English primary):**
+  1. Welcome and norms (share Spanish version on slide).
+  2. Overview of Bedell method, emphasising the value impact scale.
+  3. Clarify languages to be used (English discussion, Spanish sidebar notes accepted).
+- **Bedell scoring:** explain factors (Contribution, Impact, Criticality). Provide example scoring in both languages.
+- **Stakeholder alignment drill:** map influence vs. support, capture pain points, translate key phrases immediately.
+- **Facilitation cues:** use the bilingual question bank to unblock silence (`What risk worries you most? / ¿Qué riesgo te preocupa más?`).
+
+## Follow-up & translation clinic
+- **Debrief circle:** 10-minute reflective round summarising insights in English, confirm Spanish accuracy.
+- **Action log:** assign owners, due dates, next checkpoints. Include bilingual summary per action.
+- **Translation clinic:**
+  - Collect Spanish annotations that need polishing.
+  - Use provided glossary table to harmonise terms.
+  - Produce final bilingual stakeholder map and executive memo snippet.
+
+## Study tips
+- Role-play each section with classmates, rotating facilitation roles to build muscle memory.
+- Time each agenda block to stay within schedule; adjust cues accordingly.
+- Highlight difficult vocabulary during the clinic and add to your personal glossary.
+
+## Key artefacts
+| Artefact | Description | Where to find |
+| --- | --- | --- |
+| Facilitation script | Minute-by-minute prompts | `docs/cheat-papers/ggo-workshop-cheat.md#execution-scripts` |
+| Canvas templates | Bilingual stakeholder canvas | Linked from Subjects hub cheat paper card |
+| Action log | Post-workshop follow-up sheet | Appendix A inside this document |
+
+## Version control
+- Update this sheet after every workshop and include lessons learned.
+- Sync action logs with the planner quick actions to avoid duplication.

--- a/docs/cheat-papers/sad-lab-cheat.md
+++ b/docs/cheat-papers/sad-lab-cheat.md
@@ -1,0 +1,45 @@
+# Software Architecture & Design — Practical Microservices Lab Cheat Paper
+
+> Your English-first lab runbook with Spanish callouts for the SAD-241 clinics. Use it alongside the Git repository and observability dashboards.
+
+## Lab inventory
+- **Labs covered:** monitoring stack, chaos drills, deployment rehearsal, documentation close-out.
+- **What you get:** topology diagrams, command snippets, incident matrices, bilingual reporting templates.
+- **Before you start:** duplicate this sheet, add environment URLs, and list teammates with guard duty roles.
+
+## Environment & scaffolding
+- **Service map:** API gateway ↔ auth ↔ order service ↔ payment worker ↔ event bus. Annotate each component with Spanish alias (`puerta de enlace`, `servicio de pedidos`).
+- **Bootstrap steps:**
+  1. Export `.env.example` → `.env` and translate sensitive key descriptions.
+  2. `docker compose up --build` — verify Spanish logs for readiness cues ("Servicio listo").
+  3. Seed sample data using `npm run seed` and document English summary of fixtures.
+- **Sprint planning:** fill the bilingual user-story template: `Como operador...` / `As an operator...` with acceptance criteria.
+
+## Observability & resilience drills
+- **Instrumentation checklist:** enable OpenTelemetry collector, configure Prometheus scrape targets, map spans to business transactions. Record metrics dictionary (latency, throughput, error rate) in both languages.
+- **Chaos routine:**
+  - Introduce latency via `toxiproxy-cli toxic add order_service latency --latency 1200`.
+  - Trigger pod restart and monitor circuit breaker behaviour; log findings in English.
+  - Rollback plan: `kubectl rollout undo deployment/order-service` + Spanish annotation in incident doc.
+- **Incident matrix:** severity vs. impact table with bilingual descriptors (`Severidad Alta`, `Customer checkout failed`). Include mitigation column referencing ADR IDs.
+
+## Deployment & documentation
+- **CI/CD flow:** lint → unit tests → contract tests → canary deploy → full rollout. Translate pipeline status messages.
+- **Smoke checklist:** health endpoints, message queue depth, dashboard widgets, error budget remaining. Provide screenshots labelled English/Spanish.
+- **Post-deploy doc:** append metrics summary, incident learnings, and backlog actions. Keep bilingual glossary for new components.
+
+## Study and prep tips
+- Run a dry rehearsal before live labs using the incident matrix to explore "what if" scenarios.
+- Practice presenting monitoring insights in English to classmates; switch to Spanish for team retros.
+- After each session, update vocabulary flashcards with any new Spanish infrastructure terms.
+
+## Reference artifacts
+| Topic | Resource | Notes |
+| --- | --- | --- |
+| Observability baseline | `docs/cheat-papers/sad-lab-cheat.md#observability--resilience-drills` | Copy metrics dictionary into your dashboard wiki. |
+| Chaos scenarios | `scripts/chaos/` (repo) | Keep bilingual annotations in each script header. |
+| Reporting | `exports/` folder | Attach PDF export plus Spanish appendix before submission. |
+
+## Keep in sync
+- Latest canonical version lives here. Update timestamps when lab instructions change.
+- Cross-link this document from the Subjects hub cheat paper card for quick access.

--- a/docs/cheat-papers/sad-theory-cheat.md
+++ b/docs/cheat-papers/sad-theory-cheat.md
@@ -1,0 +1,56 @@
+# Software Architecture & Design — Theory & Decision Frameworks Cheat Paper
+
+> English-first digest with Spanish anchors for the SAD-201 course. Keep this side-by-side with the Spanish slide decks when preparing ADRs or ATAM workshops.
+
+## Quick course map
+- **Lectures covered:** architectural styles, drivers, quality attribute tactics, ATAM, lightweight documentation.
+- **Use cases:** preparing graded ADRs, facilitating scenario reviews, translating Spanish slides, refreshing vocabulary before exams.
+- **Pair with:** `Architecture decision playbook` entry inside the Subjects hub for direct links and glossary refresh.
+
+## Architecture foundations & drivers
+### English checkpoints
+- Compare **layered, hexagonal, microservices, and event-driven** styles. Note the default quality attributes they elevate and the trade-offs they incur (e.g., microservices = scalability & deployability, extra operational overhead).
+- Capture **stakeholder drivers** using the *business goals → quality attributes → scenarios* cascade. Record metrics such as latency targets or resilience budgets alongside owner personas.
+- Use the following ADR scaffold for every decision:
+  1. **Context / Contexto** — business trigger, constraints, existing systems.
+  2. **Decision / Decisión** — selected option + justification.
+  3. **Status / Estado** — proposed, accepted, superseded.
+  4. **Consequences / Consecuencias** — positive outcomes, risks, mitigations.
+
+### Spanish anchors (resumen)
+- Estilos: `capas`, `arquitectura hexagonal`, `microservicios`, `event-driven`. Atributos clave: `disponibilidad`, `mantenibilidad`, `time-to-market`.
+- Drivers comunes: modernización ERP, cumplimiento regulatorio, expansión móvil.
+- Mantén un glosario paralelo con términos como *bounded context*, *quality attribute scenario*, *stakeholder salience*.
+
+## Quality tactics & documentation
+- **Availability & reliability:** circuit breakers, health checks, redundancy, automated failover. Document *Mean Time To Recovery* (MTTR) en ambos idiomas.
+- **Performance & scalability:** caching layers, CQRS, async messaging. Incluye métricas de throughput con notas en español.
+- **Security & governance:** zero-trust, audit trails, secrets rotation. Añade responsables RACI en la ficha de control.
+- **Documentation kit:**
+  - Lightweight C4 diagrams (Context, Container, Component, Code) con etiquetas bilingües.
+  - ADR catalog spreadsheet linking decision ID ↔ architectural view.
+  - RACI matrix for stakeholder responsibilities around deployment, review, and compliance.
+
+## Evaluation workflows
+1. **ATAM Phase 0–1 (kick-off):** craft English agenda, share Spanish context brief, collect architectural drivers.
+2. **Scenario brainstorming:** run silent brainwriting, sort by utility and risk; capture results in bilingual scenario table.
+3. **Utility tree analysis:** assign importance/exposure scores, highlight trade-offs, produce heatmap.
+4. **Risk prioritisation & report:** document sensitivity points, non-risks, and recommended actions. Provide Spanish executive summary.
+5. **Decision follow-through:** track actions in backlog, update ADR status, schedule check-in for unresolved risks.
+
+## Study routines
+- Review one section before each lecture and flag vocabulary that still feels unfamiliar.
+- Practice the ADR checklist in English, then translate the highlights into Spanish for submission.
+- Pair tactics with real systems in your organisation or projects to build long-term memory cues.
+
+## Reference tables
+| Concept | English reminder | Spanish cue |
+| --- | --- | --- |
+| Quality attribute scenario | Stimulus → Environment → Response | Escenario de atributo de calidad |
+| Availability tactic | Redundancy, graceful degradation | Redundancia, degradación controlada |
+| ATAM outcome | Risks, sensitivity points, trade-offs | Riesgos, puntos sensibles, compromisos |
+
+## Export & updates
+- Full markdown lives in this repository: `docs/cheat-papers/sad-theory-cheat.md`.
+- Mirror to your own Notion or PDF; update glossaries weekly.
+- Track translation tweaks inside the Subjects hub to keep English and Spanish artefacts aligned.

--- a/docs/cheat-papers/snlp-lab-cheat.md
+++ b/docs/cheat-papers/snlp-lab-cheat.md
@@ -1,0 +1,35 @@
+# Statistical NLP — Corpus Labs Cheat Paper
+
+> Operational field guide for SNLP-360 labs with bilingual commentary.
+
+## Lab catalogue
+- **Experiments covered:** NER on AnCora, POS tagging, language modelling, bias evaluation, poster project prep.
+- **Outputs:** reproducible notebooks, evaluation tables, bilingual reflections, poster-ready summaries.
+
+## Environment prep & datasets
+- **Setup checklist:** Google Colab (GPU when available), spaCy, Hugging Face Transformers, fastText, scikit-learn. Document install commands and Spanish notes (e.g., `!pip install spacy==3.6 --quiet  # instalar spaCy`).
+- **Dataset intake:** download AnCora, Europarl, WikiLingua. Record source, licensing, preprocessing steps with bilingual comments.
+- **Data profiling:** compute token counts, entity distribution, label coverage. Use provided notebook cells and annotate key findings in Spanish.
+
+## Model training routines
+- **NER pipeline:**
+  1. Load spaCy config, adjust hyperparameters (batch size, dropout). Provide recommended ranges.
+  2. Train, evaluate, and save model artefacts; log metrics table.
+  3. Translate key pipeline stages (`tokenizer`, `tagger`, `ner`) into Spanish for lab notes.
+- **POS & language models:** highlight differences in objectives, include quick-start scripts, mention evaluation metrics (accuracy, perplexity).
+- **Experiment tracking:** record seed, dataset split, hyperparameters, environment info. Append bilingual summary per run.
+
+## Evaluation & reporting
+- **Metric sheet:** precision, recall, F1, confusion matrices. Provide template table with English headers and Spanish subtitle.
+- **Error analysis:** capture misclassified entities, category patterns, example sentences. Translate insights for Spanish wrap-up.
+- **Poster/project prep:** outline sections (Motivation, Method, Results, Ethics). Provide bilingual bullet list for each section.
+
+## Study habits
+- Document experiments immediately; use the bilingual log to avoid translation gaps later.
+- Present results to a peer in English, then summarise in Spanish to confirm retention.
+- Iterate on experiments with small parameter tweaks to understand sensitivity.
+
+## Appendices
+- **Appendix A:** notebook template with bilingual comments.
+- **Appendix B:** evaluation dashboard screenshot guide.
+- **Appendix C:** glossary of corpus and modelling terminology.

--- a/docs/cheat-papers/snlp-lecture-cheat.md
+++ b/docs/cheat-papers/snlp-lecture-cheat.md
@@ -1,0 +1,37 @@
+# Statistical NLP — Probabilistic Foundations Cheat Paper
+
+> English-deep-dive notes with Spanish cues for SNLP-320 lecture series.
+
+## Learning map
+- **Units:** N-gram modelling, smoothing algorithms, machine translation architectures, evaluation metrics, research synthesis.
+- **Goal:** explain theory in English while being ready to translate key insights to Spanish teammates or reports.
+
+## N-gram modelling fundamentals
+- **Definitions:** probability of word sequences, Markov assumption, chain rule derivations. Translate `conditional probability` → `probabilidad condicional`.
+- **Smoothing comparison:**
+  - *Add-k / Laplace* — simple bias, high perplexity for large vocabularies.
+  - *Good-Turing* — reserve mass for unseen events, needs frequency-of-frequency table.
+  - *Kneser-Ney* — absolute discounting, continuation probabilities. Include formulas and Spanish annotations.
+- **Perplexity & cross-entropy:** formula reminders, interpretation as average branching factor. Provide example calculation.
+
+## Machine translation & sequence models
+- **Classical SMT:** IBM Models 1–5 summary, alignment probabilities, EM training steps.
+- **Phrase-based models:** segmentation, phrase table, distortion model, feature weighting. Translate terms (`tabla de frases`, `modelo de distorsión`).
+- **Sparse feature integration:** describe log-linear model, tuning with MERT/MIRA, include English explanation of each feature class with Spanish gloss.
+- **Neural comparison:** encoder-decoder overview, attention mechanism cheat notes, highlight differences vs. SMT.
+
+## Evaluation & error analysis
+- **Automatic metrics:** BLEU (n-gram precision, brevity penalty), METEOR (precision, recall, alignment), TER. Provide bilingual definitions.
+- **Human evaluation:** adequacy, fluency scales; include sample rubric lines in both languages.
+- **Error taxonomy:** lexical, reordering, agreement, omission/addition. Add translation cues for each label.
+- **Reporting template:** summary paragraph, score table, qualitative insights, improvement backlog.
+
+## Study boosters
+- Re-derive smoothing formulas weekly; explain the intuition aloud in English, then summarise in Spanish.
+- Build flashcards for metric definitions with bilingual terms.
+- Write a short Spanish abstract after each English research paper to ensure comprehension.
+
+## Appendices
+- **Appendix A:** formula sheet with bilingual annotations.
+- **Appendix B:** sample BLEU calculation walkthrough.
+- **Appendix C:** translation of frequent research vocabulary.

--- a/docs/study-hub-roadmap.md
+++ b/docs/study-hub-roadmap.md
@@ -1,0 +1,80 @@
+# Study Hub Expansion Roadmap
+
+## Vision
+Create a bilingual study hub that unifies Spanish and English learning materials across every subject. The app should let an English-dominant student manage university courses, labs, and language practice in one workflow: discover materials, translate where needed, review flashcards, and track progress across disciplines.
+
+## Guiding Principles
+- **Single source of truth** – consolidate lessons, course files, and lab resources using one schema so the dashboard, flashcards, and analytics always stay in sync.
+- **Language accessibility** – surface English-first summaries and smart translations for Spanish-only content without mutating the original source.
+- **Modular study flows** – let subjects, courses, labs, and micro-lessons plug into the same scheduling, tagging, and flashcard systems.
+- **Offline-first** – preserve the existing caching/import pipeline so materials remain available offline.
+
+## User Journeys
+1. **Plan a study session**: pick a subject → choose a course or lab module → review upcoming tasks and flashcards → launch exercises or reference documents.
+2. **Translate Spanish materials**: open a Spanish PDF/lesson → see auto-generated English outline → toggle inline translations for paragraphs, keywords, and diagrams.
+3. **Track progress**: view a unified dashboard showing mastery per subject, overdue labs, and vocabulary gaps to prioritise the next session.
+
+## Information Architecture
+- **Subjects directory**: wrap each folder in `subjects/` with metadata (`subject.json`) describing title, language profile, credits, and related skills.
+- **Course & lab entities**: within each subject, store `courses/` and `labs/` directories containing lesson bundles, worksheets, and assessments. Link each lesson to flashcard decks and prerequisite tags.
+- **Resource types**:
+  - `lessons/` – structured markdown or JSON (re-using the `SeedBundle` schema) for concept explanations.
+  - `readings/` – PDFs, slides, or links augmented with extracted outlines and glossary metadata.
+  - `assignments/` – task objects with due dates, status, and submission artefacts.
+  - `flashcards/` – spaced-repetition decks tied to subjects, automatically federated into the global trainer.
+- **Cross-cutting tags**: standardise taxonomy (e.g., "databases", "microservices", "ethics") for search, analytics, and recommendations.
+
+## App Structure Updates
+- **Navigation**: extend the AppShell with a "Subjects" hub listing all subjects plus quick filters (language, type, due soon). Each subject page summarises courses, labs, and resources.
+- **Dashboard**: augment analytics with subject-level metrics (credit weight, completion, flashcard health, assignment urgency) and highlight cross-subject blockers.
+- **Lesson/Resource viewer**: add a universal viewer capable of rendering markdown, JSON lessons, and annotated PDFs with translation overlays, note-taking, and offline caching.
+- **Flashcards**: scope decks by subject while keeping a combined review queue. Allow filtering by subject, language, or difficulty during a session.
+- **Content Manager**: upgrade import/validation to support subject bundles (metadata + resources + translations). Provide progress indicators for large uploads and allow diffing existing subjects.
+
+## Language Support
+- **Metadata layer**: store English summaries, glossaries, and key questions alongside original Spanish texts so UI can show bilingual cards.
+- **On-demand translation**: integrate a translation service (API or local model) invoked when a user opens a Spanish resource, caching outputs for offline reuse.
+- **Terminology synchronisation**: maintain a bilingual terminology database to keep flashcards, notes, and course materials aligned across languages.
+- **Pronunciation aids**: reuse current audio tooling (if any) or add TTS snippets for critical vocabulary within non-language subjects taught in Spanish.
+
+## Study Workflows
+- **Session planner**: combine calendar deadlines, flashcard scheduling, and energy levels to recommend next tasks across subjects.
+- **Lab companion**: for hands-on labs, provide checklists, environment setup snippets, and quick-switch notes/translations.
+- **Reflection log**: capture daily summaries tagged by subject, generating future review prompts and adjusting spaced-repetition weights.
+
+## Analytics & Progress Tracking
+- Expand mastery metrics to include subject completion %, assignment status, and translation confidence (how often the student switches to English aids).
+- Visualise cognitive load by showing time spent per language, upcoming workload, and flashcard streaks across subjects.
+- Provide export options (e.g., CSV, Notion sync) for academic advisors or self-reporting.
+
+## Phased Implementation
+1. **Foundation (Week 1-2)**
+   - Define subject/course/lab schemas and seed initial metadata for existing folders.
+   - Update dashboard navigation to surface subjects and load stub subject pages.
+   - Ensure content manager can register new schemas without breaking current Spanish lessons.
+2. **Language Layer (Week 3-4)**
+   - Build translation metadata pipeline (auto summaries + glossary extraction).
+   - Add bilingual toggles to lesson viewer and flashcards.
+3. **Workflow Enhancements (Week 5-6)**
+   - Implement session planner and assignment tracking UI.
+   - Enhance analytics with subject-level charts and overdue alerts.
+4. **Refinement (Week 7+)**
+   - Integrate lab companion features, offline caching improvements, and optional voice/pronunciation aids.
+   - Gather feedback, polish accessibility, and iterate on high-contrast and keyboard flows.
+
+## Success Metrics
+- All subjects accessible with English guidance in ≤2 clicks.
+- ≥90% of Spanish resources include English summaries and glossary entries.
+- Dashboard highlights overdue assignments or labs at least 3 days in advance.
+- Flashcard completion rate improves by 20% thanks to cross-subject scheduling.
+
+## Risks & Mitigations
+- **Translation accuracy**: mitigate by allowing manual edits and flagging low-confidence segments.
+- **Content sprawl**: enforce tagging and metadata validation during imports.
+- **Performance**: lazy-load heavy PDFs and cache translation outputs per resource.
+- **User adoption**: provide onboarding tours showing how to manage subjects and switch languages.
+
+## Next Steps
+- Audit current `subjects/` folders, map contents to the new schema, and identify translation needs.
+- Prototype subject hub UI with existing data to validate navigation and performance.
+- Define integration strategy for translation services (API keys, rate limits, offline fallback).

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <title>Study Spanish</title>
+    <title>Study Compass</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,11 +1,11 @@
 {
-  "name": "Study Spanish Coach",
-  "short_name": "Spanish Coach",
+  "name": "Study Compass",
+  "short_name": "StudyCompass",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#111827",
   "theme_color": "#1d4ed8",
-  "description": "Offline-first Spanish lessons, analytics, and flashcards for B1–C1 learners.",
+  "description": "Offline-first bilingual study hub with subjects, labs, flashcards, and translation aids.",
   "icons": [
     {
       "src": "/icon.svg",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import FlashcardsPage from './pages/FlashcardsPage';
 import ContentManagerPage from './pages/ContentManagerPage';
 import { useHighContrast } from './hooks/useHighContrast';
 import AppShell from './components/layout/AppShell';
+import SubjectsPage from './pages/SubjectsPage';
 
 const App: React.FC = () => {
   const { enabled, toggle } = useHighContrast();
@@ -21,6 +22,7 @@ const App: React.FC = () => {
           <Route path="/" element={<HomePage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/flashcards" element={<FlashcardsPage />} />
+          <Route path="/subjects" element={<SubjectsPage />} />
           <Route path="/content-manager" element={<ContentManagerPage />} />
           <Route path="/lessons/:slug" element={<LessonPage />} />
           <Route

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -26,6 +26,12 @@ const navigation: NavigationItem[] = [
     exact: true,
   },
   {
+    to: '/subjects',
+    label: 'Subjects',
+    description: 'Courses, labs & translations',
+    icon: '📚',
+  },
+  {
     to: '/dashboard',
     label: 'Insights',
     description: 'Progress analytics',
@@ -71,8 +77,8 @@ export const AppShell: React.FC<AppShellProps> = ({
             SC
           </span>
           <span className={styles.brandText}>
-            <span className={styles.brandName}>Study Spanish Coach</span>
-            <span className={styles.brandTagline}>Plan · Practise · Shine</span>
+            <span className={styles.brandName}>Study Compass</span>
+            <span className={styles.brandTagline}>Plan · Translate · Excel</span>
           </span>
         </Link>
         <nav className={styles.nav} aria-label="Main sections">

--- a/src/data/subjectCatalog.ts
+++ b/src/data/subjectCatalog.ts
@@ -1,0 +1,1219 @@
+import { CourseItem, SubjectMetrics, SubjectSummary } from '../types/subject';
+
+const DAY_IN_MS = 86_400_000;
+const now = Date.now();
+const toIsoDate = (offsetDays: number) => new Date(now + offsetDays * DAY_IN_MS).toISOString();
+
+const withMinutes = (minutes: number) => minutes;
+
+export const subjectCatalog: SubjectSummary[] = [
+  {
+    id: 'sad',
+    slug: 'software-architecture-design',
+    name: 'Software Architecture & Design',
+    tagline: 'Translate microservices theory into resilient blueprints.',
+    description: {
+      en: 'Explore architectural styles, documentation assets, and scenario-driven evaluations with bilingual support for Spanish slide decks.',
+      es: 'Explora estilos arquitectónicos, documentación y evaluaciones guiadas por escenarios con apoyo bilingüe para las presentaciones en español.',
+    },
+    languageProfile: {
+      primary: 'es',
+      supportLevel: 'partial',
+      notes: 'Lecture decks are in Spanish; English-first briefs and key terminology lists are available for each session.',
+    },
+    credits: 6,
+    skills: ['architecture decision records', 'microservices', 'cloud strategy'],
+    focusAreas: ['design thinking', 'system reliability', 'governance'],
+    color: '#f97316',
+    reflectionPrompts: [
+      'How did the English outline help you justify the selected architecture pattern?',
+      'Which Spanish term caused friction and how will you memorise it?',
+    ],
+    courses: [
+      {
+        id: 'sad-teoria',
+        code: 'SAD-201',
+        title: 'Theory & Decision Frameworks',
+        description: 'Weekly lectures unpacking architecture drivers, trade-offs, and documentation patterns.',
+        modality: 'lecture',
+        schedule: 'Tuesdays 09:00 · Hybrid',
+        languageMix: ['es'],
+        focusAreas: ['ATAM', 'ADR writing'],
+        items: [
+          {
+            id: 'sad-lecture-foundations',
+            kind: 'lesson',
+            title: 'Introducción a arquitectura de software',
+            language: 'es',
+            summary: {
+              original: 'Panorama de estilos arquitectónicos, capas y tácticas de calidad.',
+              english: 'Overview of architectural styles, layered designs, and quality attribute tactics to watch.',
+            },
+            tags: ['architecture', 'theory'],
+            estimatedMinutes: withMinutes(90),
+            dueDate: toIsoDate(-3),
+            status: 'graded',
+            translation: {
+              status: 'complete',
+              summary: 'Read the English primer before reviewing Spanish slides to anchor vocabulary.',
+              glossary: ['arquitectura hexagonal', 'tácticas de calidad'],
+            },
+          },
+          {
+            id: 'sad-adr-workshop',
+            kind: 'assignment',
+            title: 'ADR: Arquitectura hexagonal vs. microservicios',
+            language: 'es',
+            summary: {
+              original: 'Redacta un ADR comparando arquitectura hexagonal y microservicios para un nuevo producto SaaS.',
+              english: 'Draft an ADR comparing hexagonal architecture and microservices for a new SaaS product.',
+            },
+            tags: ['architecture', 'writing', 'analysis'],
+            estimatedMinutes: withMinutes(120),
+            dueDate: toIsoDate(2),
+            status: 'in-progress',
+            translation: {
+              status: 'complete',
+              summary: 'Follow the supplied English template; keep Spanish keywords in the context section.',
+              glossary: ['puertos y adaptadores', 'dominio core'],
+            },
+          },
+          {
+            id: 'sad-review-questions',
+            kind: 'lesson',
+            title: 'Banco de preguntas: Tácticas de calidad',
+            language: 'es',
+            summary: {
+              original: 'Preguntas tipo examen enfocadas en atributos de calidad y riesgos.',
+              english: 'Exam-style prompts focusing on quality attributes and risk mitigation approaches.',
+            },
+            tags: ['revision', 'quality attributes'],
+            estimatedMinutes: withMinutes(45),
+            dueDate: toIsoDate(5),
+            status: 'scheduled',
+            translation: {
+              status: 'partial',
+              summary: 'Key questions have English hints; free-response rationales still need polishing.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'sad-teoria-cheat',
+            title: 'Architecture decision playbook',
+            language: 'en',
+            coverage: 'full-course',
+            description: 'Exhaustive bilingual outline covering every lecture and ADR exercise.',
+            englishSummary:
+              'Maps the full course into drivers, tactics, documentation assets, and evaluation loops so you can revise everything in English at a glance.',
+            spanishSummary:
+              'Incluye recordatorios en español de términos críticos y pasos para conectar teoría con las prácticas de decisión.',
+            sections: [
+              {
+                title: 'Architecture foundations & drivers',
+                bullets: [
+                  'Contrasta estilos en capas, hexagonal, microservicios y event-driven con sus atributos de calidad asociados.',
+                  'Lista impulsores de negocio, stakeholders y escenarios tácticos vinculados a métricas de valor.',
+                  'Plantilla ADR paso a paso con indicaciones bilingües para contexto, decisión, estado y consecuencias.',
+                ],
+              },
+              {
+                title: 'Quality tactics & documentation',
+                bullets: [
+                  'Resumen de tácticas de disponibilidad, rendimiento, seguridad y mantenibilidad con ejemplos de trade-offs.',
+                  'Guía para seleccionar viewpoints y construir mapas de capacidad alineados con las lecciones.',
+                  'Checklist para elaborar documentación liviana: diagramas C4, catálogos de decisiones y matrices RACI.',
+                ],
+              },
+              {
+                title: 'Evaluation workflows',
+                bullets: [
+                  'Secuencia completa del método ATAM con preguntas gatillo bilingües para cada fase.',
+                  'Tablas de priorización de escenarios y criterios de riesgo traducidos.',
+                  'Hoja de cálculo para puntuar opciones arquitectónicas con métricas cuantitativas y narrativas.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Repasa una sección antes de cada clase y subraya la terminología española que aún te cuesta.',
+              'Usa el checklist ADR para ensayar justificaciones en inglés antes de escribir la versión final en español.',
+              'Relaciona cada táctica con un sistema real de tu portafolio para reforzar la memoria a largo plazo.',
+            ],
+            downloadHint: 'Consulta docs/cheat-papers/sad-theory-cheat.md para la versión completa y exportable.',
+          },
+        ],
+      },
+      {
+        id: 'sad-practical',
+        code: 'SAD-241',
+        title: 'Practical Microservices Lab',
+        description: 'Hands-on labs configuring observability, resilience, and deployment topologies.',
+        modality: 'lab',
+        schedule: 'Thursdays 12:00 · On-campus',
+        languageMix: ['es', 'en'],
+        focusAreas: ['observability', 'documentation'],
+        items: [
+          {
+            id: 'sad-lab-monitoring',
+            kind: 'lab',
+            title: 'Laboratorio: Observabilidad en microservicios',
+            language: 'es',
+            summary: {
+              original: 'Instrumenta métricas, logs y traces para el sistema de pedidos.',
+              english: 'Instrument metrics, logs, and traces for the order management system.',
+            },
+            tags: ['observability', 'devops'],
+            estimatedMinutes: withMinutes(150),
+            dueDate: toIsoDate(-1),
+            status: 'submitted',
+            translation: {
+              status: 'machine',
+              summary: 'Machine-translated checklist verified for accuracy; screenshots still in Spanish.',
+              notes: 'Consider adding manual English captions for Grafana dashboards.',
+            },
+            lab: {
+              environment: 'Docker Compose stack with Jaeger and Prometheus',
+              checklists: [
+                'Configura exportadores en los servicios críticos.',
+                'Anota 3 hipótesis de fallo y captura evidencia.',
+                'Sube un ADR resumido en inglés.',
+              ],
+              deliverable: 'Zip con dashboards + ADR en doble idioma.',
+            },
+          },
+          {
+            id: 'sad-lab-resilience',
+            kind: 'lab',
+            title: 'Chaos engineering sprint',
+            language: 'en',
+            summary: {
+              original: 'Inject latency and failure into the payment gateway to validate fallbacks.',
+            },
+            tags: ['resilience', 'testing'],
+            estimatedMinutes: withMinutes(120),
+            dueDate: toIsoDate(6),
+            status: 'not-started',
+            translation: {
+              status: 'complete',
+              summary: 'Use the English runbook to brief Spanish-speaking teammates before executing failures.',
+            },
+            lab: {
+              environment: 'Kubernetes + Gremlin sandbox',
+              checklists: [
+                'Mapa dependencias y define umbrales críticos.',
+                'Programa tres experimentos y registra resultados.',
+              ],
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'sad-lab-cheat',
+            title: 'Microservices lab runbook',
+            language: 'en',
+            coverage: 'labs',
+            description: 'Single-page operational guide consolidating every lab step, checklist, and bilingual command reference.',
+            englishSummary:
+              'Covers environments, observability stack setup, resilience drills, and deployment workflows with English-first explanations.',
+            spanishSummary:
+              'Incluye comandos anotados en español para que puedas seguir cada laboratorio sin perder matices locales.',
+            sections: [
+              {
+                title: 'Environment & scaffolding',
+                bullets: [
+                  'Diagrama de servicios, colas y gateways con equivalentes de terminología en ambos idiomas.',
+                  'Guía de configuración de contenedores, variables y secretos compartidos.',
+                  'Plantilla de historias de usuario técnicas para preparar cada sprint de laboratorio.',
+                ],
+              },
+              {
+                title: 'Observability & resilience drills',
+                bullets: [
+                  'Pasos para instrumentar métricas, logs y traces con ejemplos de consultas listos.',
+                  'Procedimiento de chaos engineering con checklist de rollback bilingüe.',
+                  'Matriz de incidentes con niveles de severidad y playbooks de respuesta.',
+                ],
+              },
+              {
+                title: 'Deployment & documentation',
+                bullets: [
+                  'Pipeline CI/CD completo con puntos de control para revisiones en inglés.',
+                  'Checklist de pruebas de humo, contratos y documentación post-lanzamiento.',
+                  'Formato para reportar hallazgos y próximos pasos en español e inglés.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Simula cada laboratorio en seco usando la tabla de incidentes antes del día oficial.',
+              'Practica explicando en inglés cada métrica de observabilidad a un compañero.',
+              'Documenta ajustes de infraestructura en español para reforzar vocabulario técnico.',
+            ],
+            downloadHint: 'Disponible en docs/cheat-papers/sad-lab-cheat.md con enlaces a scripts auxiliares.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ggo',
+    slug: 'it-governance',
+    name: 'Gobierno de TI',
+    tagline: 'Align technology portfolios with executive strategy.',
+    description: {
+      en: 'Bridge Spanish governance frameworks with English executive summaries and stakeholder templates.',
+      es: 'Conecta los marcos de gobierno de TI con plantillas ejecutivas en inglés.',
+    },
+    languageProfile: {
+      primary: 'es',
+      supportLevel: 'partial',
+      notes: 'Spanish readings with concise English briefs and bilingual stakeholder canvases.',
+    },
+    credits: 5,
+    skills: ['stakeholder mapping', 'value management', 'strategic alignment'],
+    focusAreas: ['COBIT', 'risk management', 'business alignment'],
+    color: '#22d3ee',
+    reflectionPrompts: [
+      'Which stakeholder insight surprised you when drafting the bilingual executive memo?',
+      'How confident are you presenting the value map in English?',
+    ],
+    courses: [
+      {
+        id: 'ggo-intro',
+        code: 'GGO-101',
+        title: 'Introducción al gobierno de TI',
+        description: 'Foundational lectures covering COBIT principles, value delivery, and performance metrics.',
+        modality: 'lecture',
+        schedule: 'Mondays 15:00 · In-person',
+        languageMix: ['es'],
+        focusAreas: ['COBIT', 'value delivery'],
+        items: [
+          {
+            id: 'ggo-reading-cobit',
+            kind: 'reading',
+            title: 'Lectura: Marco COBIT 2019',
+            language: 'es',
+            summary: {
+              original: 'Resumen de dominios, factores de diseño y metas alineadas a COBIT 2019.',
+              english: 'Digest of COBIT 2019 domains, design factors, and governance objectives.',
+            },
+            tags: ['governance', 'frameworks'],
+            estimatedMinutes: withMinutes(80),
+            dueDate: toIsoDate(1),
+            status: 'in-progress',
+            translation: {
+              status: 'partial',
+              summary: 'English highlights for each governance objective; need glossary for acronyms.',
+            },
+          },
+          {
+            id: 'ggo-executive-brief',
+            kind: 'assignment',
+            title: 'Executive brief: Valor de TI',
+            language: 'es',
+            summary: {
+              original: 'Elabora un memo ejecutivo que justifique la inversión en un nuevo sistema ERP.',
+              english: 'Write an executive memo justifying investment in a new ERP system.',
+            },
+            tags: ['writing', 'strategy'],
+            estimatedMinutes: withMinutes(90),
+            dueDate: toIsoDate(4),
+            status: 'not-started',
+            translation: {
+              status: 'complete',
+              summary: 'Use the English memo template and translate key KPIs back to Spanish for the appendix.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'ggo-intro-cheat',
+            title: 'Governance executive cheat paper',
+            language: 'en',
+            coverage: 'full-course',
+            description: 'Full-stack summary of COBIT, value delivery, and performance domains with bilingual scorecards.',
+            englishSummary:
+              'Covers every lecture outcome in memo-ready English so you can brief executives without re-reading Spanish slides.',
+            spanishSummary:
+              'Contiene traducciones clave al español para conservar el matiz de los marcos regulatorios.',
+            sections: [
+              {
+                title: 'COBIT 2019 essentials',
+                bullets: [
+                  'Resumen de principios, objetivos de gobierno y factores de diseño con tablas bilingües.',
+                  'Mapa de metas en cascada y ejemplos de métricas alineadas a cada dominio.',
+                  'Glosario de procesos EDM/APO/BAI/DSS/MEA con equivalencias ejecutivas.',
+                ],
+              },
+              {
+                title: 'Value delivery & performance',
+                bullets: [
+                  'Matrices de beneficios, riesgos y costos traducidas para memorandos rápidos.',
+                  'Plantilla de cuadro de mando integral con KPI en ambos idiomas.',
+                  'Checklist para evaluar madurez y justificar inversiones ERP en minutos.',
+                ],
+              },
+              {
+                title: 'Stakeholder communication',
+                bullets: [
+                  'Guía para construir mapas de poder/interés y canales de comunicación.',
+                  'Scripts breves en inglés para responder preguntas frecuentes en comités.',
+                  'Lista de verificación de entregables por audiencia (CEO, CFO, PMO).',
+                ],
+              },
+            ],
+            studyTips: [
+              'Practica cada script frente a un espejo para ganar fluidez en inglés ejecutivo.',
+              'Actualiza el cuadro de mando con ejemplos reales de tu empresa para afianzar conceptos.',
+              'Comparte el glosario con tus compañeros para validar traducciones clave.',
+            ],
+            downloadHint: 'Disponible en docs/cheat-papers/ggo-intro-cheat.md con plantillas reutilizables.',
+          },
+        ],
+      },
+      {
+        id: 'ggo-workshop',
+        code: 'GGO-205',
+        title: 'Stakeholder Workshops',
+        description: 'Interactive labs mapping stakeholders and quantifying IT-business alignment.',
+        modality: 'lab',
+        schedule: 'Wednesdays 17:00 · Workshop',
+        languageMix: ['es', 'en'],
+        focusAreas: ['stakeholder alignment', 'facilitation'],
+        items: [
+          {
+            id: 'ggo-lab-bedell',
+            kind: 'lab',
+            title: 'Método Bedell para alineación negocio-TI',
+            language: 'es',
+            summary: {
+              original: 'Aplica el método Bedell para evaluar el impacto del sistema de información propuesto.',
+              english: 'Apply the Bedell method to evaluate the impact of the proposed information system.',
+            },
+            tags: ['analysis', 'value'],
+            estimatedMinutes: withMinutes(110),
+            dueDate: toIsoDate(-5),
+            status: 'submitted',
+            translation: {
+              status: 'machine',
+              summary: 'Rough English translation of the scoring sheet; facilitator notes remain in Spanish.',
+              notes: 'Schedule time to refine facilitator instructions.',
+            },
+            lab: {
+              environment: 'Stakeholder canvas template (Miro) bilingual',
+              checklists: [
+                'Identifica stakeholders clave y pondera influencia.',
+                'Evalúa impacto del sistema propuesto en 3 horizontes.',
+                'Prepara una síntesis de riesgos en inglés.',
+              ],
+            },
+          },
+          {
+            id: 'ggo-lab-stakeholder-map',
+            kind: 'project',
+            title: 'Stakeholder map & translation clinic',
+            language: 'en',
+            summary: {
+              original: 'Deliver stakeholder analysis slides in English with annotated Spanish glossary.',
+            },
+            tags: ['presentation', 'bilingual'],
+            estimatedMinutes: withMinutes(100),
+            dueDate: toIsoDate(8),
+            status: 'scheduled',
+            translation: {
+              status: 'complete',
+              summary: 'Slides already in English; maintain glossary for Spanish delivery.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'ggo-workshop-cheat',
+            title: 'Stakeholder facilitation blueprint',
+            language: 'en',
+            coverage: 'labs',
+            description: 'Minute-by-minute facilitation script with bilingual prompts, scoring rubrics, and follow-up templates.',
+            englishSummary:
+              'Bundles alignment canvases, Bedell scoring tables, and translation clinics so you can run every workshop confidently in English.',
+            spanishSummary:
+              'Incorpora instrucciones en español para explicar dinámicas sin perder claridad.',
+            sections: [
+              {
+                title: 'Workshop setup',
+                bullets: [
+                  'Checklist previo: objetivos, agenda y materiales con traducción.',
+                  'Plantillas de canvas y scoring listos para imprimir o compartir en Miro.',
+                  'Lista de stakeholders sugeridos y roles durante las dinámicas.',
+                ],
+              },
+              {
+                title: 'Execution scripts',
+                bullets: [
+                  'Guión bilingüe para abrir sesiones, explicar Bedell y moderar debates.',
+                  'Banco de preguntas para descubrir dolor de negocio y medir alineación.',
+                  'Tablas para registrar puntajes y acuerdos inmediatos.',
+                ],
+              },
+              {
+                title: 'Follow-up & translation clinic',
+                bullets: [
+                  'Plantilla de acta en inglés con glosario español adjunto.',
+                  'Checklist de compromisos, riesgos y responsables post taller.',
+                  'Guía rápida para preparar mapas visuales bilingües.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Haz role-play de cada sección con compañeros para ganar confianza.',
+              'Cronometra cada bloque usando la guía minuto a minuto para evitar retrasos.',
+              'Resalta términos difíciles en la clínica de traducción para repasarlos luego.',
+            ],
+            downloadHint: 'Consulta docs/cheat-papers/ggo-workshop-cheat.md con enlaces a canvas editables.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'dbd',
+    slug: 'database-design',
+    name: 'Diseño de Bases de Datos',
+    tagline: 'Design bilingual schemas and optimise SQL workflow.',
+    description: {
+      en: 'Solidify relational modelling concepts with English walkthroughs for Spanish lab guides.',
+      es: 'Consolida el modelado relacional con guías en español y explicaciones en inglés.',
+    },
+    languageProfile: {
+      primary: 'es',
+      supportLevel: 'complete',
+      notes: 'Every lab includes English instructions, ERD terminology, and bilingual SQL comments.',
+    },
+    credits: 4,
+    skills: ['normalisation', 'SQL optimisation', 'data modelling'],
+    focusAreas: ['database design', 'queries'],
+    color: '#38bdf8',
+    reflectionPrompts: [
+      'Which Spanish database term still needs an English cue?',
+      'How can you reuse the English ERD legend for the next project?',
+    ],
+    courses: [
+      {
+        id: 'dbd-lecture',
+        code: 'DBD-110',
+        title: 'Modelado relacional',
+        description: 'Lectures and guided practice around conceptual, logical, and physical design.',
+        modality: 'lecture',
+        schedule: 'Fridays 10:00 · Hybrid',
+        languageMix: ['es'],
+        focusAreas: ['normalisation', 'constraints'],
+        items: [
+          {
+            id: 'dbd-erd-lesson',
+            kind: 'lesson',
+            title: 'Caso estudio: Biblioteca universitaria',
+            language: 'es',
+            summary: {
+              original: 'Modela entidades y relaciones para la biblioteca, incluyendo préstamos y multas.',
+              english: 'Model the library ERD with loans, fines, and bilingual attribute naming tips.',
+            },
+            tags: ['erd', 'case study'],
+            estimatedMinutes: withMinutes(70),
+            dueDate: toIsoDate(3),
+            status: 'in-progress',
+            translation: {
+              status: 'complete',
+              summary: 'Use the English checklist before switching to the Spanish modelling worksheet.',
+            },
+          },
+          {
+            id: 'dbd-quiz-normalisation',
+            kind: 'assignment',
+            title: 'Quiz: Formas normales',
+            language: 'es',
+            summary: {
+              original: 'Evalúa tu dominio de 1FN-3FN y BCNF.',
+              english: 'Assess your mastery of 1NF-3NF and BCNF with bilingual answer keys.',
+            },
+            tags: ['quiz', 'normalisation'],
+            estimatedMinutes: withMinutes(35),
+            dueDate: toIsoDate(-2),
+            status: 'graded',
+            translation: {
+              status: 'complete',
+              summary: 'Answer key includes English explanations for each violation.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'dbd-lecture-cheat',
+            title: 'Relational modelling master sheet',
+            language: 'en',
+            coverage: 'full-course',
+            description: 'Complete ERD, normalisation, and constraint reference with bilingual annotations.',
+            englishSummary:
+              'Summarises conceptual through physical design, normal forms, and SQL integrity rules for fast English revision.',
+            spanishSummary:
+              'Incluye cuadros de equivalencias en español para vocabulario de entidades, atributos y restricciones.',
+            sections: [
+              {
+                title: 'Conceptual & logical design',
+                bullets: [
+                  'Pasos para levantar requisitos, identificar entidades y relaciones cardinales.',
+                  'Patrones para modelar jerarquías, asociaciones débiles y multivaluados.',
+                  'Guía para transformar modelos conceptuales en esquemas lógicos bilingües.',
+                ],
+              },
+              {
+                title: 'Normalisation toolkit',
+                bullets: [
+                  'Tabla comparativa de 1FN a BCNF con ejemplos ilustrativos.',
+                  'Procedimiento para detectar dependencias funcionales y multivaluadas.',
+                  'Checklist de síntomas de denormalización aceptable para rendimiento.',
+                ],
+              },
+              {
+                title: 'Constraints & SQL patterns',
+                bullets: [
+                  'Listado bilingüe de constraints (PK, FK, CHECK, UNIQUE) con sintaxis.',
+                  'Snippets SQL comentados para triggers, vistas y reglas de negocio.',
+                  'Preguntas frecuentes de examen con respuestas explicadas.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Redibuja el ERD de ejemplo usando la nomenclatura inglesa para memorizar términos.',
+              'Practica detectar dependencias funcionales con los casos resueltos.',
+              'Enseña a un compañero la sección de constraints para consolidar tu dominio.',
+            ],
+            downloadHint: 'Ubica el resumen extendido en docs/cheat-papers/dbd-lecture-cheat.md.',
+          },
+        ],
+      },
+      {
+        id: 'dbd-lab',
+        code: 'DBD-204',
+        title: 'Laboratorio SQL Performance',
+        description: 'Practical lab to optimise SQL queries with bilingual documentation.',
+        modality: 'lab',
+        schedule: 'Thursdays 18:00 · Online',
+        languageMix: ['es', 'en'],
+        focusAreas: ['query tuning', 'indexing'],
+        items: [
+          {
+            id: 'dbd-lab-indexing',
+            kind: 'lab',
+            title: 'Optimización de consultas con índices',
+            language: 'es',
+            summary: {
+              original: 'Mide el impacto de índices compuestos en consultas críticas.',
+              english: 'Measure the impact of composite indexes on critical queries.',
+            },
+            tags: ['sql', 'performance'],
+            estimatedMinutes: withMinutes(120),
+            dueDate: toIsoDate(7),
+            status: 'scheduled',
+            translation: {
+              status: 'complete',
+              summary: 'Step-by-step English lab instructions with cross-referenced Spanish screenshots.',
+            },
+            lab: {
+              environment: 'PostgreSQL 15 + pg_stat_statements',
+              checklists: [
+                'Captura plan de ejecución base.',
+                'Aplica índices propuestos y compara métricas.',
+                'Escribe conclusiones en ambos idiomas.',
+              ],
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'dbd-lab-cheat',
+            title: 'SQL performance war room sheet',
+            language: 'en',
+            coverage: 'labs',
+            description: 'Step-by-step bilingual lab manual consolidating every optimisation drill and measurement table.',
+            englishSummary:
+              'Walks through indexing strategy, query plans, benchmarking, and reporting so you can execute labs without flipping notes.',
+            spanishSummary:
+              'Describe métricas clave y comandos en español para seguir el laboratorio al pie de la letra.',
+            sections: [
+              {
+                title: 'Preparation & baselines',
+                bullets: [
+                  'Checklist para clonar base de datos, poblarla y capturar planes iniciales.',
+                  'Tabla de métricas (tiempo, buffers, CPU) con traducción.',
+                  'Guía para habilitar pg_stat_statements y registrar resultados.',
+                ],
+              },
+              {
+                title: 'Indexing & tuning drills',
+                bullets: [
+                  'Recetario de índices simples, compuestos y parciales con ejemplos.',
+                  'Secuencia para analizar EXPLAIN/ANALYZE y detectar cuellos de botella.',
+                  'Tips para reescribir consultas y usar CTEs o particiones.',
+                ],
+              },
+              {
+                title: 'Reporting & bilingual delivery',
+                bullets: [
+                  'Formato de informe con tablas comparativas antes/después.',
+                  'Guión en inglés para presentar hallazgos a profesores o stakeholders.',
+                  'Checklist para documentar aprendizajes en español dentro del repositorio.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Cronometra cada experimento y anota observaciones en ambos idiomas.',
+              'Ejecuta las consultas del recetario en un entorno limpio antes del laboratorio real.',
+              'Practica explicar cada mejora de rendimiento con el guión incluido.',
+            ],
+            downloadHint: 'Manual detallado disponible en docs/cheat-papers/dbd-lab-cheat.md.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'snlp',
+    slug: 'statistical-nlp',
+    name: 'Statistical NLP',
+    tagline: 'Blend English theory with Spanish corpora experiments.',
+    description: {
+      en: 'Balance English research papers with Spanish corpora labs and translation cheat-sheets.',
+      es: 'Equilibra artículos de investigación en inglés con laboratorios de corpus en español.',
+    },
+    languageProfile: {
+      primary: 'en',
+      supportLevel: 'partial',
+      notes: 'Most lectures are in English; lab rubrics include Spanish clarifications for datasets.',
+    },
+    credits: 5,
+    skills: ['language modelling', 'evaluation metrics', 'data wrangling'],
+    focusAreas: ['N-grams', 'neural language models', 'evaluation'],
+    color: '#a855f7',
+    reflectionPrompts: [
+      'Which Spanish annotations posed evaluation issues and how did you resolve them?',
+      'Summarise today’s paper in Spanish to reinforce comprehension.',
+    ],
+    courses: [
+      {
+        id: 'snlp-lecture',
+        code: 'SNLP-320',
+        title: 'Probabilistic Foundations',
+        description: 'Lectures covering N-gram models, smoothing, and evaluation metrics.',
+        modality: 'lecture',
+        schedule: 'Tuesdays 14:00 · Online',
+        languageMix: ['en'],
+        focusAreas: ['probability', 'evaluation'],
+        items: [
+          {
+            id: 'snlp-lesson-smoothing',
+            kind: 'lesson',
+            title: 'Lecture: Kneser-Ney smoothing',
+            language: 'en',
+            summary: {
+              original: 'Deep dive into absolute discounting and interpolated Kneser-Ney.',
+              english: 'Deep dive into absolute discounting and interpolated Kneser-Ney.',
+            },
+            tags: ['theory', 'probability'],
+            estimatedMinutes: withMinutes(80),
+            dueDate: toIsoDate(-4),
+            status: 'graded',
+            translation: {
+              status: 'planned',
+              summary: 'Spanish crib sheet pending for smoothing terminology.',
+            },
+          },
+          {
+            id: 'snlp-reading-mt',
+            kind: 'reading',
+            title: 'Paper: Statistical MT with sparse features',
+            language: 'en',
+            summary: {
+              original: 'Research paper on sparse feature integration for phrase-based MT.',
+              english: 'Research paper on sparse feature integration for phrase-based MT.',
+            },
+            tags: ['research', 'machine translation'],
+            estimatedMinutes: withMinutes(95),
+            dueDate: toIsoDate(2),
+            status: 'in-progress',
+            translation: {
+              status: 'partial',
+              summary: 'Spanish abstract provided; figure captions pending translation.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'snlp-lecture-cheat',
+            title: 'Probabilistic NLP mega summary',
+            language: 'en',
+            coverage: 'full-course',
+            description: 'Complete rundown of N-gram theory, smoothing, evaluation, and translation models with bilingual cues.',
+            englishSummary:
+              'Condenses every lecture into digestible formulas, diagrams, and evaluation workflows written in English.',
+            spanishSummary:
+              'Resalta equivalencias en español para métricas, términos estadísticos y pasos de derivación.',
+            sections: [
+              {
+                title: 'N-gram modelling fundamentals',
+                bullets: [
+                  'Definiciones clave, supuestos de Markov y cálculo de probabilidades con ejemplos anotados.',
+                  'Tabla comparativa de smoothing (Laplace, Good-Turing, Kneser-Ney) con intuiciones bilingües.',
+                  'Notas sobre perplexity, cross-entropy y ajuste de parámetros.',
+                ],
+              },
+              {
+                title: 'Machine translation & sequence models',
+                bullets: [
+                  'Resumen de modelos IBM, alineamientos y decoding beam search.',
+                  'Guía para integrar sparse features y optimización discriminativa.',
+                  'Tabla de comparación entre modelos estadísticos y neurales.',
+                ],
+              },
+              {
+                title: 'Evaluation & error analysis',
+                bullets: [
+                  'Checklist para calcular BLEU, METEOR y métricas humanas.',
+                  'Plantilla de matriz de errores con categorías bilingües.',
+                  'Pasos para elaborar resúmenes en español de papers ingleses.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Repite las derivaciones con la sección de fórmulas hasta poder explicarlas sin guion.',
+              'Traduce al español cada término complejo y agrega ejemplos propios.',
+              'Usa la matriz de errores para analizar tus prácticas y reforzar vocabulario.',
+            ],
+            downloadHint: 'Encuentra el resumen completo en docs/cheat-papers/snlp-lecture-cheat.md.',
+          },
+        ],
+      },
+      {
+        id: 'snlp-lab',
+        code: 'SNLP-360',
+        title: 'Corpus Labs',
+        description: 'Weekly labs experimenting with Spanish corpora and bilingual evaluation.',
+        modality: 'lab',
+        schedule: 'Fridays 11:00 · Lab',
+        languageMix: ['en', 'es'],
+        focusAreas: ['data prep', 'evaluation'],
+        items: [
+          {
+            id: 'snlp-lab-ner',
+            kind: 'lab',
+            title: 'Lab: Named Entity Recognition en corpus español',
+            language: 'es',
+            summary: {
+              original: 'Entrena y evalúa modelos NER sobre el corpus AnCora.',
+              english: 'Train and evaluate NER models on the AnCora corpus.',
+            },
+            tags: ['ner', 'python'],
+            estimatedMinutes: withMinutes(140),
+            dueDate: toIsoDate(0),
+            status: 'in-progress',
+            translation: {
+              status: 'partial',
+              summary: 'English lab notebook provided; dataset instructions remain in Spanish.',
+            },
+            lab: {
+              environment: 'Google Colab + spaCy',
+              checklists: [
+                'Configura entorno bilingüe con comentarios en inglés/español.',
+                'Evalúa F1 y analiza errores con notas bilingües.',
+              ],
+            },
+          },
+          {
+            id: 'snlp-project-poster',
+            kind: 'project',
+            title: 'Poster project: Bias in language models',
+            language: 'en',
+            summary: {
+              original: 'Prepare a bilingual poster discussing bias metrics on Spanish benchmarks.',
+            },
+            tags: ['research', 'presentation'],
+            estimatedMinutes: withMinutes(200),
+            dueDate: toIsoDate(12),
+            status: 'scheduled',
+            translation: {
+              status: 'complete',
+              summary: 'Poster template includes Spanish captions and English narrative.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'snlp-lab-cheat',
+            title: 'Corpus experimentation field guide',
+            language: 'en',
+            coverage: 'labs',
+            description: 'Hands-on bilingual lab reference covering setup, modelling, evaluation, and reporting for every corpus activity.',
+            englishSummary:
+              'Walks through preprocessing, training loops, evaluation checkpoints, and reporting expectations for all labs.',
+            spanishSummary:
+              'Incluye instrucciones específicas en español para manipular corpus y documentar hallazgos.',
+            sections: [
+              {
+                title: 'Environment prep & datasets',
+                bullets: [
+                  'Checklist de configuración en Colab y requisitos de librerías.',
+                  'Guía para descargar y explorar AnCora, Europarl y corpus complementarios.',
+                  'Plantillas de notas bilingües para registrar observaciones de datos.',
+                ],
+              },
+              {
+                title: 'Model training routines',
+                bullets: [
+                  'Secuencia para entrenar NER, POS tagging y lenguaje con spaCy/HF.',
+                  'Consejos de hiperparámetros con traducción y rangos recomendados.',
+                  'Scripts listos para experimentos con seguimiento de semillas.',
+                ],
+              },
+              {
+                title: 'Evaluation & reporting',
+                bullets: [
+                  'Checklist de métricas (precision, recall, F1) y visualizaciones sugeridas.',
+                  'Guía bilingüe para análisis de error y redacción de conclusiones.',
+                  'Formato de póster y entregables con secciones en inglés y español.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Documenta cada experimento en la plantilla de notas para detectar patrones rápidamente.',
+              'Practica presentar resultados en inglés y luego traduce los insights clave al español.',
+              'Repite experimentos con variaciones mínimas para dominar el flujo de trabajo.',
+            ],
+            downloadHint: 'Disponible en docs/cheat-papers/snlp-lab-cheat.md listo para imprimir.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'admeav',
+    slug: 'advanced-machine-learning',
+    name: 'Advanced Machine Learning',
+    tagline: 'Synthesize machine learning theory across languages.',
+    description: {
+      en: 'Combine English-heavy research seminars with Spanish implementation clinics and bilingual glossaries.',
+      es: 'Combina seminarios de investigación en inglés con clínicas de implementación en español y glosarios bilingües.',
+    },
+    languageProfile: {
+      primary: 'en',
+      supportLevel: 'partial',
+      notes: 'Seminars in English; lab notebooks provide Spanish callouts for tricky proofs.',
+    },
+    credits: 6,
+    skills: ['bayesian inference', 'optimisation', 'ml ops'],
+    focusAreas: ['probabilistic modelling', 'ethics', 'deployment'],
+    color: '#facc15',
+    reflectionPrompts: [
+      'Explain the latest seminar topic in Spanish to ensure cross-language retention.',
+      'Log a vocabulary pair for each confusing Spanish technical term.',
+    ],
+    courses: [
+      {
+        id: 'admeav-seminar',
+        code: 'ADML-401',
+        title: 'Research Seminar Series',
+        description: 'Weekly research paper discussions with bilingual recap sheets.',
+        modality: 'seminar',
+        schedule: 'Thursdays 08:00 · Hybrid',
+        languageMix: ['en'],
+        focusAreas: ['bayesian inference', 'causality'],
+        items: [
+          {
+            id: 'admeav-paper-gaussian',
+            kind: 'reading',
+            title: 'Paper: Gaussian Processes with Constraints',
+            language: 'en',
+            summary: {
+              original: 'Review constrained Gaussian Process inference and sparse approximations.',
+            },
+            tags: ['research', 'gaussian processes'],
+            estimatedMinutes: withMinutes(110),
+            dueDate: toIsoDate(-6),
+            status: 'graded',
+            translation: {
+              status: 'partial',
+              summary: 'Spanish annotations cover figures; need translation for appendix proofs.',
+            },
+          },
+          {
+            id: 'admeav-seminar-dl',
+            kind: 'lesson',
+            title: 'Seminar: Continual learning debate',
+            language: 'en',
+            summary: {
+              original: 'Panel discussion on catastrophic forgetting mitigation strategies.',
+            },
+            tags: ['discussion', 'continual learning'],
+            estimatedMinutes: withMinutes(75),
+            dueDate: toIsoDate(1),
+            status: 'scheduled',
+            translation: {
+              status: 'planned',
+              summary: 'Spanish recap sheet scheduled after the live debate.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'admeav-seminar-cheat',
+            title: 'Advanced ML seminar digest',
+            language: 'en',
+            coverage: 'full-course',
+            description: 'Comprehensive recap of every seminar paper, debate theme, and bilingual vocabulary list.',
+            englishSummary:
+              'Distills key theorems, experiment takeaways, and discussion prompts so you can brief the cohort in English quickly.',
+            spanishSummary:
+              'Ofrece resúmenes ejecutivos en español para explicar los conceptos complejos tras cada sesión.',
+            sections: [
+              {
+                title: 'Gaussian processes & Bayesian inference',
+                bullets: [
+                  'Notas sobre kernels, inducción escasa y restricciones con ejemplos numéricos.',
+                  'Guía para derivar funciones de covarianza y explicar su intuición en español.',
+                  'Checklist de preguntas para dirigir debates sobre aproximaciones y trade-offs.',
+                ],
+              },
+              {
+                title: 'Continual learning & ethics',
+                bullets: [
+                  'Resumen bilingüe de métodos contra el olvido catastrófico (regularización, rehearsal, arquitectura).',
+                  'Lista de pros/contras para comparar papers recientes.',
+                  'Plantilla de discusión ética con prompts sobre sesgos, transparencia y responsabilidad.',
+                ],
+              },
+              {
+                title: 'Seminar facilitation toolkit',
+                bullets: [
+                  'Cronograma sugerido para presentaciones y paneles.',
+                  'Banco de preguntas rápidas en inglés/español para dinamizar Q&A.',
+                  'Checklist de entregables post-seminario (resumen, glosario, acciones).',
+                ],
+              },
+            ],
+            studyTips: [
+              'Redacta un mini brief en inglés después de cada lectura usando la plantilla incluida.',
+              'Traduce al español los conceptos más complejos para verificar comprensión.',
+              'Graba tu intervención de debate y evalúa fluidez con el banco de preguntas.',
+            ],
+            downloadHint: 'Consulta docs/cheat-papers/admeav-seminar-cheat.md para la versión completa.',
+          },
+        ],
+      },
+      {
+        id: 'admeav-lab',
+        code: 'ADML-455',
+        title: 'MLOps Implementation Clinics',
+        description: 'Apply research ideas to bilingual ML pipelines with fairness tracking.',
+        modality: 'lab',
+        schedule: 'Saturdays 09:00 · Lab',
+        languageMix: ['en', 'es'],
+        focusAreas: ['ml ops', 'ethics'],
+        items: [
+          {
+            id: 'admeav-lab-monitoring',
+            kind: 'lab',
+            title: 'Lab: Monitorización de modelos bilingües',
+            language: 'es',
+            summary: {
+              original: 'Configura monitoreo para drift lingüístico en modelos desplegados.',
+              english: 'Configure monitoring for linguistic drift in deployed models.',
+            },
+            tags: ['ml ops', 'monitoring'],
+            estimatedMinutes: withMinutes(160),
+            dueDate: toIsoDate(9),
+            status: 'not-started',
+            translation: {
+              status: 'partial',
+              summary: 'English runbook available; dashboards still annotated in Spanish.',
+            },
+            lab: {
+              environment: 'MLflow + Evidently + FastAPI',
+              checklists: [
+                'Define métricas de drift en ambos idiomas.',
+                'Configura alertas y documenta respuestas en inglés.',
+              ],
+            },
+          },
+          {
+            id: 'admeav-project-ethics',
+            kind: 'project',
+            title: 'Capstone: Ethical deployment playbook',
+            language: 'en',
+            summary: {
+              original: 'Draft a bilingual playbook for deploying ML services ethically.',
+            },
+            tags: ['ethics', 'project'],
+            estimatedMinutes: withMinutes(210),
+            dueDate: toIsoDate(14),
+            status: 'scheduled',
+            translation: {
+              status: 'complete',
+              summary: 'Template includes Spanish action cards and English executive summary.',
+            },
+          },
+        ],
+        cheatPapers: [
+          {
+            id: 'admeav-lab-cheat',
+            title: 'Bilingual MLOps implementation dossier',
+            language: 'en',
+            coverage: 'labs',
+            description: 'End-to-end operational dossier with bilingual runbooks, fairness checkpoints, and deployment rituals.',
+            englishSummary:
+              'Consolidates monitoring recipes, deployment scripts, and ethical guardrails in English so you can run clinics smoothly.',
+            spanishSummary:
+              'Incluye anotaciones en español para explicar configuraciones y métricas a equipos locales.',
+            sections: [
+              {
+                title: 'Pipeline setup & automation',
+                bullets: [
+                  'Checklist de infraestructura (repos, CI/CD, contenedores) con pasos bilingües.',
+                  'Guía para parametrizar experimentos en MLflow y sincronizar con Evidently.',
+                  'Tabla de responsabilidades RACI para equipo técnico y stakeholders.',
+                ],
+              },
+              {
+                title: 'Monitoring & drift response',
+                bullets: [
+                  'Procedimientos para configurar métricas de drift lingüístico y alertas automáticas.',
+                  'Playbook de respuesta con escenarios comunes y acciones recomendadas.',
+                  'Formato de bitácora bilingüe para incidentes y aprendizajes.',
+                ],
+              },
+              {
+                title: 'Ethical deployment playbook',
+                bullets: [
+                  'Lista de chequeo de fairness, privacidad y explicabilidad.',
+                  'Guía para preparar briefing ejecutivo bilingüe previo a producción.',
+                  'Plantilla de tablero de control con indicadores técnicos y de impacto social.',
+                ],
+              },
+            ],
+            studyTips: [
+              'Ensaya la ejecución del runbook antes de cada clínica y ajusta tiempos.',
+              'Comparte el tablero de control con mentores para recibir retroalimentación temprana.',
+              'Convierte las anotaciones españolas en tarjetas de memoria para reforzar vocabulario.',
+            ],
+            downloadHint: 'Versión extendida guardada en docs/cheat-papers/admeav-lab-cheat.md.',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const flattenItems = (subject: SubjectSummary): CourseItem[] =>
+  subject.courses.flatMap((course) => course.items);
+
+const isDueWithin = (item: CourseItem, days: number) => {
+  if (!item.dueDate) return false;
+  const dueTime = new Date(item.dueDate).getTime();
+  if (Number.isNaN(dueTime)) return false;
+  const nowTime = Date.now();
+  return dueTime >= nowTime && dueTime <= nowTime + days * DAY_IN_MS;
+};
+
+const isOverdue = (item: CourseItem) => {
+  if (!item.dueDate) return false;
+  const dueTime = new Date(item.dueDate).getTime();
+  if (Number.isNaN(dueTime)) return false;
+  return dueTime < Date.now();
+};
+
+export const computeSubjectMetrics = (subject: SubjectSummary): SubjectMetrics => {
+  const items = flattenItems(subject);
+  const totalItems = items.length;
+  const assignments = items.filter((item) => item.kind === 'assignment' || item.kind === 'project').length;
+  const labs = items.filter((item) => item.kind === 'lab').length;
+  const englishReady = items.filter(
+    (item) => item.language === 'en' || item.translation?.status === 'complete' || item.translation?.status === 'partial'
+  ).length;
+  const spanishOnly = items.filter((item) => item.language === 'es' && !item.translation).length;
+  const translationCoverage = totalItems === 0 ? 0 : englishReady / totalItems;
+  const upcoming = items.filter((item) => isDueWithin(item, 7));
+  const overdue = items.filter((item) => isOverdue(item) && item.status !== 'graded');
+
+  return {
+    subject,
+    totalItems,
+    assignments,
+    labs,
+    translationCoverage,
+    englishReady,
+    spanishOnly,
+    upcoming,
+    overdue,
+  };
+};
+
+export const computeCatalogInsights = (catalog: SubjectSummary[]) => {
+  const metrics = catalog.map((subject) => computeSubjectMetrics(subject));
+  const totals = metrics.reduce(
+    (acc, entry) => {
+      acc.items += entry.totalItems;
+      acc.assignments += entry.assignments;
+      acc.labs += entry.labs;
+      acc.englishReady += entry.englishReady;
+      acc.spanishOnly += entry.spanishOnly;
+      acc.subjects += 1;
+      acc.overdue += entry.overdue.length;
+      acc.upcoming += entry.upcoming.length;
+      return acc;
+    },
+    {
+      subjects: 0,
+      items: 0,
+      assignments: 0,
+      labs: 0,
+      englishReady: 0,
+      spanishOnly: 0,
+      overdue: 0,
+      upcoming: 0,
+    }
+  );
+
+  const translationCoverage = totals.items === 0 ? 0 : totals.englishReady / totals.items;
+
+  return { metrics, totals: { ...totals, translationCoverage } };
+};
+
+export const getUpcomingSubjectFocus = (catalog: SubjectSummary[], windowDays = 5) => {
+  const focusPool = catalog
+    .flatMap((subject) =>
+      flattenItems(subject).map((item) => ({
+        subject,
+        item,
+      }))
+    )
+    .filter(({ item }) => isDueWithin(item, windowDays) || (item.dueDate && isOverdue(item)));
+
+  if (focusPool.length === 0) {
+    return undefined;
+  }
+
+  focusPool.sort((a, b) => {
+    const dueA = a.item.dueDate ? new Date(a.item.dueDate).getTime() : Number.POSITIVE_INFINITY;
+    const dueB = b.item.dueDate ? new Date(b.item.dueDate).getTime() : Number.POSITIVE_INFINITY;
+    return dueA - dueB;
+  });
+
+  const pick = focusPool[0];
+  const dueDate = pick.item.dueDate ? new Date(pick.item.dueDate) : undefined;
+  return {
+    subjectId: pick.subject.id,
+    subjectName: pick.subject.name,
+    subjectSlug: pick.subject.slug,
+    itemId: pick.item.id,
+    itemTitle: pick.item.title,
+    dueDate: dueDate?.toISOString(),
+    language: pick.item.language,
+  };
+};
+
+export type CatalogInsights = ReturnType<typeof computeCatalogInsights>;

--- a/src/hooks/usePlannerActions.ts
+++ b/src/hooks/usePlannerActions.ts
@@ -3,7 +3,8 @@ import { To } from 'react-router-dom';
 import { useWorkspaceSnapshot } from './useWorkspaceSnapshot';
 import { db } from '../db';
 import { PlannerQuickAction, PlannerTimelineCard } from '../types/planner';
-import { deckLabel, formatRelativeTime } from '../lib/plannerUtils';
+import { deckLabel, describeDueDate, formatRelativeTime } from '../lib/plannerUtils';
+import { getUpcomingSubjectFocus, subjectCatalog } from '../data/subjectCatalog';
 
 const STORAGE_KEY = 'planner-goals';
 
@@ -138,6 +139,19 @@ export const usePlannerActions = () => {
       icon: '🧠',
       badge: workspace.dueFlashcards ? `${workspace.dueFlashcards}` : undefined,
     });
+
+    const subjectFocus = getUpcomingSubjectFocus(subjectCatalog);
+    if (subjectFocus) {
+      const due = describeDueDate(subjectFocus.dueDate);
+      items.push({
+        key: 'subject-focus',
+        to: `/subjects?focus=${encodeURIComponent(subjectFocus.subjectSlug)}`,
+        label: `Prep ${subjectFocus.subjectName}`,
+        hint: subjectFocus.itemTitle ? `${subjectFocus.itemTitle} · ${due.label}` : due.label,
+        icon: subjectFocus.language === 'es' ? '🈶' : '📚',
+        badge: subjectFocus.language === 'es' ? 'EN help' : undefined,
+      });
+    }
 
     if (workspace.weakestTag) {
       items.push({

--- a/src/lib/plannerUtils.ts
+++ b/src/lib/plannerUtils.ts
@@ -34,3 +34,49 @@ export const formatRelativeTime = (value?: string) => {
   }
   return date.toLocaleDateString();
 };
+
+export type DueDescriptorTone = 'none' | 'future' | 'urgent' | 'overdue';
+
+export interface DueDescriptor {
+  label: string;
+  tone: DueDescriptorTone;
+}
+
+const DAY_IN_MS = 86_400_000;
+
+export const describeDueDate = (value?: string): DueDescriptor => {
+  if (!value) {
+    return { label: 'No due date', tone: 'none' };
+  }
+
+  const due = new Date(value);
+  if (Number.isNaN(due.getTime())) {
+    return { label: 'Date unavailable', tone: 'none' };
+  }
+
+  const now = Date.now();
+  const diff = due.getTime() - now;
+  const absDiff = Math.abs(diff);
+
+  if (absDiff < 60_000) {
+    return { label: diff >= 0 ? 'Due now' : 'Just closed', tone: diff >= 0 ? 'urgent' : 'overdue' };
+  }
+
+  if (diff >= 0) {
+    if (absDiff < DAY_IN_MS) {
+      const hours = Math.ceil(absDiff / (1000 * 60 * 60));
+      return { label: `Due in ${hours} hour${hours === 1 ? '' : 's'}`, tone: 'urgent' };
+    }
+    const days = Math.ceil(absDiff / DAY_IN_MS);
+    const tone: DueDescriptorTone = days <= 3 ? 'urgent' : 'future';
+    return { label: `Due in ${days} day${days === 1 ? '' : 's'}`, tone };
+  }
+
+  if (absDiff < DAY_IN_MS) {
+    const hours = Math.ceil(absDiff / (1000 * 60 * 60));
+    return { label: `Overdue by ${hours} hour${hours === 1 ? '' : 's'}`, tone: 'overdue' };
+  }
+
+  const days = Math.ceil(absDiff / DAY_IN_MS);
+  return { label: `Overdue by ${days} day${days === 1 ? '' : 's'}`, tone: 'overdue' };
+};

--- a/src/pages/SubjectsPage.module.css
+++ b/src/pages/SubjectsPage.module.css
@@ -1,0 +1,758 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+  font-family: var(--ui-font-display);
+  letter-spacing: -0.01em;
+}
+
+.subtitle {
+  max-width: 62ch;
+  margin: 8px 0 0;
+  color: var(--ui-text-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.headerStat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 22px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(15, 118, 110, 0.18);
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.15), rgba(34, 197, 94, 0.12));
+  box-shadow: 0 24px 60px -48px rgba(14, 165, 233, 0.4);
+}
+
+.headerStatLabel {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.headerStatValue {
+  font-size: 2.6rem;
+  font-family: var(--ui-font-display);
+}
+
+.summaryGrid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summaryCard {
+  padding: 18px 20px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 24px 48px -40px rgba(15, 23, 42, 0.4);
+}
+
+.summaryCard h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-family: var(--ui-font-display);
+}
+
+.summaryCard p {
+  margin: 8px 0 0;
+  color: var(--ui-text-secondary);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.filterGroup {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.filterButton {
+  padding: 10px 18px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.filterButton:hover,
+.filterButton:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.45);
+  box-shadow: 0 18px 40px -36px rgba(59, 130, 246, 0.5);
+}
+
+.filterButtonActive {
+  background: linear-gradient(140deg, rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.25));
+  border-color: rgba(14, 165, 233, 0.5);
+}
+
+.filterSummary {
+  margin-left: auto;
+  font-weight: 600;
+  color: var(--ui-text-secondary);
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+}
+
+.subjectList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.emptyState {
+  margin: 0;
+  padding: 20px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px dashed rgba(15, 23, 42, 0.18);
+  background: rgba(248, 250, 252, 0.8);
+  color: var(--ui-text-secondary);
+}
+
+.subjectListItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  text-align: left;
+  padding: 16px 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.subjectListItem:hover,
+.subjectListItem:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow: 0 20px 44px -36px rgba(59, 130, 246, 0.5);
+}
+
+.subjectListItemActive {
+  border-color: rgba(16, 185, 129, 0.5);
+  box-shadow: 0 22px 50px -36px rgba(16, 185, 129, 0.55);
+  background: linear-gradient(150deg, rgba(167, 243, 208, 0.45), rgba(56, 189, 248, 0.35));
+}
+
+.subjectListTitle {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.subjectListSubtitle {
+  color: var(--ui-text-secondary);
+  font-size: 0.9rem;
+}
+
+.subjectListMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(15, 23, 42, 0.06);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.chipUrgent {
+  background: rgba(250, 204, 21, 0.25);
+  color: #92400e;
+}
+
+.chipOverdue {
+  background: rgba(248, 113, 113, 0.3);
+  color: #7f1d1d;
+}
+
+.subjectDetail {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 20px 24px;
+  border-radius: var(--ui-radius-xl);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(18px);
+  min-height: 100%;
+}
+
+.detailHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.detailTitle {
+  margin: 0;
+  font-family: var(--ui-font-display);
+  font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.detailTagline {
+  margin: 6px 0 0;
+  color: var(--ui-text-secondary);
+}
+
+.detailBadge {
+  border: 2px solid;
+  border-radius: var(--ui-radius-pill);
+  padding: 10px 16px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.detailMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.metaPill {
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.8);
+  font-size: 0.85rem;
+}
+
+.detailDescription {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.detailDescriptionSecondary {
+  margin: 4px 0 0;
+  color: var(--ui-text-secondary);
+}
+
+.skillRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(226, 232, 240, 0.6);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.translationBar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.translationProgress {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.translationProgressFill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, #22d3ee, #34d399);
+}
+
+.translationSummary {
+  margin: 0;
+  color: var(--ui-text-secondary);
+}
+
+.languageNotes {
+  margin: 0;
+  font-style: italic;
+  color: var(--ui-text-secondary);
+}
+
+.courses {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.courseCard {
+  padding: 18px 20px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.72);
+}
+
+.courseHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.courseTitle {
+  margin: 0;
+  font-size: 1.3rem;
+  font-family: var(--ui-font-display);
+}
+
+.courseSubtitle {
+  margin: 6px 0 0;
+  color: var(--ui-text-secondary);
+}
+
+.courseMeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.metaChip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.focusAreaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.itemList {
+  margin: 18px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  list-style: none;
+  padding: 0;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.8);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tone-none {
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+.tone-future {
+  border-color: rgba(37, 99, 235, 0.25);
+}
+
+.tone-urgent {
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 18px 40px -36px rgba(250, 204, 21, 0.4);
+}
+
+.tone-overdue {
+  border-color: rgba(248, 113, 113, 0.45);
+  box-shadow: 0 18px 44px -36px rgba(248, 113, 113, 0.4);
+}
+
+.itemHeader {
+  display: flex;
+  gap: 14px;
+}
+
+.itemIcon {
+  font-size: 1.6rem;
+  display: inline-flex;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--ui-radius-lg);
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.itemBody {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.itemTitleRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.itemTitle {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.statusBadge {
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.status-not-started {
+  background: rgba(148, 163, 184, 0.35);
+  color: #0f172a;
+}
+
+.status-in-progress {
+  background: rgba(59, 130, 246, 0.2);
+  color: #1d4ed8;
+}
+
+.status-submitted {
+  background: rgba(14, 116, 144, 0.2);
+  color: #0f766e;
+}
+
+.status-graded {
+  background: rgba(16, 185, 129, 0.25);
+  color: #047857;
+}
+
+.status-blocked {
+  background: rgba(248, 113, 113, 0.3);
+  color: #7f1d1d;
+}
+
+.status-scheduled {
+  background: rgba(250, 204, 21, 0.25);
+  color: #92400e;
+}
+
+.itemSummary {
+  margin: 0;
+  color: var(--ui-text-secondary);
+  line-height: 1.5;
+}
+
+.translationNotes {
+  padding: 12px;
+  border-radius: var(--ui-radius-md);
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(14, 165, 233, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.glossaryRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.glossaryChips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.chipSoft {
+  padding: 4px 8px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.translationNote {
+  margin: 0;
+  color: rgba(15, 118, 110, 0.9);
+}
+
+.tagRow {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.itemMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.metaBadge {
+  padding: 4px 10px;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badgeSoft {
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px dashed rgba(15, 23, 42, 0.16);
+}
+
+.metaButton {
+  padding: 6px 12px;
+  border-radius: var(--ui-radius-pill);
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.12);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.metaButton:hover,
+.metaButton:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px -34px rgba(37, 99, 235, 0.5);
+}
+
+.metaButtonActive {
+  border-color: rgba(14, 165, 233, 0.6);
+  background: rgba(14, 165, 233, 0.15);
+}
+
+.metaTranslationStatus {
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
+}
+
+.labDetails {
+  border-top: 1px dashed rgba(15, 23, 42, 0.12);
+  padding-top: 12px;
+  color: var(--ui-text-secondary);
+}
+
+.labDetails summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.labEnvironment {
+  margin: 0 0 8px;
+}
+
+.labDeliverable {
+  margin: 8px 0 0;
+}
+
+.reflectionBox {
+  margin-top: 12px;
+  padding: 16px 18px;
+  border-radius: var(--ui-radius-lg);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.reflectionBox h3 {
+  margin: 0 0 10px;
+}
+
+.reflectionBox ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cheatSection {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px dashed rgba(15, 23, 42, 0.12);
+}
+
+.cheatHeading {
+  margin: 0 0 14px;
+  font-size: 1.05rem;
+  font-family: var(--ui-font-display);
+}
+
+.cheatGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.cheatCard {
+  padding: 16px;
+  border-radius: var(--ui-radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.82);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cheatCardHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.cheatTitle {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.cheatDescription {
+  margin: 6px 0 0;
+  color: var(--ui-text-secondary);
+  line-height: 1.5;
+}
+
+.cheatBadges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.cheatSummaries {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cheatSummary {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.cheatSummarySecondary {
+  margin: 0;
+  color: var(--ui-text-secondary);
+}
+
+.cheatOutline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cheatSectionDetails {
+  padding: 10px 12px;
+  border-radius: var(--ui-radius-md);
+  background: rgba(79, 70, 229, 0.08);
+  border: 1px solid rgba(79, 70, 229, 0.18);
+}
+
+.cheatSectionDetails summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.cheatSectionDetails ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cheatTips {
+  padding: 12px;
+  border-radius: var(--ui-radius-md);
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.cheatTipsHeading {
+  margin: 0 0 8px;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.cheatTips ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cheatDownload {
+  margin: 0;
+  color: rgba(15, 118, 110, 0.9);
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .subjectList {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 8px;
+  }
+
+  .subjectListItem {
+    min-width: 260px;
+  }
+}

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -1,0 +1,533 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { subjectCatalog, computeCatalogInsights } from '../data/subjectCatalog';
+import { CourseItem, SubjectMetrics, SubjectSummary } from '../types/subject';
+import { describeDueDate } from '../lib/plannerUtils';
+import styles from './SubjectsPage.module.css';
+
+type LanguageFilter = 'all' | 'spanish' | 'english-ready' | 'needs-translation';
+type UrgencyFilter = 'all' | 'due-soon' | 'overdue';
+
+type SubjectMetricsMap = Record<string, SubjectMetrics>;
+
+const languageFilterCopy: Record<LanguageFilter, string> = {
+  all: 'All languages',
+  spanish: 'Spanish-first',
+  'english-ready': 'English-ready',
+  'needs-translation': 'Needs English help',
+};
+
+const urgencyFilterCopy: Record<UrgencyFilter, string> = {
+  all: 'All timelines',
+  'due-soon': 'Due soon',
+  overdue: 'Overdue',
+};
+
+const itemKindIcon: Record<CourseItem['kind'], string> = {
+  lesson: '📘',
+  reading: '📖',
+  assignment: '📝',
+  lab: '🧪',
+  project: '🎯',
+};
+
+const statusCopy: Record<NonNullable<CourseItem['status']>, string> = {
+  'not-started': 'Not started',
+  'in-progress': 'In progress',
+  submitted: 'Submitted',
+  graded: 'Graded',
+  blocked: 'Blocked',
+  scheduled: 'Scheduled',
+};
+
+const languageBadge: Record<CourseItem['language'], string> = {
+  es: 'Spanish source',
+  en: 'English source',
+};
+
+const cheatCoverageLabel: Record<'full-course' | 'unit' | 'labs', string> = {
+  'full-course': 'Full course coverage',
+  unit: 'Unit bundle',
+  labs: 'Lab workflows',
+};
+
+const formatMinutes = (minutes?: number) => {
+  if (!minutes) return 'Flexible';
+  if (minutes < 60) {
+    return `~${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  if (!remaining) {
+    return `${hours} hr${hours === 1 ? '' : 's'}`;
+  }
+  return `${hours} hr${hours === 1 ? '' : 's'} ${remaining} min`;
+};
+
+const translationStatusLabel: Record<string, string> = {
+  complete: 'English ready',
+  partial: 'English in progress',
+  machine: 'Machine translated',
+  planned: 'Translation planned',
+};
+
+const buildMetricsMap = (catalogMetrics: SubjectMetrics[]): SubjectMetricsMap =>
+  catalogMetrics.reduce<SubjectMetricsMap>((acc, entry) => {
+    acc[entry.subject.id] = entry;
+    return acc;
+  }, {});
+
+const filterMetrics = (
+  metrics: SubjectMetrics[],
+  language: LanguageFilter,
+  urgency: UrgencyFilter
+): SubjectMetrics[] => {
+  return metrics.filter((entry) => {
+    if (language === 'spanish' && entry.subject.languageProfile.primary !== 'es') {
+      return false;
+    }
+    if (language === 'english-ready' && entry.translationCoverage < 0.75) {
+      return false;
+    }
+    if (language === 'needs-translation' && entry.spanishOnly === 0) {
+      return false;
+    }
+
+    if (urgency === 'due-soon' && entry.upcoming.length === 0) {
+      return false;
+    }
+    if (urgency === 'overdue' && entry.overdue.length === 0) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const buildTranslationCoverageLabel = (value: number) => {
+  const percent = Math.round(value * 100);
+  if (percent >= 90) return 'Fully bilingual';
+  if (percent >= 70) return 'Almost ready in English';
+  if (percent >= 40) return 'Half bilingual';
+  if (percent > 0) return 'English scaffolding started';
+  return 'Spanish-only right now';
+};
+
+const renderTagList = (tags: string[]) =>
+  tags.map((tag) => (
+    <span key={tag} className={styles.tag}>
+      {tag}
+    </span>
+  ));
+
+const SubjectsPage: React.FC = () => {
+  const { metrics: catalogMetrics, totals } = useMemo(() => computeCatalogInsights(subjectCatalog), []);
+  const slugToId = useMemo(
+    () =>
+      subjectCatalog.reduce<Record<string, string>>((acc, subject) => {
+        acc[subject.slug] = subject.id;
+        return acc;
+      }, {}),
+    []
+  );
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialSubjectId = useMemo(() => {
+    const focusSlug = searchParams.get('focus');
+    if (focusSlug && slugToId[focusSlug]) {
+      return slugToId[focusSlug];
+    }
+    return catalogMetrics[0]?.subject.id ?? '';
+  }, [catalogMetrics, searchParams, slugToId]);
+  const metricsMap = useMemo(() => buildMetricsMap(catalogMetrics), [catalogMetrics]);
+  const [languageFilter, setLanguageFilter] = useState<LanguageFilter>('all');
+  const [urgencyFilter, setUrgencyFilter] = useState<UrgencyFilter>('all');
+  const [activeSubjectId, setActiveSubjectId] = useState<string>(initialSubjectId);
+  const [translationExpanded, setTranslationExpanded] = useState<Record<string, boolean>>({});
+
+  const filteredMetrics = useMemo(
+    () => filterMetrics(catalogMetrics, languageFilter, urgencyFilter),
+    [catalogMetrics, languageFilter, urgencyFilter]
+  );
+
+  useEffect(() => {
+    if (!filteredMetrics.length) {
+      setActiveSubjectId('');
+      return;
+    }
+
+    const stillVisible = filteredMetrics.some((entry) => entry.subject.id === activeSubjectId);
+    if (!stillVisible) {
+      setActiveSubjectId(filteredMetrics[0].subject.id);
+    }
+  }, [filteredMetrics, activeSubjectId]);
+
+  const activeMetrics = activeSubjectId ? metricsMap[activeSubjectId] : undefined;
+  const activeSubject = activeMetrics?.subject;
+
+  const handleSelectSubject = (subject: SubjectSummary) => {
+    setActiveSubjectId(subject.id);
+  };
+
+  useEffect(() => {
+    const current = searchParams.get('focus');
+    if (!activeSubject) {
+      if (current) {
+        const next = new URLSearchParams(searchParams);
+        next.delete('focus');
+        setSearchParams(next, { replace: true });
+      }
+      return;
+    }
+
+    if (current === activeSubject.slug) return;
+    const next = new URLSearchParams(searchParams);
+    next.set('focus', activeSubject.slug);
+    setSearchParams(next, { replace: true });
+  }, [activeSubject, searchParams, setSearchParams]);
+
+  const toggleTranslation = (itemId: string) => {
+    setTranslationExpanded((prev) => ({
+      ...prev,
+      [itemId]: !prev[itemId],
+    }));
+  };
+
+  const subjectCountCopy = filteredMetrics.length === catalogMetrics.length ? 'All subjects' : `${filteredMetrics.length} subject${filteredMetrics.length === 1 ? '' : 's'}`;
+
+  return (
+    <div className={styles.page} aria-labelledby="subjects-heading">
+      <header className={styles.header}>
+        <div>
+          <h1 id="subjects-heading" className={styles.title}>
+            Subjects hub
+          </h1>
+          <p className={styles.subtitle}>
+            Plan every subject in English-first detail while keeping Spanish materials intact. Filter by language support, find due labs, and open bilingual guides in one spot.
+          </p>
+        </div>
+        <div className={styles.headerStat}>
+          <span className={styles.headerStatLabel}>Bilingual coverage</span>
+          <span className={styles.headerStatValue}>{Math.round(totals.translationCoverage * 100)}%</span>
+        </div>
+      </header>
+
+      <section className={styles.summaryGrid} aria-label="Workspace summary">
+        <article className={styles.summaryCard}>
+          <h2>{totals.subjects} subjects</h2>
+          <p>
+            {totals.items} tracked resources · {totals.assignments} assignments · {totals.labs} labs.
+          </p>
+        </article>
+        <article className={styles.summaryCard}>
+          <h2>{totals.englishReady} English-ready</h2>
+          <p>{totals.spanishOnly} items still need English scaffolding.</p>
+        </article>
+        <article className={styles.summaryCard}>
+          <h2>{totals.upcoming} upcoming</h2>
+          <p>{totals.overdue} overdue items waiting for wrap-up.</p>
+        </article>
+      </section>
+
+      <section className={styles.filters} aria-label="Subject filters">
+        <div className={styles.filterGroup} role="group" aria-label="Language filter">
+          {Object.entries(languageFilterCopy).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              className={`${styles.filterButton} ${languageFilter === value ? styles.filterButtonActive : ''}`}
+              onClick={() => setLanguageFilter(value as LanguageFilter)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className={styles.filterGroup} role="group" aria-label="Timeline filter">
+          {Object.entries(urgencyFilterCopy).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              className={`${styles.filterButton} ${urgencyFilter === value ? styles.filterButtonActive : ''}`}
+              onClick={() => setUrgencyFilter(value as UrgencyFilter)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <p className={styles.filterSummary}>{subjectCountCopy}</p>
+      </section>
+
+      <section className={styles.layout}>
+        <nav className={styles.subjectList} aria-label="Subjects list">
+          {filteredMetrics.length === 0 ? (
+            <p className={styles.emptyState}>
+              No subjects match the selected filters yet. Adjust filters to continue planning.
+            </p>
+          ) : (
+            filteredMetrics.map((entry) => {
+              const coverage = Math.round(entry.translationCoverage * 100);
+              return (
+                <button
+                  key={entry.subject.id}
+                  type="button"
+                  className={`${styles.subjectListItem} ${activeSubjectId === entry.subject.id ? styles.subjectListItemActive : ''}`}
+                  onClick={() => handleSelectSubject(entry.subject)}
+                >
+                  <span className={styles.subjectListTitle}>{entry.subject.name}</span>
+                  <span className={styles.subjectListSubtitle}>{entry.subject.tagline}</span>
+                  <div className={styles.subjectListMeta}>
+                    <span className={styles.chip}>{coverage}% EN ready</span>
+                    {entry.upcoming.length > 0 && <span className={`${styles.chip} ${styles.chipUrgent}`}>{entry.upcoming.length} due soon</span>}
+                    {entry.overdue.length > 0 && <span className={`${styles.chip} ${styles.chipOverdue}`}>{entry.overdue.length} overdue</span>}
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </nav>
+
+        <section className={styles.subjectDetail} aria-live="polite">
+          {!activeSubject || !activeMetrics ? (
+            <div className={styles.emptyState}>
+              Select a subject to inspect bilingual resources, labs, and translation notes.
+            </div>
+          ) : (
+            <article>
+              <header className={styles.detailHeader}>
+                <div>
+                  <h2 className={styles.detailTitle}>{activeSubject.name}</h2>
+                  <p className={styles.detailTagline}>{activeSubject.tagline}</p>
+                </div>
+                <div className={styles.detailBadge} style={{ borderColor: activeSubject.color }}>
+                  {buildTranslationCoverageLabel(activeMetrics.translationCoverage)}
+                </div>
+              </header>
+
+              <div className={styles.detailMeta}>
+                <span className={styles.metaPill}>
+                  Primary language: <strong>{activeSubject.languageProfile.primary === 'es' ? 'Spanish' : 'English'}</strong>
+                </span>
+                <span className={styles.metaPill}>
+                  English support: <strong>{activeSubject.languageProfile.supportLevel}</strong>
+                </span>
+                <span className={styles.metaPill}>
+                  Credits: <strong>{activeSubject.credits}</strong>
+                </span>
+              </div>
+
+              <p className={styles.detailDescription}>{activeSubject.description.en}</p>
+              {activeSubject.description.es && (
+                <p className={styles.detailDescriptionSecondary}>{activeSubject.description.es}</p>
+              )}
+
+              <div className={styles.skillRow}>
+                {renderTagList(activeSubject.skills)}
+                {renderTagList(activeSubject.focusAreas)}
+              </div>
+
+              <div className={styles.translationBar}>
+                <div className={styles.translationProgress}>
+                  <div
+                    className={styles.translationProgressFill}
+                    style={{ width: `${Math.min(100, Math.round(activeMetrics.translationCoverage * 100))}%` }}
+                    aria-hidden="true"
+                  />
+                </div>
+                <p className={styles.translationSummary}>
+                  {activeMetrics.englishReady} items ready in English · {activeMetrics.spanishOnly} still Spanish-only.
+                </p>
+              </div>
+
+              {activeSubject.languageProfile.notes && (
+                <p className={styles.languageNotes}>{activeSubject.languageProfile.notes}</p>
+              )}
+
+              <div className={styles.courses}>
+                {activeSubject.courses.map((course) => (
+                  <section key={course.id} className={styles.courseCard} aria-labelledby={`course-${course.id}`}>
+                    <header className={styles.courseHeader}>
+                      <div>
+                        <h3 id={`course-${course.id}`} className={styles.courseTitle}>
+                          {course.title}
+                        </h3>
+                        <p className={styles.courseSubtitle}>{course.description}</p>
+                      </div>
+                      <div className={styles.courseMeta}>
+                        <span className={styles.metaChip}>{course.modality}</span>
+                        <span className={styles.metaChip}>{course.schedule}</span>
+                        <span className={styles.metaChip}>{course.languageMix.join(' · ')}</span>
+                      </div>
+                    </header>
+
+                    {course.focusAreas.length > 0 && (
+                      <div className={styles.focusAreaRow}>{renderTagList(course.focusAreas)}</div>
+                    )}
+
+                    <ul className={styles.itemList}>
+                      {course.items.map((item) => {
+                        const dueDescriptor = describeDueDate(item.dueDate);
+                        const expanded = translationExpanded[item.id] ?? false;
+                        const hasTranslation = Boolean(item.translation);
+                        return (
+                          <li key={item.id} className={`${styles.item} ${styles[`tone-${dueDescriptor.tone}`]}`}>
+                            <div className={styles.itemHeader}>
+                              <span className={styles.itemIcon} aria-hidden="true">
+                                {itemKindIcon[item.kind]}
+                              </span>
+                              <div className={styles.itemBody}>
+                                <div className={styles.itemTitleRow}>
+                                  <h4 className={styles.itemTitle}>{item.title}</h4>
+                                  {item.status && (
+                                    <span className={`${styles.statusBadge} ${styles[`status-${item.status}`]}`}>
+                                      {statusCopy[item.status]}
+                                    </span>
+                                  )}
+                                </div>
+                                <p className={styles.itemSummary}>{item.summary.original}</p>
+                                {expanded && hasTranslation && (
+                                  <div className={styles.translationNotes}>
+                                    <p>
+                                      <strong>English guidance:</strong> {item.translation?.summary}
+                                    </p>
+                                    {item.translation?.glossary && item.translation.glossary.length > 0 && (
+                                      <div className={styles.glossaryRow}>
+                                        <strong>Glossary:</strong>
+                                        <div className={styles.glossaryChips}>
+                                          {item.translation.glossary.map((term) => (
+                                            <span key={term} className={styles.chipSoft}>
+                                              {term}
+                                            </span>
+                                          ))}
+                                        </div>
+                                      </div>
+                                    )}
+                                    {item.translation?.notes && <p className={styles.translationNote}>{item.translation.notes}</p>}
+                                  </div>
+                                )}
+                                {item.tags.length > 0 && <div className={styles.tagRow}>{renderTagList(item.tags)}</div>}
+                              </div>
+                            </div>
+
+                            <div className={styles.itemMeta}>
+                              <span className={`${styles.metaBadge} ${styles[`tone-${dueDescriptor.tone}`]}`}>
+                                {dueDescriptor.label}
+                              </span>
+                              <span className={styles.metaChip}>{languageBadge[item.language]}</span>
+                              <span className={styles.metaChip}>{formatMinutes(item.estimatedMinutes)}</span>
+                              {hasTranslation ? (
+                                <button
+                                  type="button"
+                                  className={`${styles.metaButton} ${expanded ? styles.metaButtonActive : ''}`}
+                                  onClick={() => toggleTranslation(item.id)}
+                                >
+                                  {expanded ? 'Hide English notes' : 'Show English notes'}
+                                </button>
+                              ) : (
+                                <span className={`${styles.metaBadge} ${styles.badgeSoft}`}>
+                                  Needs English outline
+                                </span>
+                              )}
+                              {item.translation && (
+                                <span className={`${styles.metaChip} ${styles.metaTranslationStatus}`}>
+                                  {translationStatusLabel[item.translation.status] ?? 'Translation'}
+                                </span>
+                              )}
+                            </div>
+
+                            {item.lab && (
+                              <details className={styles.labDetails}>
+                                <summary>Lab checklist</summary>
+                                <p className={styles.labEnvironment}>
+                                  <strong>Environment:</strong> {item.lab.environment}
+                                </p>
+                                <ul>
+                                  {item.lab.checklists.map((step, index) => (
+                                    <li key={`${item.id}-step-${index}`}>{step}</li>
+                                  ))}
+                                </ul>
+                                {item.lab.deliverable && (
+                                  <p className={styles.labDeliverable}>
+                                    <strong>Deliverable:</strong> {item.lab.deliverable}
+                                  </p>
+                                )}
+                              </details>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+
+                    {course.cheatPapers && course.cheatPapers.length > 0 && (
+                      <div className={styles.cheatSection} aria-label="Cheat papers">
+                        <h4 className={styles.cheatHeading}>Cheat papers</h4>
+                        <div className={styles.cheatGrid}>
+                          {course.cheatPapers.map((paper) => (
+                            <article key={paper.id} className={styles.cheatCard}>
+                              <header className={styles.cheatCardHeader}>
+                                <div>
+                                  <h5 className={styles.cheatTitle}>{paper.title}</h5>
+                                  <p className={styles.cheatDescription}>{paper.description}</p>
+                                </div>
+                                <div className={styles.cheatBadges}>
+                                  <span className={styles.metaChip}>{cheatCoverageLabel[paper.coverage]}</span>
+                                  <span className={styles.metaChip}>{languageBadge[paper.language]}</span>
+                                </div>
+                              </header>
+                              <div className={styles.cheatSummaries}>
+                                <p className={styles.cheatSummary}>{paper.englishSummary}</p>
+                                {paper.spanishSummary && (
+                                  <p className={styles.cheatSummarySecondary}>{paper.spanishSummary}</p>
+                                )}
+                              </div>
+                              <div className={styles.cheatOutline}>
+                                {paper.sections.map((section) => (
+                                  <details key={`${paper.id}-${section.title}`} className={styles.cheatSectionDetails}>
+                                    <summary>{section.title}</summary>
+                                    <ul>
+                                      {section.bullets.map((bullet, index) => (
+                                        <li key={`${paper.id}-${section.title}-${index}`}>{bullet}</li>
+                                      ))}
+                                    </ul>
+                                  </details>
+                                ))}
+                              </div>
+                              {paper.studyTips.length > 0 && (
+                                <div className={styles.cheatTips}>
+                                  <p className={styles.cheatTipsHeading}>Study tips</p>
+                                  <ul>
+                                    {paper.studyTips.map((tip, index) => (
+                                      <li key={`${paper.id}-tip-${index}`}>{tip}</li>
+                                    ))}
+                                  </ul>
+                                </div>
+                              )}
+                              {paper.downloadHint && (
+                                <p className={styles.cheatDownload}>{paper.downloadHint}</p>
+                              )}
+                            </article>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </section>
+                ))}
+              </div>
+
+              {activeSubject.reflectionPrompts.length > 0 && (
+                <aside className={styles.reflectionBox} aria-label="Reflection prompts">
+                  <h3>Reflection prompts</h3>
+                  <ul>
+                    {activeSubject.reflectionPrompts.map((prompt) => (
+                      <li key={prompt}>{prompt}</li>
+                    ))}
+                  </ul>
+                </aside>
+              )}
+            </article>
+          )}
+        </section>
+      </section>
+    </div>
+  );
+};
+
+export default SubjectsPage;

--- a/src/types/subject.ts
+++ b/src/types/subject.ts
@@ -1,0 +1,100 @@
+export type SubjectLanguage = 'en' | 'es';
+
+export type TranslationStatus = 'complete' | 'partial' | 'machine' | 'planned';
+
+export interface TranslationSupport {
+  status: TranslationStatus;
+  summary: string;
+  notes?: string;
+  glossary?: string[];
+}
+
+export type CourseItemKind = 'lesson' | 'reading' | 'assignment' | 'lab' | 'project';
+
+export type CourseItemStatus = 'not-started' | 'in-progress' | 'submitted' | 'graded' | 'blocked' | 'scheduled';
+
+export interface CourseItem {
+  id: string;
+  kind: CourseItemKind;
+  title: string;
+  language: SubjectLanguage;
+  summary: {
+    original: string;
+    english?: string;
+  };
+  tags: string[];
+  estimatedMinutes?: number;
+  dueDate?: string;
+  status?: CourseItemStatus;
+  translation?: TranslationSupport;
+  lab?: {
+    environment: string;
+    checklists: string[];
+    deliverable?: string;
+  };
+}
+
+export interface CheatPaperSection {
+  title: string;
+  bullets: string[];
+}
+
+export interface CheatPaper {
+  id: string;
+  title: string;
+  language: SubjectLanguage;
+  coverage: 'full-course' | 'unit' | 'labs';
+  description: string;
+  englishSummary: string;
+  spanishSummary?: string;
+  sections: CheatPaperSection[];
+  studyTips: string[];
+  downloadHint?: string;
+}
+
+export interface SubjectCourse {
+  id: string;
+  code?: string;
+  title: string;
+  description: string;
+  modality: 'lecture' | 'lab' | 'seminar' | 'project';
+  schedule: string;
+  languageMix: SubjectLanguage[];
+  focusAreas: string[];
+  items: CourseItem[];
+  cheatPapers?: CheatPaper[];
+}
+
+export interface SubjectSummary {
+  id: string;
+  slug: string;
+  name: string;
+  tagline: string;
+  description: {
+    en: string;
+    es?: string;
+  };
+  languageProfile: {
+    primary: SubjectLanguage;
+    supportLevel: 'complete' | 'partial' | 'planned';
+    notes: string;
+  };
+  credits: number;
+  skills: string[];
+  focusAreas: string[];
+  color: string;
+  courses: SubjectCourse[];
+  reflectionPrompts: string[];
+}
+
+export interface SubjectMetrics {
+  subject: SubjectSummary;
+  totalItems: number;
+  assignments: number;
+  labs: number;
+  translationCoverage: number;
+  englishReady: number;
+  spanishOnly: number;
+  upcoming: CourseItem[];
+  overdue: CourseItem[];
+}


### PR DESCRIPTION
## Summary
- define cheat paper data structures and populate every course with bilingual outlines and study tips
- render cheat papers on the Subjects hub with collapsible outlines, study guidance, and styling
- publish markdown cheat papers for each course covering architecture, governance, databases, NLP, and ML clinics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d810d5066c8324921ad0a6948ea448