### PR TITLE
Build hierarchical study tree for subjects

### DIFF
--- a/src/data/subjectCatalog.ts
+++ b/src/data/subjectCatalog.ts
@@ -188,6 +188,7 @@ export const subjectCatalog: SubjectSummary[] = [
             language: 'en',
             summary: {
               original: 'Inject latency and failure into the payment gateway to validate fallbacks.',
+              english: 'Stress the payment gateway with latency and failure injections to verify fallbacks.',
             },
             tags: ['resilience', 'testing'],
             estimatedMinutes: withMinutes(120),
@@ -414,6 +415,7 @@ export const subjectCatalog: SubjectSummary[] = [
             language: 'en',
             summary: {
               original: 'Deliver stakeholder analysis slides in English with annotated Spanish glossary.',
+              english: 'Deliver stakeholder analysis slides in English and include a supporting Spanish glossary.',
             },
             tags: ['presentation', 'bilingual'],
             estimatedMinutes: withMinutes(100),
@@ -832,6 +834,7 @@ export const subjectCatalog: SubjectSummary[] = [
             language: 'en',
             summary: {
               original: 'Prepare a bilingual poster discussing bias metrics on Spanish benchmarks.',
+              english: 'Create a bilingual poster that explains bias metrics on Spanish-language benchmarks.',
             },
             tags: ['research', 'presentation'],
             estimatedMinutes: withMinutes(200),
@@ -931,6 +934,7 @@ export const subjectCatalog: SubjectSummary[] = [
             language: 'en',
             summary: {
               original: 'Review constrained Gaussian Process inference and sparse approximations.',
+              english: 'Review constrained Gaussian Process inference techniques and sparse approximation methods.',
             },
             tags: ['research', 'gaussian processes'],
             estimatedMinutes: withMinutes(110),
@@ -948,6 +952,7 @@ export const subjectCatalog: SubjectSummary[] = [
             language: 'en',
             summary: {
               original: 'Panel discussion on catastrophic forgetting mitigation strategies.',
+              english: 'Host a panel conversation that compares strategies to reduce catastrophic forgetting.',
             },
             tags: ['discussion', 'continual learning'],
             estimatedMinutes: withMinutes(75),
@@ -1047,6 +1052,7 @@ export const subjectCatalog: SubjectSummary[] = [
             language: 'en',
             summary: {
               original: 'Draft a bilingual playbook for deploying ML services ethically.',
+              english: 'Draft a bilingual playbook that guides ethical deployment of machine learning services.',
             },
             tags: ['ethics', 'project'],
             estimatedMinutes: withMinutes(210),

--- a/src/data/subjectResources.ts
+++ b/src/data/subjectResources.ts
@@ -1,0 +1,167 @@
+export interface ResourceLink {
+  label: string;
+  href: string;
+  description?: string;
+  type?: 'pdf' | 'slides' | 'worksheet';
+}
+
+export const subjectResourceLibrary: Record<string, ResourceLink[]> = {
+  sad: [
+    {
+      label: 'Session 0 overview slides (PDF)',
+      href: new URL('../../subjects/Sad/0_Presentation.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Session 1 introduction deck (PDF)',
+      href: new URL('../../subjects/Sad/Session_1_Introduction_Deck_Bullets_Notes.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Session 2 microservices deck (PDF)',
+      href: new URL('../../subjects/Sad/Session_2_Microservices_Bullets_Notes.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Session 3 cloud service models deck (PDF)',
+      href: new URL('../../subjects/Sad/Session_3_Cloud_Service_Models_Bullets_Notes.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+  ],
+  ggo: [
+    {
+      label: 'Introducción a Gobierno de TI slides (PDF)',
+      href: new URL('../../subjects/Ggo/T1. Intro Gobierno de TI/23 Introducción a Gobierno de TI.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Valor de TI lecture slides (PDF)',
+      href: new URL('../../subjects/Ggo/T2. Valor de TI/23 Valor TI.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Alineación de negocio y TI slides (PDF)',
+      href: new URL('../../subjects/Ggo/T3. Alineación de negocio y SI_TI. Bedell/22 Alineación.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Método Bedell worksheet (PDF)',
+      href: new URL(
+        "../../subjects/Ggo/T3. Alineación de negocio y SI_TI. Bedell/Calcular la imp del stma de información Método Bedell_VA_1.pdf",
+        import.meta.url
+      ).href,
+      type: 'worksheet',
+    },
+    {
+      label: 'Stakeholder analysis template (PDF)',
+      href: new URL('../../subjects/Ggo/T3. Alineación de negocio y SI_TI. Bedell/Análisis de stakeholders 2024.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+  ],
+  snlp: [
+    {
+      label: 'Chapter 1 slides (PDF)',
+      href: new URL('../../subjects/snlp/slides/Chapter 1.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Chapter 2 slides (PDF)',
+      href: new URL('../../subjects/snlp/slides/Chapter 2.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Chapter 3 Keras slides (PDF)',
+      href: new URL('../../subjects/snlp/slides/Chapter 3 KERAS.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Chapter 4 NLP slides (PDF)',
+      href: new URL('../../subjects/snlp/slides/Chapter 4 NLP.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Chapter 5 LLM slides (PDF)',
+      href: new URL('../../subjects/snlp/slides/Chapter 5 LLM.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Chapter 6 Speech slides (PDF)',
+      href: new URL('../../subjects/snlp/slides/Chapter 6 SPEECH.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Assignments overview (PDF)',
+      href: new URL('../../subjects/snlp/slides/Assignments.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+    {
+      label: 'Poster presentation template (PDF)',
+      href: new URL('../../subjects/snlp/slides/Presentation.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Lab session 1 pre-work (PDF)',
+      href: new URL('../../subjects/snlp/lab/PRE-WORK Lab Session 1.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+    {
+      label: 'Lab session 2 guide (PDF)',
+      href: new URL('../../subjects/snlp/lab/Lab Session 2.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+    {
+      label: 'Lab session 3 guide (PDF)',
+      href: new URL('../../subjects/snlp/lab/Lab Session 3.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+  ],
+  admeav: [
+    {
+      label: 'Presentation overview (PDF)',
+      href: new URL('../../subjects/Admeav/Teoria/slides/T0_Presentation.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Hand-crafted feature extraction slides (PDF)',
+      href: new URL('../../subjects/Admeav/Teoria/slides/T1_Hand crafted feature extraction.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'CNN feature extraction slides (PDF)',
+      href: new URL('../../subjects/Admeav/Teoria/slides/T2_CNN based feature extraction _1_.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+  ],
+  dbd: [
+    {
+      label: 'Presentación inicial (PDF)',
+      href: new URL('../../subjects/Dbd/presentacionDBD.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Planificación de prácticas (PDF)',
+      href: new URL('../../subjects/Dbd/Planificación_prácticas.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+    {
+      label: 'Tema 1 teoría (PDF)',
+      href: new URL('../../subjects/Dbd/Teoria/tema1_DBD.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Tema 2 teoría (PDF)',
+      href: new URL('../../subjects/Dbd/Teoria/tema2_DBD.pdf', import.meta.url).href,
+      type: 'slides',
+    },
+    {
+      label: 'Cuestiones tema 2 (PDF)',
+      href: new URL('../../subjects/Dbd/Teoria/Cuestiones _T2_.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+    {
+      label: 'Cuestiones tema 2 solución (PDF)',
+      href: new URL('../../subjects/Dbd/Teoria/Cuestiones _T2__Solución.pdf', import.meta.url).href,
+      type: 'worksheet',
+    },
+  ],
+};

--- a/src/pages/SubjectsPage.module.css
+++ b/src/pages/SubjectsPage.module.css
@@ -1,758 +1,455 @@
 .page {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 24px;
+  padding-bottom: 48px;
 }
 
 .header {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 24px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .title {
   margin: 0;
-  font-size: clamp(2.1rem, 4vw, 2.8rem);
-  font-family: var(--ui-font-display);
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-family: var(--ui-font-display, 'Inter');
   letter-spacing: -0.01em;
 }
 
-.subtitle {
-  max-width: 62ch;
-  margin: 8px 0 0;
-  color: var(--ui-text-secondary);
-  font-size: 1rem;
+.intro {
+  margin: 0;
+  max-width: 65ch;
+  color: var(--ui-text-secondary, #475569);
   line-height: 1.6;
 }
 
-.headerStat {
+.meta {
+  margin: 0;
+  color: var(--ui-text-tertiary, #64748b);
+  font-size: 0.95rem;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 28px;
+  align-items: flex-start;
+}
+
+.tree {
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.92);
+  padding: 16px;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.35);
+}
+
+.treeList,
+.treeCourseList,
+.treeItemList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.treeCourseList {
+  padding-left: 12px;
+}
+
+.treeItemList {
+  padding-left: 24px;
+}
+
+.treeSubject {
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 12px;
+  border-radius: 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.treeSubject:hover,
+.treeSubject:focus-visible {
+  background: rgba(56, 189, 248, 0.12);
+  outline: none;
+}
+
+.treeSubjectActive {
+  background: rgba(16, 185, 129, 0.16);
+  transform: translateY(-1px);
+}
+
+.treeMeta {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--ui-text-tertiary, #64748b);
+  line-height: 1.4;
+  margin-top: 4px;
+}
+
+.treeBadge {
+  align-self: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.treeCourse {
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: rgba(15, 23, 42, 0.03);
+  padding: 12px;
+  border-radius: 12px;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 18px 22px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid rgba(15, 118, 110, 0.18);
-  background: linear-gradient(160deg, rgba(14, 165, 233, 0.15), rgba(34, 197, 94, 0.12));
-  box-shadow: 0 24px 60px -48px rgba(14, 165, 233, 0.4);
+  transition: background 0.18s ease, transform 0.18s ease;
 }
 
-.headerStatLabel {
-  font-size: 0.75rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.7);
+.treeCourse:hover,
+.treeCourse:focus-visible {
+  background: rgba(59, 130, 246, 0.15);
+  outline: none;
 }
 
-.headerStatValue {
-  font-size: 2.6rem;
-  font-family: var(--ui-font-display);
-}
-
-.summaryGrid {
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.summaryCard {
-  padding: 18px 20px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(255, 255, 255, 0.75);
-  backdrop-filter: blur(16px);
-  box-shadow: 0 24px 48px -40px rgba(15, 23, 42, 0.4);
-}
-
-.summaryCard h2 {
-  margin: 0;
-  font-size: 1.6rem;
-  font-family: var(--ui-font-display);
-}
-
-.summaryCard p {
-  margin: 8px 0 0;
-  color: var(--ui-text-secondary);
-}
-
-.filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.filterGroup {
-  display: inline-flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.filterButton {
-  padding: 10px 18px;
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background: rgba(255, 255, 255, 0.7);
-  cursor: pointer;
-  font-weight: 600;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
-}
-
-.filterButton:hover,
-.filterButton:focus-visible {
+.treeCourseActive {
+  background: rgba(59, 130, 246, 0.22);
   transform: translateY(-1px);
-  border-color: rgba(59, 130, 246, 0.45);
-  box-shadow: 0 18px 40px -36px rgba(59, 130, 246, 0.5);
 }
 
-.filterButtonActive {
-  background: linear-gradient(140deg, rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.25));
-  border-color: rgba(14, 165, 233, 0.5);
+.treeCourseHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
 }
 
-.filterSummary {
-  margin-left: auto;
-  font-weight: 600;
-  color: var(--ui-text-secondary);
-}
-
-.layout {
+.treeItem {
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
   display: grid;
-  gap: 24px;
-  grid-template-columns: minmax(260px, 320px) 1fr;
+  grid-template-columns: 24px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  transition: background 0.18s ease, transform 0.18s ease;
 }
 
-.subjectList {
+.treeItem:hover,
+.treeItem:focus-visible {
+  background: rgba(79, 70, 229, 0.22);
+  outline: none;
+}
+
+.treeItemActive {
+  background: rgba(129, 140, 248, 0.32);
+  color: #1e1b4b;
+  transform: translateY(-1px);
+}
+
+.treeItemIcon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.treeItemLabel {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.treeItemKind {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--ui-text-tertiary, #64748b);
+}
+
+.detail {
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 28px;
+  min-height: 420px;
+  box-shadow: 0 24px 48px -36px rgba(15, 23, 42, 0.4);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 24px;
 }
 
 .emptyState {
   margin: 0;
-  padding: 20px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px dashed rgba(15, 23, 42, 0.18);
-  background: rgba(248, 250, 252, 0.8);
-  color: var(--ui-text-secondary);
+  color: var(--ui-text-secondary, #475569);
 }
 
-.subjectListItem {
+.detailPlaceholder {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
-  text-align: left;
-  padding: 16px 18px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(255, 255, 255, 0.72);
-  cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  gap: 12px;
 }
 
-.subjectListItem:hover,
-.subjectListItem:focus-visible {
-  transform: translateY(-2px);
-  border-color: rgba(59, 130, 246, 0.35);
-  box-shadow: 0 20px 44px -36px rgba(59, 130, 246, 0.5);
-}
-
-.subjectListItemActive {
-  border-color: rgba(16, 185, 129, 0.5);
-  box-shadow: 0 22px 50px -36px rgba(16, 185, 129, 0.55);
-  background: linear-gradient(150deg, rgba(167, 243, 208, 0.45), rgba(56, 189, 248, 0.35));
-}
-
-.subjectListTitle {
-  font-size: 1.05rem;
-  font-weight: 700;
-}
-
-.subjectListSubtitle {
-  color: var(--ui-text-secondary);
-  font-size: 0.9rem;
-}
-
-.subjectListMeta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(15, 23, 42, 0.06);
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
-.chipUrgent {
-  background: rgba(250, 204, 21, 0.25);
-  color: #92400e;
-}
-
-.chipOverdue {
-  background: rgba(248, 113, 113, 0.3);
-  color: #7f1d1d;
-}
-
-.subjectDetail {
+.itemDetail {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 20px 24px;
-  border-radius: var(--ui-radius-xl);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(255, 255, 255, 0.82);
-  backdrop-filter: blur(18px);
-  min-height: 100%;
+  gap: 28px;
 }
 
 .detailHeader {
   display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.detailTitle {
+.breadcrumb {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--ui-text-tertiary, #64748b);
   margin: 0;
-  font-family: var(--ui-font-display);
-  font-size: clamp(1.6rem, 3vw, 2rem);
-}
-
-.detailTagline {
-  margin: 6px 0 0;
-  color: var(--ui-text-secondary);
-}
-
-.detailBadge {
-  border: 2px solid;
-  border-radius: var(--ui-radius-pill);
-  padding: 10px 16px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
-.detailMeta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.metaPill {
-  padding: 6px 12px;
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(248, 250, 252, 0.8);
   font-size: 0.85rem;
 }
 
-.detailDescription {
+.detailHeader h2 {
   margin: 0;
-  font-size: 1rem;
-  line-height: 1.6;
-}
-
-.detailDescriptionSecondary {
-  margin: 4px 0 0;
-  color: var(--ui-text-secondary);
-}
-
-.skillRow {
+  font-size: clamp(1.6rem, 2.4vw, 2.1rem);
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.tag {
-  display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(226, 232, 240, 0.6);
-  font-size: 0.8rem;
-  font-weight: 600;
-  text-transform: capitalize;
-}
-
-.translationBar {
-  display: flex;
-  flex-direction: column;
   gap: 10px;
 }
 
-.translationProgress {
-  position: relative;
-  width: 100%;
-  height: 10px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(15, 23, 42, 0.08);
+.detailIcon {
+  font-size: 1.6rem;
 }
 
-.translationProgressFill {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(120deg, #22d3ee, #34d399);
-}
-
-.translationSummary {
-  margin: 0;
-  color: var(--ui-text-secondary);
-}
-
-.languageNotes {
-  margin: 0;
-  font-style: italic;
-  color: var(--ui-text-secondary);
-}
-
-.courses {
-  display: flex;
-  flex-direction: column;
-  gap: 22px;
-}
-
-.courseCard {
-  padding: 18px 20px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(248, 250, 252, 0.72);
-}
-
-.courseHeader {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: flex-start;
-}
-
-.courseTitle {
-  margin: 0;
-  font-size: 1.3rem;
-  font-family: var(--ui-font-display);
-}
-
-.courseSubtitle {
-  margin: 6px 0 0;
-  color: var(--ui-text-secondary);
-}
-
-.courseMeta {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
-  font-size: 0.85rem;
-}
-
-.metaChip {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(15, 23, 42, 0.08);
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.focusAreaRow {
+.detailMetaRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 12px;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--ui-text-secondary, #475569);
 }
 
-.itemList {
-  margin: 18px 0 0;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  list-style: none;
-  padding: 0;
-}
-
-.item {
+.summaryBlock,
+.translationBlock,
+.tagBlock,
+.labBlock,
+.cheatBlock,
+.resources {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 16px 18px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(255, 255, 255, 0.8);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.tone-none {
-  border-color: rgba(15, 23, 42, 0.08);
-}
-
-.tone-future {
-  border-color: rgba(37, 99, 235, 0.25);
-}
-
-.tone-urgent {
-  border-color: rgba(250, 204, 21, 0.45);
-  box-shadow: 0 18px 40px -36px rgba(250, 204, 21, 0.4);
-}
-
-.tone-overdue {
-  border-color: rgba(248, 113, 113, 0.45);
-  box-shadow: 0 18px 44px -36px rgba(248, 113, 113, 0.4);
-}
-
-.itemHeader {
-  display: flex;
-  gap: 14px;
-}
-
-.itemIcon {
-  font-size: 1.6rem;
-  display: inline-flex;
-  width: 48px;
-  height: 48px;
-  border-radius: var(--ui-radius-lg);
-  align-items: center;
-  justify-content: center;
-  background: rgba(15, 23, 42, 0.08);
-}
-
-.itemBody {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.itemTitleRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-}
-
-.itemTitle {
+.summaryBlock h3,
+.translationBlock h3,
+.tagBlock h3,
+.labBlock h3,
+.cheatBlock h3,
+.resources h3 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1.2rem;
 }
 
-.statusBadge {
-  padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.status-not-started {
-  background: rgba(148, 163, 184, 0.35);
-  color: #0f172a;
-}
-
-.status-in-progress {
-  background: rgba(59, 130, 246, 0.2);
-  color: #1d4ed8;
-}
-
-.status-submitted {
-  background: rgba(14, 116, 144, 0.2);
-  color: #0f766e;
-}
-
-.status-graded {
-  background: rgba(16, 185, 129, 0.25);
-  color: #047857;
-}
-
-.status-blocked {
-  background: rgba(248, 113, 113, 0.3);
-  color: #7f1d1d;
-}
-
-.status-scheduled {
-  background: rgba(250, 204, 21, 0.25);
-  color: #92400e;
-}
-
-.itemSummary {
+.summaryEnglish {
   margin: 0;
-  color: var(--ui-text-secondary);
+  line-height: 1.6;
+  color: var(--ui-text-primary, #1f2937);
+}
+
+.summaryOriginal {
+  margin: 0;
   line-height: 1.5;
+  color: var(--ui-text-secondary, #475569);
+  font-style: italic;
 }
 
-.translationNotes {
-  padding: 12px;
-  border-radius: var(--ui-radius-md);
-  background: rgba(14, 165, 233, 0.12);
-  border: 1px solid rgba(14, 165, 233, 0.2);
+.translationBlock p {
+  margin: 0;
+}
+
+.glossaryList {
+  margin: 0;
+  padding-left: 20px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.glossaryRow {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.glossaryChips {
-  display: flex;
   gap: 6px;
-  flex-wrap: wrap;
 }
 
-.chipSoft {
-  padding: 4px 8px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(15, 23, 42, 0.08);
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.translationNote {
-  margin: 0;
-  color: rgba(15, 118, 110, 0.9);
-}
-
-.tagRow {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.itemMeta {
+.tagPillRow {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  align-items: center;
 }
 
-.metaBadge {
+.tagPill {
+  display: inline-flex;
+  align-items: center;
   padding: 4px 10px;
-  border-radius: var(--ui-radius-pill);
-  background: rgba(15, 23, 42, 0.08);
-  font-size: 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+  font-size: 0.8rem;
   font-weight: 600;
 }
 
-.badgeSoft {
-  background: rgba(248, 250, 252, 0.9);
-  border: 1px dashed rgba(15, 23, 42, 0.16);
+.labBlock .meta {
+  color: var(--ui-text-secondary, #475569);
 }
 
-.metaButton {
-  padding: 6px 12px;
-  border-radius: var(--ui-radius-pill);
-  border: 1px solid rgba(37, 99, 235, 0.35);
-  background: rgba(37, 99, 235, 0.12);
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
-}
-
-.metaButton:hover,
-.metaButton:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 18px 36px -34px rgba(37, 99, 235, 0.5);
-}
-
-.metaButtonActive {
-  border-color: rgba(14, 165, 233, 0.6);
-  background: rgba(14, 165, 233, 0.15);
-}
-
-.metaTranslationStatus {
-  background: rgba(34, 197, 94, 0.18);
-  color: #047857;
-}
-
-.labDetails {
-  border-top: 1px dashed rgba(15, 23, 42, 0.12);
-  padding-top: 12px;
-  color: var(--ui-text-secondary);
-}
-
-.labDetails summary {
-  cursor: pointer;
-  font-weight: 600;
-  margin-bottom: 8px;
-}
-
-.labEnvironment {
-  margin: 0 0 8px;
-}
-
-.labDeliverable {
-  margin: 8px 0 0;
-}
-
-.reflectionBox {
-  margin-top: 12px;
-  padding: 16px 18px;
-  border-radius: var(--ui-radius-lg);
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-}
-
-.reflectionBox h3 {
-  margin: 0 0 10px;
-}
-
-.reflectionBox ul {
+.checklist {
   margin: 0;
-  padding-left: 18px;
+  padding-left: 20px;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.cheatSection {
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px dashed rgba(15, 23, 42, 0.12);
-}
-
-.cheatHeading {
-  margin: 0 0 14px;
-  font-size: 1.05rem;
-  font-family: var(--ui-font-display);
-}
-
-.cheatGrid {
-  display: grid;
+.cheatList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .cheatCard {
-  padding: 16px;
-  border-radius: var(--ui-radius-lg);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(255, 255, 255, 0.82);
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: rgba(248, 250, 252, 0.95);
+  padding: 18px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
 }
 
-.cheatCardHeader {
-  display: flex;
-  justify-content: space-between;
-  gap: 14px;
-  align-items: flex-start;
-}
-
-.cheatTitle {
+.cheatCard h4 {
   margin: 0;
-  font-size: 1rem;
 }
 
-.cheatDescription {
-  margin: 6px 0 0;
-  color: var(--ui-text-secondary);
-  line-height: 1.5;
-}
-
-.cheatBadges {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 8px;
-}
-
-.cheatSummaries {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.cheatSummary {
-  margin: 0;
-  line-height: 1.6;
-}
-
-.cheatSummarySecondary {
-  margin: 0;
-  color: var(--ui-text-secondary);
-}
-
-.cheatOutline {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.cheatSectionDetails {
+.cheatCard details {
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.85);
   padding: 10px 12px;
-  border-radius: var(--ui-radius-md);
-  background: rgba(79, 70, 229, 0.08);
-  border: 1px solid rgba(79, 70, 229, 0.18);
 }
 
-.cheatSectionDetails summary {
+.cheatCard summary {
   cursor: pointer;
   font-weight: 600;
-  margin-bottom: 8px;
 }
 
-.cheatSectionDetails ul {
+.resourceList {
+  list-style: none;
   margin: 0;
-  padding-left: 18px;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 10px;
 }
 
-.cheatTips {
-  padding: 12px;
-  border-radius: var(--ui-radius-md);
-  background: rgba(16, 185, 129, 0.12);
-  border: 1px solid rgba(16, 185, 129, 0.2);
-}
-
-.cheatTipsHeading {
-  margin: 0 0 8px;
-  font-weight: 700;
-  font-size: 0.95rem;
-}
-
-.cheatTips ul {
-  margin: 0;
-  padding-left: 18px;
+.resourceLink {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.92);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
 }
 
-.cheatDownload {
-  margin: 0;
-  color: rgba(15, 118, 110, 0.9);
+.resourceLink:hover,
+.resourceLink:focus-visible {
+  border-color: rgba(59, 130, 246, 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px -24px rgba(59, 130, 246, 0.45);
+}
+
+.resourceIcon {
+  font-size: 1.4rem;
+}
+
+.resourceLabel {
   font-weight: 600;
 }
 
 @media (max-width: 960px) {
-  .layout {
+  .workspace {
     grid-template-columns: 1fr;
   }
 
-  .subjectList {
-    flex-direction: row;
-    overflow-x: auto;
-    padding-bottom: 8px;
+  .tree {
+    position: relative;
+    overflow: hidden;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tree,
+  .detail,
+  .cheatCard,
+  .resourceLink {
+    background: rgba(30, 41, 59, 0.65);
+    border-color: rgba(148, 163, 184, 0.25);
   }
 
-  .subjectListItem {
-    min-width: 260px;
+  .treeCourse,
+  .treeItem {
+    background: rgba(51, 65, 85, 0.5);
+  }
+
+  .treeCourseActive {
+    background: rgba(96, 165, 250, 0.35);
+  }
+
+  .treeItemActive {
+    background: rgba(129, 140, 248, 0.5);
+    color: rgba(226, 232, 240, 0.95);
+  }
+
+  .intro,
+  .meta,
+  .treeMeta,
+  .detailMetaRow,
+  .summaryOriginal,
+  .emptyState,
+  .detailPlaceholder p,
+  .labBlock .meta {
+    color: rgba(226, 232, 240, 0.82);
+  }
+
+  .tagPill {
+    background: rgba(59, 130, 246, 0.35);
+    color: rgba(224, 231, 255, 0.95);
+  }
+
+  .treeItemKind {
+    color: rgba(226, 232, 240, 0.7);
+  }
+
+  .cheatCard details {
+    background: rgba(15, 23, 42, 0.55);
   }
 }


### PR DESCRIPTION
## Summary
- restructure the subjects page into a collapsible navigation tree so learners move from subject to course to individual lessons or labs
- introduce a focused lesson detail workspace that surfaces summaries, translation aids, lab checklists, cheat sheets, and original resources only after a lesson is selected
- refresh the page styling to support the new tree layout and improve readability across light and dark themes

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d81957b11c832497efd035079d0b47