### PR TITLE
Embed original lesson pdf content into summaries

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,7 +7,8 @@ const config: Config = {
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '\\.(css|less|sass|scss)$': 'identity-obj-proxy'
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '^(.*\\.txt)\\?raw$': '$1'
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
@@ -16,7 +17,8 @@ const config: Config = {
       {
         tsconfig: '<rootDir>/tsconfig.test.json'
       }
-    ]
+    ],
+    '^.+\\.txt$': '<rootDir>/scripts/jestRawTextTransform.cjs'
   }
 };
 

--- a/scripts/jestRawTextTransform.cjs
+++ b/scripts/jestRawTextTransform.cjs
@@ -1,0 +1,10 @@
+const { readFileSync } = require('node:fs');
+
+module.exports = {
+  process(sourceText, sourcePath) {
+    const content = sourceText ?? readFileSync(sourcePath, 'utf8');
+    return {
+      code: `module.exports = ${JSON.stringify(content)};`,
+    };
+  },
+};

--- a/src/data/lessonSummaries/index.ts
+++ b/src/data/lessonSummaries/index.ts
@@ -1,23 +1,24 @@
 import { LessonSummaryContent } from '../../types/subject';
+import { admeavSlideT0Summary } from './admeav-slide-t0';
+import { admeavSlideT1Summary } from './admeav-slide-t1';
+import { admeavSlideT2Summary } from './admeav-slide-t2';
+import { dbdPresentacionSummary } from './dbd-presentacion';
+import { dbdTema1Summary } from './dbd-tema-1';
+import { dbdTema2Summary } from './dbd-tema-2';
+import { ggoTema1Summary } from './ggo-tema-1';
+import { ggoTema2Summary } from './ggo-tema-2';
+import { ggoTema3Summary } from './ggo-tema-3';
 import { sadSession0Summary } from './sad-session-0';
 import { sadSession1Summary } from './sad-session-1';
 import { sadSession2Summary } from './sad-session-2';
 import { sadSession3Summary } from './sad-session-3';
-import { ggoTema1Summary } from './ggo-tema-1';
-import { ggoTema2Summary } from './ggo-tema-2';
-import { ggoTema3Summary } from './ggo-tema-3';
-import { dbdPresentacionSummary } from './dbd-presentacion';
-import { dbdTema1Summary } from './dbd-tema-1';
-import { dbdTema2Summary } from './dbd-tema-2';
 import { snlpChapter1Summary } from './snlp-chapter-1';
 import { snlpChapter2Summary } from './snlp-chapter-2';
 import { snlpChapter3Summary } from './snlp-chapter-3';
 import { snlpChapter4Summary } from './snlp-chapter-4';
 import { snlpChapter5Summary } from './snlp-chapter-5';
 import { snlpChapter6Summary } from './snlp-chapter-6';
-import { admeavSlideT0Summary } from './admeav-slide-t0';
-import { admeavSlideT1Summary } from './admeav-slide-t1';
-import { admeavSlideT2Summary } from './admeav-slide-t2';
+import { englishLessonIds, lessonSummaryText } from './text';
 
 const lessons: Record<string, LessonSummaryContent> = {
   'sad-session-0': sadSession0Summary,
@@ -40,6 +41,31 @@ const lessons: Record<string, LessonSummaryContent> = {
   'admeav-slide-t1': admeavSlideT1Summary,
   'admeav-slide-t2': admeavSlideT2Summary,
 };
+
+for (const [lessonId, text] of Object.entries(lessonSummaryText)) {
+  const summary = lessons[lessonId];
+
+  if (!summary) {
+    throw new Error(`Missing lesson summary metadata for id: ${lessonId}`);
+  }
+
+  const existingOriginal = summary.summary.original;
+  const combinedOriginal = existingOriginal ? `${existingOriginal}\n\n${text}` : text;
+  const english = englishLessonIds.has(lessonId)
+    ? summary.summary.english
+      ? `${summary.summary.english}\n\n${text}`
+      : text
+    : summary.summary.english;
+
+  lessons[lessonId] = {
+    ...summary,
+    summary: {
+      ...summary.summary,
+      original: combinedOriginal,
+      ...(english ? { english } : {}),
+    },
+  };
+}
 
 export const lessonSummaries = lessons;
 

--- a/src/data/lessonSummaries/text/admeav-slide-t0.txt
+++ b/src/data/lessonSummaries/text/admeav-slide-t0.txt
@@ -1,0 +1,103 @@
+Advanced methods of artificial vision
+Presentation
+
+Faculty
+• Aula 4P - 1.2
+– Rocío del Amor, madeam2.upv.es
+2
+
+Syllabus
+3
+
+Computer vision
+4
+
+Syllabus
+5
+Theory:
+T0. Presentation
+T1. Hand-crafted feature extraction (P1) 
+T2. CNN-based feature extraction
+T3. Transformer-based feature extraction 
+T4. Large Vision-Language Models
+T5. Avanced Learning Methodologies (P2) 
+T6. Autoencoders 
+T7. Segmentation (P3) 
+T8. Object detection and tracking (P4) 
+T9. Generative adversarial networks (P5)
+
+Syllabus
+T0,T1
+ T1
+T2
+T1
+T2
+T2
+ T3
+T4
+T5
+EX
+ T6T3
+T7
+T9
+T9
+T8
+P1
+P2
+ P3
+T3
+ T3
+T5
+R
+6
+T7
+T8T8
+T6
+P4
+T9
+P5
+T
+EX
+05/11/2025
+Exam (T1-T5)
+21/01/2025
+Exam (T6-T9)
+15/01/2025
+Project presentation
+
+Theoretical class structure
+• The theory classes will be 
+accompanied by a notebook 
+in Python (Google Collab).
+• Starting from the next 
+session, it is essential that 
+you all bring your computers 
+with a Google Collab 
+account.
+https://colab.research.google.com
+Jupyter Notebook
+15 o 20 minutos
+Theory class
+Masterclass 
+(*.PPT)
+7
+
+Assesment
+8
+The assessment of the content will consist of two parts:
+- Participation and performance in lab sessions (20% of the mark). They 
+will be assessed through the work done in the laboratory class.
+- Theoretical-practical contents (40% of the mark). They will be evaluated 
+through two written tests, each accounting for 20% of the mark, one in the 
+middle of the semester and another at the end.
+- Evaluation of the work (40% of the mark): the code presented (20%) and 
+an oral presentation of the same (20%) will be evaluated. The work may be 
+recovered by improving it as necessary in order to pass the evaluation.
+The final mark of the course, for all students, will be the maximum between the 
+ordinary evaluation and the recovery.
+
+References
+• Deep learning (Goodfellow, Ian)
+• Deep learning with Python (Chollet, François)
+• Deep Learning: Foundations and Concepts (Bishop)
+9

--- a/src/data/lessonSummaries/text/admeav-slide-t1.txt
+++ b/src/data/lessonSummaries/text/admeav-slide-t1.txt
@@ -1,0 +1,629 @@
+Advanced methods of artificial vision
+Chapter 1: Hand crafted feature extraction
+
+Index
+1.Introduction
+2.Statistical descriptors
+3.Local Binary Patterns
+4.Histogram of Oriented Gradients
+5.SIFT
+6.Gabor Filters
+2
+
+Index
+1.Introduction
+2.Statistical descriptors
+3.Local Binary Patterns
+4.Histogram of Oriented Gradients
+5.SIFT
+6.Gabor Filters
+3
+
+What is a feature?
+• A feature (also called a descriptor) is a usually numerical value that is related to some
+relevant aspect of an entire image, part of an image, or a shape resulting from a
+segmentation process.
+• Supposedly, a feature should have close values when the relevant aspect whose
+essence it is trying to capture (colour, texture, area, etc.) is similar from a human point
+of view.
+• Another highly desirable property of a good feature is its robustness, understood as
+immunity to noise (the values of the feature should not change too much if the image
+or shape on which it is calculated is affected by a moderate level of noise).
+• Generally, not a single feature is associat ed with the object of interest but several or
+many of them grouped together in what is known as a feature vector.
+4
+
+5
+Feature extraction methodology
+• How do we analyse the image?
+– Global descriptors: descripto rs for the complete image
+– Local descriptors:
+• Rectangular blocks or patches
+• Landmark extraction: Harris, SIFT,…
+• Descriptors
+– Statistical descriptors
+– Cooccurrence Matrix
+– Histograms of Oriented Gradients
+– Local Binary Patterns
+– Gabbor Filters
+– SIFT, SURF
+–… .
+
+Statistical descriptors
+• Analyse the statistical distribution of some property for each of the pixels in the image.
+• Classified into: first order methods (those based on the histogram), second order methods 
+(those based on co-occurrence matrices), and higher order methods.
+• First-order statistics:
+– The normalised histogram of the image is calculated.
+– Properties that are obtai ned from this histogram.
+6
+6
+Mean                Variance Skewne ss Kurtosis               Entropy
+
+Co-occurrence matrix
+• Histogram-based statistics have the disadvantage of losing spatial 
+information.
+• The same information would be obtained for an image of a chessboard with 
+the black and white squares swapped.
+• To capture the spatial dependencies of gr ey level values, which contribute 
+to the perception of textures present in an image, a 2D structure called co-
+occurrence matrix is defined to analyse textures.
+• The co-occurrence matrix 𝑃ሺ𝑖, 𝑗ሻ is defined by specifying a shift direction 
+𝑑ൌ𝑑 ሺ 𝑖, 𝑗ሻ and counting all pairs of pixels separated by d and having grey 
+values 𝑖 and 𝑗.
+7
+https://scikit-image.org/docs/stable/user_guide/index.html
+
+Co-occurrence matrix
+8
+8
+Contrast: 0.3307
+Correlation: 0.9032
+Energy: 0.1323
+Homogeneity: 0.8534
+1 2 3 4 5 6 7 8
+1
+2
+3
+4
+5
+6
+7
+8
+
+Index
+1.Introduction
+2.Statistical descriptors
+3.Local Binary Patterns
+4.Histogram of Oriented Gradients
+5.SIFT
+6.Gabor Filters
+9
+
+Local Binary Patterns(LBP)
+10
+Ojala T, Pietikäinen M & Mäenpää T (2002) Multiresolution gray-scale and rotation invariant texture
+classification with Local Binary Patterns. IEEE Transactions on Pattern Analysis and Machine Intelligence
+24(7):971-987.
+
+Local Binary Patterns(LBP)
+11
+𝑃ൌ 8 y  R ൌ 1
+𝑃 P is the number of neighbours and  R is the neighbourhood radius.
+𝑃ൌ 16 y  R ൌ 2 𝑃ൌ 8 y  R ൌ 2
+
+Local Binary Patterns(LBP)
+12
+Histogram of 2௉ values
+
+Local Binary Patterns(LBP)
+13
+              
+𝑅𝑂𝑅ሺ𝑥, 𝑡ሻ performs 𝑡 different rotations of the 𝑥 bits 
+• e.g. 10000010, 00101000, and 00000101 are equivalent to the minimum code 00000101.
+• 𝑃ൌ 8 256 different and 36 rotationally invariant LBP patterns
+LBPRi (LBP Rotational Invariant)
+Uniform LBP 
+• Objetive: to reduce the number of possible patterns to the 
+really discriminating ones.
+• How? By analysing the uniformity (U) of the patterns : 
+number of transitions from 0 to 1 and 1 to 0.
+
+Local Binary Patterns(LBP)
+14
+Uniform rotationally invariant LBP: LBPriu2
+• Patterns with U=0 or U=2 are reassigned an individual pattern 
+code.
+• All other patterns are reassigned the same code (they become 
+indistinguishable).
+• LBP: 256 patterns, LBP Uniform: (58 + 1) patterns, (9+1) 
+rotationally invariant . In general (P+2)
+
+Local Binary Patterns(LBP)
+15
+Uniform rotationally invariant LBP: LBPriu2
+
+Local Binary Patterns(LBP)
+16
+http://scikit-image.org/docs/dev/auto_examples/plot_local_binary_pattern.html
+
+Local Binary Patterns(LBP)
+17
+LBP LBPri LBPriu2
+LBP LBPri
+LBPriu2
+P=8 R=1
+
+Local Binary Patterns(LBP)
+18
+
+Local Binary Patterns(LBP)
+19
+Original: i Máscara: mask Luminancia: ig LBP Histograma LBP
+sana
+Cáncer 
+grado 3
+Cáncer 
+grado 5
+
+Index
+1.Introduction
+2.Statistical descriptors
+3.Local Binary Patterns
+4.Histogram of Oriented Gradients
+5.SIFT
+6.Gabor Filters
+20
+
+Histograms of Oriented
+Gradients (HOG)
+• The histogram of oriented gradients (HOG ) is a widely used descriptor in image 
+processing for the purpose of object detection. The technique counts the occurrences of 
+gradient orientation in localised portions of an image. 
+• Algorithm:
+– Gradient calculation
+– Grouping the orientations
+– Block descriptor
+– Block normalisation
+21
+
+22
+Convolution
+7275716359626674
+7275706258616572
+6973696359636871
+6973696259626770
+7274706157596470
+6869686563646668
+6769696766676970
+6366676564666869
+-101
+-202
+-101
+10-1
+20-2
+10-1
+𝑦 𝑚, 𝑛ൌ 𝑥 𝑚, 𝑛∗ ℎ𝑚, 𝑛ൌ ෍ ෍ 𝑥𝑘, 𝑙ℎ ሾ 𝑚െ𝑘, 𝑛െ𝑙ሿ
+௟௞
+Kernel
+ℎሾെ𝑘, െ𝑙]ℎሾ𝑘, 𝑙]
+െ1 ∗62 ൅0 ∗59 ൅1 ∗62 ൅ሺെ2ሻ∗ 59 ൅0 ∗57 ൅2 ∗61 ൅ሺെ1ሻ∗ 64 ൅0 ∗63 ൅1 ∗65 ൌ 3
+3
+Imagen de salida
+22
+
+23
+Gradient Computation
+-101
+-202
+-101
+121
+000
+-1-2-1
+𝑀𝑎𝑔𝑛𝑖𝑡𝑢𝑑𝑒 ൌ 𝐺௫ଶ ൅𝐺௬ଶ
+𝐺௫ 𝐺௬
+𝑂𝑟𝑖𝑒𝑛𝑡𝑎𝑡𝑖𝑜𝑛 ൌtanିଵ 𝐺௬
+𝐺௫ 23
+
+Histograms of Oriented
+Gradients (HOG)
+• Division of the image into cells of fixed size.  
+• Calculation of a histogram of the orientations in each cell.
+• Global descriptor combines histograms of all cells.
+24
+orientation
+
+Histograms of Oriented
+Gradients (HOG)
+• Division of the range of orientations into a fixed number of intervals.
+• Assign each pixel in the cell to an interval based on the gradient orientation.
+• Accumulate the gradient magnitude of all pixels assigned to an interval.
+25
+orientation
+orientation
+
+Histograms of Oriented
+Gradients (HOG)
+Orientation histogram calculation: interpolation in orientation
+• Problems
+– Gradients with very similar orientations  can be assigned to different intervals.
+– Sensitive to small gradient variations.
+• Solution:
+– Assign each gradient to the two closest intervals with a we ight proportional to the distance from the orientation 
+to the centre of each interval.
+26
+orientation
+orientation
+
+Histograms of Oriented
+Gradients (HOG)
+Assign each gradient to the two closest intervals with a weight proportional to the distance from 
+the orientation to the centre of each interval.
+𝑔 𝑥, 𝑦ൌ 100
+𝜃 𝑥, 𝑦ൌ 45º
+Assuming that for the histogram calculation the orientation is divided into 9 intervals (without 
+considering the sign), what would be the contribution of this pixel to each of the intervals of the 
+histogram?
+27
+
+Histograms of Oriented
+Gradients (HOG)
+Assign each gradient to the two closest intervals with a weight proportional to the distance from 
+the orientation to the centre of each interval.
+𝑔 𝑥, 𝑦ൌ 100
+𝜃 𝑥, 𝑦ൌ 45º
+Assuming that for the histogram calculation the orientation is divided into 9 intervals (without 
+considering the sign), what would be the contribution of this pixel to each of the intervals of the 
+histogram?
+28
+00 000007525
+
+Histograms of Oriented
+Gradients (HOG)
+29
+Orientation histogram calculation: spatial integration
+• A histogram is calculated for each of the cells.
+• Each pixel contributes to the histogram of its corresponding cell.
+𝑖
+𝑗
+1  2  3 4  5  6  7  8  9
+
+Histograms of Oriented
+Gradients (HOG)
+30
+Orientation histogram calculation: spatial integration
+• Problems
+• Pixels in close proximity can be assigned to different cells.
+• Sensitive to small variations in object shape.
+• Solution:
+• Assign each pixel to the four nearest cells with a weight proportional to the distance of the pixel from the centre
+of each cell.
+1  2  3 4  5  6  7  8  9
+
+Histograms of Oriented
+Gradients (HOG)
+31
+Given an image and the division into cells as shown and assuming that the orientation is divided 
+into 9 intervals without considering the sign (0º-180º), in which histograms (𝑖,𝑗) of the final 
+representation and in which intervals 𝑘 and with which weight will the pixel (𝑥=12,𝑦=18) with 
+orientation 𝜃ൌ 60º contribute?
+
+Histograms of Oriented
+Gradients (HOG)
+32
+Given an image and the division into cells as shown and assuming that the orientation is divided 
+into 9 intervals without considering the sign (0º-180º), in which histograms (𝑖,𝑗) of the final 
+representation and in which intervals 𝑘 and with which weight will the pixel (𝑥=12,𝑦=18) with 
+orientation 𝜃ൌ 60º contribute?
+
+Histograms of Oriented
+Gradients (HOG)
+33
+Block normalisation
+• Grouping of cells in blocks of b x b cells.
+• Single vector per block concatenating the histograms of all cells.
+• Vector normalisation using the L2 norm.
+𝐶ଵଵ 𝐶ଵଶ
+𝐶ଶଵ 𝐶ଶଶ
+𝑣ൌሺ 𝑥ଵ, 𝑥ଶ,…, 𝑥ேሻ
+𝑣ᇱ ൌ 𝑣
+𝑣 ଶ
+ଶ ൅𝜀
+ൌ 𝑣
+𝑥ଵ
+ଶ ൅𝑥ଶ
+ଶ ൅⋯൅𝑥 ே
+ଶ ൅𝜀
+
+Histograms of Oriented
+Gradients (HOG)
+34
+Final descriptor 
+• Block overlap.  
+• For each block, normalised histogram of cells.
+• Final descriptor: concatenation of all block histograms 
+𝐻𝑂𝐺 ൌ ሺ𝑥ଵ, 𝑥ଶ… 𝑥ே)
+
+Histograms of Oriented
+Gradients (HOG)
+35
+Final descriptor
+• Each cell contributes to the description of several blocks.
+• In each block with a different normalization.
+
+Index
+1.Introduction
+2.Statistical descriptors
+3.Local Binary Patterns
+4.Histogram of Oriented Gradients
+5.SIFT
+6.Gabor Filters
+36
+
+37
+Keypoint detector
+Test image Detector: locates 
+single-scale or multi-
+scale points of interest.
+Descriptor: 
+Content invariant 
+representation
+(HOG, SIFT, etc.)
+
+38
+Harris’ detector
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+xx
+xx
+x
+y
+x
+xy
+x
+yx
+x
+x
+xxx
+xxx
+x
+N
+N
+N
+N
+)()()(
+)()()(
+)( 2
+2
+III
+III
+C
+
+
+
+
+2
+1
+λ0
+0λ)(xCExample
+General case RRC 
+
+
+ 
+2
+11
+λ0
+0λ)(x
+1λ 2λ
+1λ 2λhigh and       small: edge
+1λ 2λsmall and       high: edge
+1λ 2λ
+For each pixel is calculated:
+and         high: corner
+and         small: flat area
+
+39
+Harris’ detector
+• Algorithm designed for motion tracking.
+• Reduces calculation time co mpared to tracking all points. 
+• Invariant to translation and rotation.
+• Not invariant to scale changes.
+• Algorithm
+– Reduce image noise (Gaussian filter for example).
+– Image gradients calculation.
+– Construct the matrix C for each pixel.
+– Obtain and analyse determinant (          ) and trace (              )  
+of the matrix C.
+21 λλ 
+ 21 λλ 
+
+40
+Matching of features
+Original images
+Keypoints (corners) 
+detected with Harris’ 
+detector
+
+41
+Matching of features
+CORRELATION
+
+
+
+
+
+2211
+2211
+2
+2
+2
+1
+,
+21
+21
+)()(
+)()(
+),(
+xx
+xx
+xx
+xx
+xx
+xx
+xx
+NN
+NN
+ss
+ss
+R
+
+42
+Matching of features
+Need for a robust algorithm
+Search of matchings: Putative matchings
+
+43
+Robust estimation
+RANSAC (RANdom SAmple Consensus)
+Algorithm
+1. Take a sample: minimum number of points to 
+estimate the model.
+2. Look at the support of that model: number of points 
+below a distance t (consensusset).
+3. Repeat the process for N samples and select the 
+model with the highest support.
+4. Points with a distance less than t are 
+inliers.Reestimate the model with all inliers.
+
+44
+Example RANSAC
+Initial matches
+Robust estimation
+
+45
+RANSAC estimation: Panoramic image construction
+Robust estimation
+
+46
+Robust estimation
+RANSAC estimation: Panoramic image construction
+
+47
+Robust estimation
+RANSAC estimation: Panoramic image construction
+
+48
+SIFT Detector
+SIFT (Scale Invariant Feature Transform)
+• Invariant descriptor to position, scale, rotation, illumination, contrast and point of
+view.
+• Algorithm
+1. Detection of extremes in scale and space: Extract rotation and scale
+invariant points of interest (keypoints).
+2. Eliminate ‘weak’ keypoints.
+3. Orientation assignment: Assign one or more orientations to each point of
+interest.
+4. Keypoint descriptor: Use local gradients at the selected scale.
+D. Lowe, “Distinctive Image Features from Scale-Invariant  Keypoints”, International Journal of 
+Computer Vision, 60(2):91-110, 2004.
+
+49
+SIFT: Extrema detection 
+k0σ0
+k1σ0
+𝐷 𝑥, 𝑦, 𝜎ൌ 𝐿 𝑥, 𝑦, 𝑘𝜎 െ𝐿 𝑥, 𝑦, 𝜎
+𝐿 𝑥, 𝑦, 𝜎ൌ 𝐺 𝑥, 𝑦, 𝜎∗ 𝐼 𝑥, 𝑦,
+𝑘ௌ ൌ 2ௌ
+
+50
+SIFT: Weak keypoints elimination
+(a)Image 233x189
+(b) 832 extreme DoG
+(c) 729 left after low contrast 
+thresholding
+(d) 536 after Hessian ratio
+Weak keypoints
+• keypoints with low contrast (<0.03).
+• Bad edge
+
+51
+SIFT Descriptor
+Orientation assignment
+• Histogram of gradient directions for each keypoint.
+• Histogram weighted by the magnitude of the gradient and by a 
+Gaussian function with σ=1.5 s.
+22( ,) (( 1 ,) ( 1 ,) ) (( , 1 ) ( , 1 ) )
+( , ) tan 2(( ( , 1) ( , 1)) / ( ( 1, ) ( 1, )))
+mxy Lx y Lx y Lxy Lxy
+x ya L x y L x y L x yL x y
+
+   
+     
+𝐿 𝑥, 𝑦, 𝜎ൌ 𝐺 𝑥, 𝑦, 𝜎∗ 𝐼 𝑥, 𝑦,
+0 2 
+
+52
+SIFT descriptor
+Orientation assignment
+1. 16 x16 window around each keypoint.
+2. Divide into 4x4 cells.
+3. Calculate the histogram in each cell (partial vote).
+(8 bins)
+16 histograms x 8 orientations 
+= 128 features
+
+SIFT Detector
+
+SIFT: Matching of features
+Descriptor with mínimum distance
+Problems with ambiguities
+I1 I2
+
+
+
+N
+i
+ii ffffSSD
+1
+2
+2121 )(),(
+f1
+ f2
+
+SIFT: Matching of features
+Problems with ambiguities
+I1 I2
+f1
+ f2
+
+Index
+1.Introduction
+2.Statistical descriptors
+3.Local Binary Patterns
+4.Histogram of Oriented Gradients
+5.SIFT
+6.Gabor Filters
+56
+
+Gabor filters
+• Bank of linear filters.
+• Each filter analyzes whether there is any specific  frequency content in the image in specific 
+directions.
+• Image analysis with Gabor filters is thought by some to be similar to perception in the human 
+visual system.
+Source: Deep Learning: Foundations and 
+Concepts. Christopher M. Bishop and Hugh 
+Bishop

--- a/src/data/lessonSummaries/text/admeav-slide-t2.txt
+++ b/src/data/lessonSummaries/text/admeav-slide-t2.txt
@@ -1,0 +1,1071 @@
+Advanced methods of artificial vision
+Unit 2: CNN-based feature extraction
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+2
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+3
+
+4
+A neural network (NN) is a set of layers composed of neurons.
+NN of 2 layers NN of 3 layers
+fully connected layers: Denses
+Neural Networks: Structure
+
+5
+𝑓෍
+𝑖
+𝑤𝑖𝑥𝑖 +𝑏𝑤1𝑥1
+𝑤2𝑥2
+𝑓 𝑧 = 𝑎
+𝒛
+𝑥1
+𝑥2
+1 1
+𝑤1,1
+0
+𝑤2,1
+0
+𝑤1,2
+0
+𝑤2,2
+0
+𝑤1,1
+1
+𝑤2,1
+1
+𝑏0 𝑏1
+𝑧1
+1
+𝑧2
+1
+𝑎1
+1
+𝑎2
+1
+𝑧1
+2 𝑎1
+2 ො𝑦
+Neural Networks: Structure
+
+6
+ෝ𝑦𝑖
+𝑤1,1
+0
+𝑤1,2
+0
+𝑤1,1
+1
+𝑤4,4
+1
+𝑓(𝑊1𝑥𝑖 +𝑏0)
+𝑊0 =
+𝑤1,1
+0 𝑤2,1
+0 𝑤3,1
+0
+𝑤1,2
+0 𝑤2,2
+0 𝑤3,2
+0
+𝑤1,3
+0
+𝑤1,4
+0
+𝑤2,3
+0
+𝑤2,4
+0
+𝑤3,3
+0
+𝑤3,4
+0
+𝐷1×𝐷
+𝑊1 = 𝐷2×𝐷1
+𝑊2 = 𝐾×𝐷2
+𝑓(𝑊1𝑎1 +𝑏1) 𝑓(𝑊2𝑎2 +𝑏2)
+𝑥𝑖 =
+𝑥1
+𝑥2
+𝑥3
+ 
+𝑤1,1
+2
+Neural Networks: Structure
+
+Optimization
+7
+MLP   𝑥𝑖
+ො𝑦𝑖
+𝐽 = ෍
+𝑖
+𝑦𝑖 − ො𝑦𝑖 2
+𝑦𝑖
+Optimise 𝑊0, 𝑊1, 𝑊2, 𝑏0, 𝑏1, 𝑏2
+
+Optimization
+8
+𝐽 = ෍
+𝑖
+𝑦𝑖 − ො𝑦𝑖 2 𝑎𝑟𝑔𝑚𝑖𝑛𝑊,𝑏 𝐽
+𝛻𝐽 = 0 𝛻𝐽 = 𝜕𝐽
+𝜕𝑤0
+𝜕𝐽
+𝜕𝑤1
+= 0
+𝐽 = 2+0.5× 𝑤0
+2 +𝑤1
+2 −0.5×𝑤0 ×𝑤1 +1.7×𝑤1
+To solve this system
+
+Optimization: Gradient Descent
+9
+Iterative process:
+𝑤0(𝑡+1) = 𝑤0(𝑡)−η 𝜕𝐽
+𝜕𝑤0
+𝑤1(𝑡+1) = 𝑤1(𝑡)−η 𝜕𝐽
+𝜕𝑤1
+η: learning rate
+- High values: fast learning but be 
+careful with convergence
+- Valores bajos: slow learning
+
+Gradient descent variants
+10
+• Gradient Descent: original (vanilla version)
+• For each training set data:
+• Fordward pass
+• Error calculation and accumulation
+• Update the weights (backpropagation)
+• Stocasthic Gradient Descent (SGD)
+• For each training set data:
+• Fordward pass
+• Error calcutlation and accumulation
+• Update the weights (backpropagation)
+• Minibacth Gradient Descent (SGD)
+• Divide the training set in batches
+• For each batch
+• For each data from the batch
+• Fordward pass
+• Error calculation and accumulation
+• Update the weights (backpropagation)
+The weights are updated 
+only once in the training set
+The weights are updated for 
+each data in the training set
+The weights are updated for 
+each batch in the training 
+set
+Consume a lot of 
+resources but it is 
+more precise
+Optimal with 
+vectorised
+versions of 
+the 
+algorithm
+Hyperparameter to optimise, the batch size: for example in CNNs it is 
+usually 256 for a training set of 1.2 million.
+
+Forward-Backward propagation
+11
+Training data
+
+Effect of learning rate
+12
+
+Data partitioning
+13
+data
+Training (70-80%) Test (20-30%)
+20-30%  training
+Validation Test (20-30%)Training
+batch1 batch2 batch3 batch4 batch5 .  .  . Batch N-1 batch N
+
+Training process
+14
+. . .
+epoch 1 epoch M
+Training Training Training
+Validation Validation Validation
+Model 1 Model 2 Model M
+Test
+Model with highest accuracy 
+or lowest validation loss
+epoch 2
+
+Activation functions
+15
+Sigmoid
+Hyperbolic tangent
+Relu (Rectified Linear Unit)
+𝑓 𝑥 = 𝜎 𝑥 = 1
+1+𝑒−𝑥
+𝑓 𝑥 = 𝑡𝑎𝑛ℎ 𝑥 =2𝜎 2𝑥 −1
+𝑓 𝑥 = max(0,𝑥)
+𝑓 𝑥 = α∗𝑥 𝑥 < 0 +𝑥(𝑥 ≥ 0)
+Elu (Exponential Linear Unit) (𝛼=1) 
+Leaky Relu (𝛼=0.3) 
+𝑓 𝑥 = α∗(𝑒𝑥 −1) 𝑥 < 0 +𝑥(𝑥 ≥ 0)
+
+Optimizers
+16
+
+17
+
+18
+Vary the learning rate throughout the training, with epochs: larger at the 
+beginning and more precise at the end.
+•  “Step decay”: Reduce the learning rate by some factor every few 
+epochs.Typical values might be to reduce the learning rate by half every 5 
+epochs, or by 0.1 every 20 epochs. 
+In practice: (observe the validation error while training with a fixed learning rate, 
+and reduce the learning rate by a constant (e.g. 0.5) every time the validation 
+error stops improving.
+•  “Exponential decay”: 
+𝜂 = 𝜂0𝑒−𝑘𝑡
+• "1/t decay”: 
+𝜂 = 𝜂0
+1+𝑘𝑡𝑒−𝑘𝑡
+𝜂0,𝑘: hyperparameters    𝑡: number of epoch
+NN: learning rate optimization
+
+Detecting overfitting
+19
+
+Detecting overfitting
+20
+
+21
+Regularization penalty
+𝝀 :regularization strength
+– 𝑳𝟐
+– 𝑳𝟏
+– Elastic Net
+𝐿 = 1
+𝑁෍
+𝑖=1
+𝑁
+𝐿𝑖 𝐿 = 1
+𝑁෍
+𝑖=1
+𝑁
+𝐿𝑖 +λ𝑅(𝑊)
+𝑅(𝑊) = ෍
+𝑖
+෍
+𝑗
+𝑊𝑖,𝑗
+2
+𝑅(𝑊) = ෍
+𝑖
+෍
+𝑗
+𝑊𝑖,𝑗
+𝑅(𝑊) = ෍
+𝑖
+෍
+𝑗
+𝑊𝑖,𝑗
+2 +𝛽 𝑊𝑖,𝑗 W(𝑡 +1) = 𝑊(𝑡)−η𝛻𝐽
+W 𝑡 +1 = 𝑊 𝑡 −η𝛻𝐽+λ𝑅(𝑊)
+Update without regularization
+Update with regularization
+Loss with regularizationLoss without regularization
+
+Drop-oupt
+22
+•  “drop-out”: randomly disconnect inputs from one layer to the next with a probability 𝑝: prob. to maintain 
+the link or to disconnect it (implementation dependent)
+• For a batch, the links are deactivated for the forward and backward propagation stages, then reactivated and 
+randomly deactivated again for the next batch.
+• dropout only is used in training.
+•  Disconnecting connections randomly ensures that no single node is always responsible for "activating" when a 
+given pattern occurs. It ensures that there are multiple, redundant nodes that will be triggered when similar inputs 
+are presented, which in turn helps our model to generalise.
+Without drop-out Drop-out with 𝑝 = 0.5
+
+23
+KERAS
+• Keras is a high-level framework for training neural networks. This library was 
+developed by François Chollet in 2015 with the aim of simplifying the programming 
+of algorithms based on deep learning.
+• It offers a more intuitive and high-level set of abstractions. Training can still be 
+done on GPU, remembering that this is the only way we have to train a neural 
+network in an allowable time interval.
+
+24
+Basic layers in Keras
+keras.layers.Dense(units, activation=None, use_bias=True, 
+kernel_initializer='glorot_uniform', bias_initializer='zeros')
+keras.layers.Activation(activation)
+keras.layers.Dropout(rate, noise_shape=None, seed=None)
+keras.layers.Conv2D(filters, kernel_size, strides=(1, 1), padding='valid')
+keras.layers.MaxPooling2D(pool_size=(2, 2), strides=None, padding='valid', 
+data_format=None)
+keras.layers.BatchNormalization(axis=-1, momentum=0.99, epsilon=0.001, 
+center=True, scale=True)
+keras.layers.Flatten(data_format=None)
+https://keras.io/layers/core/ 
+Keras documentation
+
+25
+Architecture definition: 
+Sequential mode
+Sequential mode (or API): An object of type Model () is instantiated and the layers 
+that make up the architecture are added one after the other.
+# Imports 
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Activation
+# Sequential model
+model = Sequential()
+# Architecture definition
+model.add(Dense(64, input_dim=784))
+model.add(Activation('relu'))
+model.add(Dense(64, activation='relu'))
+model.add(Dense(10, activation='softmax'))
+https://keras.io/models/sequential/
+
+26
+Architecture definition: 
+Functional mode
+Functional mode (or API): An input is defined and the architecture is defined from these inputs (indicating which 
+is the input to each layer). Once the architecture has been defined, the model object is created by passing it the 
+inputs and outputs (last layer defined).
+# Imports 
+from tensorflow.keras.layers import Input, Dense
+from tensorflow.keras.models import Model 
+# Input definition
+inputs = Input(shape=(784,))
+# Architecture definition
+x = Dense(64, activation='relu')(inputs)
+x = Dense(64, activation='relu')(x)
+predictions = Dense(10, activation='softmax')(x)
+# We create the model object as a union of inputs and architecture
+model = Model(inputs=inputs, outputs=predictions)
+https://keras.io/models/model/
+
+27
+Compiling a Keras model
+Before training the model in Keras, it is necessary to compile it by configuring the training 
+process. This process is carried out by means of the command model.compile.
+# Example for a multi-class classification problem
+model.compile(optimizer=‘sgd',
+              loss='categorical_crossentropy',
+              metrics=['accuracy'])
+# Example for a binary classification problem
+model.compile(optimizer=SGD(lr=0.01, decay=1e-6, momentum=0.9, 
+nesterov=True),
+              loss='binary_crossentropy',
+              metrics=['accuracy'])
+# Example for a regression problem
+model.compile(optimizer='rmsprop',
+              loss='mse')
+
+28
+Training in Keras
+Once the model has been compiled in Keras it is possible to launch the training process. Keras trains models 
+from data and labels stored in Numpy arrays using the model.fit method.
+# Data generation
+import numpy as np
+data = np.random.random((1000, 100))
+labels = np.random.randint(2, size=(1000, 1)) 
+# Example with labels in one-hot encoding
+model.compile(optimizer='rmsprop',loss='categorical_crossentropy',
+              metrics=['accuracy'])
+one_hot_labels = keras.utils.to_categorical(labels, num_classes=10)
+model.fit(data, one_hot_labels, epochs=10, batch_size=32)
+# Example with categorical labels
+model.compile(optimizer='rmsprop', loss=‘sparse_categorical_crossentropy',
+              metrics=['accuracy'])
+model.fit(data, labels, epochs=10, validation_data=(data_v, labels_v), 
+batch_size=32)
+
+29
+Prediction and evaluation in 
+Keras
+Once the trained model is available, an evaluation of the model must be carried out. T o do 
+this, the test data is predicted with the model.predict command and then performance 
+metrics are obtained or model.evaluate is used
+# Example with model.evaluate
+model.evaluate(x=X_test, y=y_test, batch_size=None)
+%% Returns the values of losses and metrics used in training for the test data.
+# Example with model.predict and evaluation_report
+from sklearn.metrics import classification_report
+predictions = model.predict(x=X_test, batch_size=None)
+print(classification_report(y_labels,predictions.argmax(axis=1))
+%% Returns more metrics
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+30
+
+Concept of image
+31
+Gray image RGB image
+level: 0….255 (black….white)
+
+Problem with images
+32
+28
+28
+784
+200
+200x784= 156.800 weights
+Example: In the MNIST database for image classification
+• When the size of the image starts to grow, using fully connected 
+layers (one neuron per pixel) becomes unfeasible.
+
+Hand-crafted learning
+33
+Hand-crafted learning
+HOG
+LBP
+Co-occurrence
+Granulometry SIFT
+SURF
+Colour
+Data Feature Extraction Classification or 
+Regression
+
+Automated learning
+34
+(Data)2
+Feature extraction Classification
+Deep neural networks
+
+Convolutional neural networks
+35
+35
+• Convolutional networks are a specialized kind of neural network for 
+processing data that has a grid-like topology. They take advantadge of:
+– local connectivity
+– parameter sharing
+– pooling / subsampling hidden units
+Multilayer Perceptron Convolutional neural network
+3
+
+Convolution
+36
+74 66 62 59 63 71 75 72
+72 65 61 58 62 70 75 72
+71 68 63 59 63 69 73 69
+70 67 62 59 62 69 73 69
+70 64 59 57 61 70 74 72
+68 66 64 63 65 68 69 68
+70 69 67 66 67 69 69 67
+69 68 66 64 65 67 66 63
+1 0 -1
+2 0 -2
+1 0 -1
+-1 0 1
+-2 0 2
+-1 0 1
+𝑦 𝑚,𝑛 = 𝑥 𝑚,𝑛 ∗ℎ 𝑚,𝑛 = ෍
+𝑘
+෍
+𝑙
+𝑥 𝑘,𝑙 ℎ[𝑚−𝑘,𝑛−𝑙]
+Kernel
+ℎ[−𝑘,−𝑙]ℎ[𝑘,𝑙]
+−1 ∗62+0∗59+1∗62+(−2)∗59+0∗57+2∗61+(−1)∗64+0∗63+1∗65 = 3
+3
+Imagen de salida
+
+37
+Convolution
+1 0 -1
+2 0 -2
+1 0 -1
+1 2 1
+0 0 0
+-1 -2 -1
+
+Local connectivity
+38
+38
+ Receptive field
+෍ 𝑓
+ ෍ 𝑓
+ ෍ 𝑓
+… …
+each hidden unit is connected only to a subregion (patch) 
+of the input image: receptive ﬁeld
+w111 … w1N1
+… … …
+wN11 … wNN1
+w111 … w1N1
+… … …
+wN11 … wNN1
+
+Parameter sharing
+39
+39
+෍ 𝑓
+ ෍ 𝑓
+ ෍ 𝑓
+… …
+ ෍ 𝑓
+ ෍ 𝑓
+ ෍ 𝑓… …
+ ෍ 𝑓
+ ෍ 𝑓
+ ෍ 𝑓… …
+units organized into the same
+‘‘feature map’’ share parameters
+Feature map 1 Feature map 2 Feature map 3
+hidden units within a feature
+map cover diﬀerent positions in
+the image
+w111 … w1N1
+… … …
+wN11 … wNN1
+w111 … w1N1
+… … …
+wN11 … wNN1
+w111 … w1N1
+… … …
+wN11 … wNN1
+Kernel of 
+feature 
+map 1
+Kernel of 
+feature map 2
+Kernel of 
+feature map 3
+
+Feature maps
+40
+Input image
+Feature maps
+Convolutions
+w111 … w1N1
+… … …
+wN11 … wNN1
+Learnable
+
+Feature maps
+41
+Input image Feature map 1 Feature map 2
+
+Pooling
+42
+maxpooling
+Pooling is performed in non overlapping neighborhoods (subsampling)
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+43
+
+Convolutional layers
+44
+Filtro
+
+Convolutional layers
+45
+Presentación
+N. of input images 
+𝑁𝑖𝑛𝑝𝑢𝑡
+Image 
+size
+Input images 
+(from the 
+previous layer)
+Output images 
+(to the next layer)
+Kernels 
+(𝐾 ×𝐾 ×𝑁𝑖𝑛𝑝𝑢𝑡 ×𝑁𝑜𝑢𝑡𝑝𝑢𝑡)
+N. of output images 
+𝑁𝑜𝑢𝑝𝑢𝑡
+𝐾
+𝐾
+𝑁𝑖𝑛𝑝𝑢𝑡
+𝑁𝑜𝑢𝑡𝑝𝑢𝑡
+
+Convolutional layers: Stride
+Input 
+image
+7 x 7
+Activation map
+5 x 5
+Stride = 1
+Kernel = 3 x 3
+• The center of the kernel (or mask filter) moves to the next pixel in steps given by 
+the Stride hyperparameter
+Warning !!! 
+Reduction of the image size.
+It depends on kernel size and stride46
+
+Convolutional layers: zero 
+padding
+47
+What happens when a 5 x 5 x 3 filter is applied to a 32 x 32 x 3 input volume (32 x 32 
+pixel RGB image)? 
+In the first layers of the network we want to preserve as much information as possible 
+from the original image.
+Size of activation map: 28 x 28 x 3
+Zero
+Padding
+5 x 5 x  3
+Kernel
+Ouptut image
+28 x 28 x 3
+Input image
+32 x 32 x 3
+Zero padding
+36 x 36 x 3
+Input image
+32 x 32 x 3
+5x5x3
+Kernel
+Ouptut image
+28 x 28 x 3
+
+Pooling layers
+48
+• This layer is a decimation layer in spatial dimension (width, height)
+• Its function reduces the spatial size of the representation :
+• Reduce the number of paremeters
+• Reduce computational cost
+• Avoid overfitting
+Main functions:
+- Max pooling
+- Average pooling
+- L2-norm pooling
+Typical hyperparameters:
+• Filter size = 2×2
+• Stride = 2
+Input volume Output volume
+Stride=2
+5 8
+9 6
+3 5
+7 3
+Avg.
+
+CNN. Setup
+• Among the different layers, some aditional parameters have to been 
+considered :
+– Convolutional layer
+• Kernel size
+• Number of filters
+• Stride 
+• Zero padding
+– Pooling layer
+• Stride 
+• Window size
+– Activation layer
+– Batch normalization layer
+– Drop out layer
+– Classification: Top model
+49
+
+50
+Basic layers in Keras
+keras.layers.Dense(units, activation=None, use_bias=True, 
+kernel_initializer='glorot_uniform', bias_initializer='zeros')
+keras.layers.Activation(activation)
+keras.layers.Dropout(rate, noise_shape=None, seed=None)
+keras.layers.Conv2D(filters, kernel_size, strides=(1, 1), padding='valid')
+keras.layers.MaxPooling2D(pool_size=(2, 2), strides=None, padding='valid', 
+data_format=None)
+keras.layers.BatchNormalization(axis=-1, momentum=0.99, epsilon=0.001, 
+center=True, scale=True)
+keras.layers.Flatten(data_format=None)
+https://keras.io/layers/core/ 
+Keras documentation
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+51
+
+CNN: Feature extraction
+52
+Feature visualization of convolutional net trained on ImageNet (Zeiler, Fergus, 2013)
+• CNN = learning hierarchical representations with increasing levels of abstraction
+• End to end training: joint optimization of features and classiﬁer
+52
+
+53
+Feature extraction
+http://cs231n.stanford.edu/53
+
+Low-level features
+54
+• How does the network detect low-level features?
+• Convolutional blocks: The output (activation
+map) of the first convolutional layer will be the
+input of the second layer,and so forth.
+•The output of the second convolutional layer
+will be the activations representing higher
+level features: semicircles (combination of a
+curve and a straight edge), squares
+(combination of several straight edges), etc.
+54
+
+High-level features
+55
+55
+
+High-level features
+56
+56
+
+High-level features
+57
+57 https://poloclub.github.io/cnn-explainer/
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+58
+
+CNN for classification
+• Description of CNN
+59
+https://miro.medium.com/v2/resize:fit:847/1*eiWpS
+Vh65QZN9usE6YRJTA.png
+• Training: stochastic gradient descent/ forward-backward propagation
+• Hyperparameters setting: as MLP
+59
+
+CNN for classification
+60
+Convolutional 
+layers
+Feature extraction Classification
+• Top model:  
+• Flatten layer
+• Multilayer perceptrón
+• The last fully connected layer is a softmax layer (in the case of more than one output 
+neuron) with as many neurons as the number of classes.
+• PROBLEM: Overfitting
+
+CNN for classification
+61
+• Top model:  
+• Global averagepooling + softmax
+• Global maxpooling+ softmax
+Convolutional 
+layers
+Feature extraction
+Global average 
+pooling
+Global max 
+pooling
+Classification
+GAP: calculates the average 
+output of each feature map
+GMP: calculates the maximum 
+output of each feature map
+
+CNN.  Final Global Architecture
+62
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+63
+
+ImageNet
+• ImageNet is a database containing 14 million images classified into 1000 
+different categories (http://www.image-net.org/).
+• The most popular state-of-the-art architectures have been trained with ImageNet and 
+the resulting network weights are publicly available. 
+• The ImageNet Project runs an annual competition, the ImageNet Large Scale Visual 
+Recognition Challenge (ILSVRC), where algorithms compete to correctly classify 
+objects and scenes. 
+64
+Objetive: to reduce training
+parameters while maintaining or
+exceeding the previous year
+results, with a strong focus on
+reducing computational cost.
+
+LeNet-5
+65
+• LeNet-5 (1998, Lecun et al.): CNN pioneer.
+• 7 layers 
+• Aplication: digit classification (banks to recognise
+handwritten digits on cheques).
+• Graylevel images of 28x28 pixels. Higher resolution 
+images: more convolutional layers.
+Convolution Convolution
+Convolution
+Pooling
+Pooling
+Fully 
+Connected
+
+ALexNet
+66
+•  Winner of the 2012 ImageNet challenge and significantly outperformed all competitors by reducing the 
+top-5 error from 26% (runner-up) to 15.3%. SuperVision group.
+•  Deeper than LeNet and with more filters per layer.
+o 11x11, 5x5,3x3 convolutional filters and RELU activations.
+o Max pooling layers
+o Dropout
+o Data augmentation 
+o SGD with momentum
+o Trained for 6 days using 2 Nvidia Geforce GTX 580 GPUs.
+
+VGG16 y VGG19
+67
+•  Fairly simple architecture: blocks composed of an incremental number of convolutional
+layers with filters of size 3x3 with interleaved maxpooling layers (halving the size of the
+activation maps).
+• Classification block: 2 fully-connected layers (4096 neurons) and the output layer (1000
+neurons).
+• 16 and 19: differences in number of weighted layers in each network (convolutional and fully
+connected).
+Simonyan y Zisserman (2014). Very Deep 
+Convolutional Networks for Large Scale 
+Image recognition 
+(https://arxiv.org/abs/1409.1556)
+
+Inception V3 (GoogleNet)
+68
+•  This type of architecture, introduced in 2014 by Szegedy et al. "Going Deeper with
+Convolutions" (https://arxiv.org/abs/1409.4842), uses blocks with filters of different sizes that are
+then concatenated in order to extract features at different scales that are then combined into a
+single activation map.
+• Challenge winners in 2014, top-5 error rate of 6.67%!
+• This architecture, 22 convolutional layers, requires less memory than VGG and ResNet. It
+reduces the number of parameters from 60 million (AlexNet) to 4 million.
+
+Xception
+69
+• Proposed by François Chollet (creator of Keras).  Like Inception but provides a quick way to 
+make 2D convolutions (2 1D convolutions).
+"Xception: Deep Learning with Depthwise Separable Convolutions", https://arxiv.org/abs/1610.02357.
+
+ResNet (Microsoft)
+70
+•  Developed by He et al. in 2015 ( 2015 winners): introduces an exotic type of 
+architecture based on modules (" networks within networks "). 
+• Introduces the concept of " residual connections ". In layer 𝑙+1 the activation 
+map of the unmodified and modified 𝑙-layer 𝑙+1 is combined.. 
+“Deep Residual Learning for Image Recognition": https://arxiv.org/abs/1512.03385
+
+ResNet
+71
+•  Improved architecture in 2016 improved by including more layers of residual blocks.
+• There are variations of ResNet with different numbers of layers, but the most widely used is
+ResNet50, which consists of 50 with weights.
+• Many more layers than VGG but needs almost 5 times less memory: fully connected layers are
+replaced by a type of layer called GlobalAveragePooling, which converts 2D activation maps
+to a vector of n classes that is used to calculate the probability of belonging to each class.
+
+Comparison of sizes
+72
+Source: AN ANALYSIS OF DEEP NEURAL NETWORK MODELS FOR PRACTICAL APPLICATIONS, 2017
+
+73
+Comparison: accuracy vs number of 
+parameters
+Source: AN ANALYSIS OF DEEP NEURAL NETWORK MODELS FOR PRACTICAL APPLICATIONS, 2017
+
+Transfer learning
+•  Training a neural network is costly (time). 
+• Transfer learning techniques to avoid:
+o Define the architecture of a neural network.
+o Train it from the beginning. 
+• Idea: Initialise the weights of a predefined network with values that classify a given dataset 
+well and tune them to our problem.  
+• We avoid:
+o Need for a dataset as large as necessary if we want to train a network from scratch (from hundreds 
+of thousands or even millions of images we could go to a few thousand). 
+o Need to wait a good number of epochs to get values for the optimal weights for classification.
+•  Two techniques:
+– Transfer learning 
+– Fine-tuning
+74
+
+Transfer Learning vs Fine-
+Tuning
+75
+
+Transfer Learning
+76
+• SVM
+• Random Forest
+• etc.
+Extractor de caracterísiticas Clasificado
+r
+
+Fine-tuning
+77
+Shallow-tuning
+
+Fine-tuning
+78
+Deep-tuning
+
+Fine-tuning
+79
+Deep-tuning
+
+Fine-tuning
+80
+From 
+scratch
+
+Practical Protocol
+81
+In practise:
+1. Modify only the last layer to have the same number of outputs as 
+classes(baseline).
+2. Modify the top model and re-train the classifying stage (FC 
+layers) (“shallow tuning”).
+3. Re-train convolutional blocks (“deep tuning”). In each iteration 
+one more, starting from the output.
+Tips depending on our dataset 
+o If it is small and similar to the original: transfer learning (SVM for 
+example). It helps to prevent overfitting. 
+o If it is large and similar to the original: as we have more data we 
+probably won't incur in over-fitting, so we can do fine-tuning with 
+more confidence.
+
+Practical protocol
+82
+Tips depending on our dataset 
+o If it is small and very different from the original: transfer learning 
+but with characteristics of layers before the last convolutional. 
+o If it is large and very different from the original: train the network 
+from scratch. (from scratch). 
+Note the possible restrictions of pre-trained
+models. For example, they may require a
+minimum image size. In addition, when re-
+training networks, learning rates are usually
+chosen lower than if we do it from scratch,
+since we start from an initialisation of
+weights that is assumed to be good.
+
+Contents
+1. Revisiting the MLP
+2. Introduction to CNNs
+3. CNN layers
+4. Feature extraction
+5. CNN architecture for classification
+6. Transfer Learning
+7. Practical aspects
+83
+
+84
+Image DataGenerator class
+• Keras has implemented functionalities to facilitate/optimise data loading.
+• It is possible to load the training data in RAM in batches (batch by batch) to perform the steps
+that make up a training step and not having to store the entire dataset in memory.
+• ImageDataGenerator is nothing more than an object type that can apply or not certain
+transformations to the data being loaded by means of a series of methods of this object that
+facilitate the task.
+• The ImageDataGenerator object does not store the data itself.
+• The transformations that ImageDataGenerator allows serve to preprocess the data, rescale it or
+establish a validation partition, but its main function is that it implements the functionality to
+create synthetic image samples.
+https://keras.io/api/preprocessing/image/#imagedatagenerator-class
+
+85
+Loading batches of data from 
+disk
+The ImageDataGenerator object includes a series of methods that facilitate the task of loading data
+from disk. These methods allow the data to be loaded gradually into memory (batch by batch)
+during the training process.
+https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/image/ImageDataGenerator
+
+86
+Loading batches of data 
+from disk
+The ImageDataGenerator object includes a series of methods that facilitate the task of loading data
+from disk. These methods allow the data to be loaded gradually into memory (batch by batch)
+during the training process.
+https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/image/ImageDataGenerator
+
+87
+•  Objetive: Increase the number of images in the training set to combat overfitting.
+•  How?
+o Rotation,
+o Re-scale,
+o Translation,
+o Zoom,
+o Flips (Horizontal and Vertical),
+o Changes in color.
+• This is done in real time, during training. It is not necessary to save the augmented
+images.
+• The new images take the class of the source image, so the transformations cannot
+be too exaggerated, let alone cause them to resemble another class.
+Data Augmentation
+
+Early Stopping
+88
+https://keras.io/api/callbacks/early_stopping/
+
+89
+Data augmentation
+# Creating an instance of ImageDataGenerator class 
+train_datagen = ImageDataGenerator(rescale=1. / 255,                                   
+                 rotation_range = 0.2,
+                                   zoom_range = 0.2,
+        horizontal_flip = True,
+                                   vertical_flip = True)
+# Creating an instance of ImageDataGenerator class 
+validation_generator = validation_datagen.flow_from_directory(validationDirectory,
+                                                      target_size=(img_width, img_height),
+                                                      batch_size=batch_size,
+                                                      class_mode='categorical’)
+Source: https://medium.com/towards-data-science/image-augmentation-for-deep-learning-
+using-keras-and-histogram-equalization-9329f6ae5085 )
+
+Reduce learning rate
+90
+https://keras.io/api/callbacks/learning_rate_scheduler/
+Step decay
+Exponential decay
+Cosine Annealing
+
+Model checkpoint
+91
+https://keras.io/api/callbacks/model_checkpoint/

--- a/src/data/lessonSummaries/text/dbd-presentacion.txt
+++ b/src/data/lessonSummaries/text/dbd-presentacion.txt
@@ -1,0 +1,138 @@
+DISEÑO Y GESTIÓN DE 
+BASES DE DATOS
+Grado en Ingeniería Informática
+Módulo de Tecnología Específica: Sistemas de Información
+Profesores: Laura Mota, Pedro Valderas y Abel Gómez
+
+Grado en Ingeniería Informática
+Semestre Asignatura Carácter T P
+1B
+1A
+2A
+2B
+3A
+3B
+Bases de Datos y Sistemas de Información OB 4,5 1,5
+Diseño y Gestión de Bases de Datos 4,5     1,5
+Sistemas de Información Estratégicos 3       1,5
+Formación en la materia Bases de Datos en el Grado en Ingeniería 
+Informática (Especialización: Sistemas de Información)
+4A
+4B
+Diseño y Gestión de Bases de Datos. Presentación. 2
+Módulo
+SI
+
+Título de Grado en Ingeniería Informática
+Asignatura
+Diseño y Gestión de 
+Bases de Datos
+Bases de Datos y 
+Sistemas de Información
+Estudio y uso avanzado de bases de datos 
+relacionales (SQL). Diseño básico de bases de 
+datos relacionales (UML).
+Objetivo
+Diseño y Gestión de Bases de Datos. Presentación. 3
+Estudio de los aspectos tecnológico de los 
+SGBD relacionales y la administración de 
+sistemas de bases de datos. Diseño avanzado
+de bases de datos relacionales.
+
+Objetivos específicos de la asignatura Diseño y Gestión de 
+Bases de Datos:
+Objetivo 1: Gestión y Administración de Bases de Datos
+Estudio de los Sistemas de Gestión de Bases de Datos: componentes, 
+funciones y arquitecturas. 
+Estudio de las estrategias y técnicas para el control de la 
+independencia, la integridad, y la seguridad en los Sistemas de Gestión 
+de Bases de Datos. 
+Estudio de las tareas de administración en un sistema de bases de 
+datos: implementación, optimización, rendimiento.
+Objetivo 2: Diseño de Bases de Datos
+Estudio del diseño físico: factores, desnormalización.
+Programación en el servidor.
+Aplicación a casos de estudio.
+Diseño y Gestión de Bases de Datos. Presentación. 4
+
+Programa de teoría: Unidades didácticas
+1. Sistemas de Gestión de Bases de Datos.
+2. Procesamiento de transacciones y mantenimiento de la integridad.
+3. Recuperación de bases de datos.
+4. Control de la concurrencia en bases de datos
+5. Implementación de bases de datos
+6. Optimización de consultas en bases de datos.
+7. Seguridad en bases de datos.
+8. Diseño físico de bases de datos.
+9. Programación en el servidor.
+Diseño y Gestión de Bases de Datos. Presentación. 5
+
+Programa de prácticas: 
+Práctica 1. El SGBD Oracle.
+Práctica 2. Procesamiento de transacciones y 
+mantenimiento de la integridad en Oracle.
+Práctica 3. Recuperación de bases de datos en Oracle.
+Práctica 4. Control de la concurrencia en Oracle.
+Práctica 5. Implementación de bases de datos en Oracle (2 
+sesiones).
+Práctica 6. Optimización de consultas en Oracle.
+Práctica 7. Seguridad en Oracle.
+Práctica 8. Programación en el servidor (2 sesiones).
+Diseño y Gestión de Bases de Datos. Presentación. 6
+
+Evaluación:
+• Prueba escrita PE1:
+• Peso: 35% de la nota final.
+• Unidades didácticas evaluadas: Temas 1, 2, 3 y 4.
+• Realizada en fecha planificada por la escuela.
+• Prueba escrita PE2:
+• Peso: 30% de la nota final.
+• Unidades didácticas evaluadas: Temas 5, 6, 7 y 8.
+• Realizada en fecha planificada por la escuela.
+• Prueba práctica PP1:
+• Peso: 35% de la nota final.
+• Unidades didácticas evaluadas: Tema 9 y prácticas realizadas sobre Oracle.
+• Realizada en fecha planificada por la escuela.
+• Para aprobar, se exige un mínimo de 1 punto en cada una de las tres pruebas 
+(PE1, PE2 y PP1).
+• Recuperación en fecha planificada por la escuela:
+- PE1 y PE2: examen escrito en fecha planificada por la escuela.
+- PP1: examen en laboratorio en fecha planificada por la escuela.
+Diseño y Gestión de Bases de Datos. Presentación. 7
+
+Evaluación:
+• En caso de presentarse a la recuperación de algún acto, la nota que será tenida en 
+cuenta será la última obtenida. Si tras la recuperación no se cumple el requisito de 
+mínimos arriba descrito, la calificación máxima que se podrá obtener en la 
+asignatura será de 4,5 puntos.
+• La evaluación para los alumnos con dispensa será la misma que para los alumnos 
+sin dispensa.
+Diseño y Gestión de Bases de Datos. Presentación. 8
+
+Bibliografía:
+ Fundamentals of Database Systems (6th ed.). Elmasri, R.; 
+Navathe, S.B. Addison-Wesley, 2011.
+(Edición en español: Fundamentos de Sistemas de Bases de Datos. (5ª ed.) 
+Elmasri, R.; Navathe, S. Addison Wesley, Prentice Hall, 2007)
+An Introduction to Database Systems. (8th ed.)  Date, C.J, 
+Prentice Hall, 2003
+(Edición en español: Introducción a los Sistemas de Bases de Datos. (7ª ed.)      
+Date, CJ, Prentice Hall, 2001)
+Diseño y Gestión de Bases de Datos. Presentación. 9
+
+Bibliografía:
+ Database Administration. 
+Mullins C. S. Addison Wesley, 2013
+ Database Systems Implementation. 
+García Molina, H.; Ullman, J.; Widom, J. Morgan Kaufman, 2001
+ Databases and Transaction Processing.                                           
+Lewis, P.; Berstein, A.; Kifer, M. Springer, 2002
+ Database Tuning
+Shasha, D.; Bonet, P. Morgan Kaufman, 2003
+ Database Management Systems
+Ramakrishnan, R. McGraw Hill, 1998
+ Database Design for Smarties
+Muller R.J. Springer, 2002
+ Database Design: Know it All
+Buxton, S., Fryman, L. et al. Morgan Kaufmann, 2009
+Diseño y Gestión de Bases de Datos. Presentación. 10

--- a/src/data/lessonSummaries/text/dbd-tema-1.txt
+++ b/src/data/lessonSummaries/text/dbd-tema-1.txt
@@ -1,0 +1,772 @@
+Diseño y Gestión de Bases de 
+Datos
+Tema 1
+Sistemas de Gestión de Bases de 
+Datos
+Profesores: Laura Mota y Pedro Valderas
+1
+
+2
+ Revisar las características de la tecnología de bases de datos.
+ Revisar el concepto de sistema de gestión de bases de datos: 
+componentes y funciones.
+ Revisar la jerarquía de almacenamiento en un computador y 
+las técnicas de gestión asociadas.
+ Conocer las distintas arquitecturas de los sistemas de gestión 
+de bases de datos. 
+Objetivos:
+Sistemas de gestión de bases de datos.
+2
+
+3
+1 Características de la tecnología de bases de datos.
+2 Sistemas de gestión de bases de datos (SGBD).
+3 Transferencia de datos en un SGBD.
+4 Arquitecturas básicas de SGBD.
+5 Objetivos de un SGBD
+Sistemas de gestión de bases de datos.
+3
+
+4
+1 Características de la tecnología de bases de datos.
+Colección estructurada de datos.BASE DE DATOS
+L o sm e c a n i s m o sd ee s t r u c t u r a c i ó nd ed a t o s
+(estructuras de datos) que se pueden utilizar
+dependen del sistema informático (SGBD) con el
+que se vaya a crear y manipular la base de datos.
+Sistema de gestión de bases de datos (SGBD)
+Una base de datos es una colección estructurada de datos de carácter persistente, es decir 
+almacenada en memoria secundaria.
+La “tecnología de bases de datos” es la tecnología software que se ha desarrollado para 
+gestionar (crear y manipular) bases de datos. Los sistemas informáticos (programas) creados con 
+este propósito se denominan sistemas de gestión de bases de datos.
+Desde la aparición de la tecnología de bases de datos en la década de los años 60, han aparecido 
+muchos sistemas de gestión de bases de datos (comerciales o académicos), según sus 
+características estos sistemas se pueden agrupar en familias con propiedades comunes. Estas 
+familias se diferencian entre sí principalmente en la forma de organizar los datos en la base de 
+datos, es decir en el tipo de estructuras de datos utilizadas. Así, por ejemplo, en los sistemas de 
+gestión de bases de datos relacionales los datos se organizan en tablas (o relaciones).
+4
+
+5
+1 Características de la tecnología de bases de datos.
+La tecnología de bases de datos ha evolucionado
+intentando dar respuesta a las exigencias de
+funcionalidad y eficiencia que los usuarios plantean a
+los sistemas de información.
+¿Características de esta 
+tecnología?
+El sistema de información de una organización contiene toda la información relacionada con las 
+actividades propias de la organización.
+En el estado actual de desarrollo de la informática, se puede afirmar que el núcleo del sistema 
+de información de cualquier organización es una (o varias) bases de datos, y que, por lo tanto, 
+los sistemas de información actuales están soportados por tecnología de bases de datos.
+5
+
+6
+1 Características de la tecnología de bases de datos.
+Servicio a distintos 
+usuarios
+•Accesibilidad simultánea para 
+distintos usuarios (concurrencia).
+•Definición de vistas parciales de 
+los datos para distintos usuarios.
+Soporte del SI de la 
+organización
+•Integración de la información 
+de la organización.
+•Persistencia de los datos.
+La tecnología de bases de datos no ha dejado de evolucionar desde su aparición en la década de 
+los 60 hasta su estado de desarrollo actual.
+Independientemente de las distintas familias de sistemas de gestión de bases de datos que han 
+ido apareciendo, esta tecnología tiene unas características (propiedades) genéricas que la 
+definen:
+1) Soporte  del sistema de información de la organización: por compleja y grande que sea una 
+organización, su sistema de información puede construirse con tecnología de bases de 
+datos, es decir sobre una (o varias) bases de datos.
+2) Servicio  a distintos usuarios: como soporte del sistema de información de la organización, 
+esta tecnología debe ser capaz de dar servicio (atender peticiones de información) a todos 
+los sectores o departamentos de la organización, por lo que debe permitir y controlar el 
+acceso simultáneo de muchos usuarios al sistema. Por otro lado, si el sistema de 
+información reúne (integra) toda la información de la organización, la base de datos creada 
+puede ser muy compleja, por lo que la posibilidad de ofrecer “vistas parciales” de la misma a 
+distintos colectivos de usuarios puede simplificar y facilitar su uso.
+6
+
+7
+1 Características de la tecnología de bases de datos.
+Abstracción de 
+datos
+•Independencia de las aplicaciones 
+respecto a la representación física 
+(implementación) de los datos.
+Integridad de los 
+datos
+•Control de la calidad de la 
+información almacenada 
+(integridad): restricciones, 
+concurrencia, recuperación.
+Seguridad de los 
+datos
+•Control de la privacidad de la 
+información almacenada.
+3) Abstracción  de datos: esta característica es una caso particular del principio de abstracción
+presente en otros ámbitos de la informática: la separación entre especificación e 
+implementación. En el caso de las bases de datos, esto significa separar la especificación 
+(definición) de las estructuras de datos de la base de datos de su implementación 
+(almacenamiento en memoria secundaria). Este principio asegura que los programas 
+(aplicaciones) que se desarrollen para acceder a la base de datos sean independientes de 
+aspectos físicos de implementación, contribuyendo de esta forma a la durabilidad del 
+software desarrollado.
+4) Integridad  de los datos: esta característica hace referencia al control de la calidad de los 
+datos. Asegurar que los datos almacenados en la base de datos no se deterioran con el 
+tiempo (se pierden, se degradan, …),  es un objetivo principal de la tecnología de bases de 
+datos. Esta característica se asegura controlando el uso de la base de datos por parte de los 
+usuarios: acceso simultáneo de varios usuarios a los mismos datos, fallos del sistema durante 
+el uso de la base de datos, etc.
+5) Seguridad  de los datos: esta característica hace referencia al control del acceso a los datos. 
+La base de datos, como núcleo del sistema de información de la organización, va a ser 
+accedida por numerosos usuarios. Poder controlar quiénes son los usuarios autorizados y las 
+tareas para las que están autorizados es también un objetivo importante de la tecnología de 
+bases de datos.
+7
+
+8
+1 Características de la tecnología de bases de datos.
+Independencia de datos
+Definición de la base de datos a distintos 
+niveles de abstracción
+Esquemas de base de datos 
+En los sistemas de gestión de bases de datos, la característica de la “abstracción de datos” 
+(independencia de datos) se asegura definiendo la base de datos a distintos niveles de 
+abstracción: esquemas de la base de datos.
+8
+
+9
+1 Características de la tecnología de bases de datos.
+Esquema lógico: definición de las estructuras de datos 
+de la base de datos.
+Esquema físico: implementación de las estructuras de 
+datos definidas en el esquema lógico.
+Esquema externo: “subconjunto” del esquema lógico 
+(vistas).
+La definición (especificación) de las estructuras de datos que constituyen la base de datos se 
+realiza en el esquema lógico (obligatorio).
+La forma de implementación en memoria secundaria de las estructuras de datos definidas en el 
+esquema lógico se realiza en el esquema físico (obligatorio).
+Las posibles vistas parciales de la base de datos definidas para distintos colectivos de usuarios se 
+definen es los esquemas externos, como “subconjuntos” del esquema lógico (opcional).
+9
+
+10
+1 Características de la tecnología de bases de datos.
+SELECT dorsal, nombre 
+FROM Ciclista
+Esquemas externos
+(vistas)
+Esquema lógico
+(especificación)
+Esquema físico
+(implementación)
+Arquitectura de 
+niveles
+ORACLE
+SOImplementación de la 
+BD en disco
+Disco1
+Ciclista (dorsal, ..., …)
+Equipo (nomeq, ..., …)
+Etapa  (netapa, ..., …)
+Maillot (codigo, ..., …)
+......
+Table Ciclista
+INDEX (dorsal)
+DATAFILE Disco1:F1
+Table Equipo
+HEAP
+DATAFILE Disco1:F2  
+........
+F1
+datos
+datos
+Asignatura BDSI
+Laboratorio DSIC
+SQLDeveloper
+solicitudsolicitud
+lectura
+En el diagrama se muestra el entorno de trabajo del laboratorio de la asignatura BDASI 
+(semestre 3A), en él se pueden distinguir:
+• Los esquemas de la base de datos (relacional) Ciclismo: 
+ el esquema lógico de la base de datos donde se definen las tablas, sobre él se 
+formulan las consultas (SELECT); 
+ el esquema físico donde se elige la implementación de cada tabla del esquema 
+lógico, este esquema no es visible para los alumnos (gestionado por el administrador 
+de la base de datos); 
+ la ausencia de esquemas externos. 
+Todos estos esquemas (independientes entre sí) se almacenan en disco y están disponibles 
+para uso del SGBD. (Independencia de datos)
+• La base de datos (Ciclismo) en disco. (Persistencia de los datos).
+• El sistema de gestión de bases de datos (relacional): software de Oracle.
+• La herramienta‐cliente para el diseño de consultas (SQL) a la base de datos: herramienta 
+SQLDeveloper de Oracle.
+10
+
+1111
+1 Características de la tecnología de bases de datos.
+Aplicación 1 Aplicación 2 Aplicación 3
+Esquemas externos
+(vistas)
+Esquema lógico
+(especificación)
+Esquema físico
+(implementación)
+Descripción unificada de 
+los datos
+Independencia 
+de datos
+Control de la integridad
+Control de la seguridadSGBD
+SO
+Integración de toda 
+la información de la 
+organización
+Persistencia
+BD
+Accesibilidad simultánea 
+para distintos usuarios
+Arquitectura de 
+niveles
+disco
+Vistas 
+parciales
+DATOS SOFTWARE
+datos
+datos
+solicitud
+lectura/ 
+escritura
+En este diagrama se ilustran todas las características de la tecnología de bases de datos en un 
+diagrama genérico:
+• Soporte del SI de la organización: integración de toda la información de la organización en un 
+repositorio en memoria secundaria: base de datos. (Persistencia)
+• Servicio a distintos usuarios: acceso simultáneo y vistas parciales (esquemas externos) para 
+los usuarios.
+• Abstracción de datos: definición de distintos esquemas (independientes entre sí) de la base 
+de datos. (Independencia de datos)
+• Control de la integridad: control del acceso concurrente, control ante fallos del sistema, …
+• Control de la seguridad: control de los usuarios autorizados, y de los permisos concedidos 
+para realizar operaciones sobre la base de datos, …
+11
+
+12
+1 Características de la tecnología de bases de datos.
+2 Sistemas de gestión de bases de datos (SGBD).
+3 Transferencia de datos en un SGBD.
+4 Arquitecturas básicas de SGBD.
+5 Objetivos de un SGBD.
+Sistemas de Gestión de bases de Datos.
+12
+
+13
+2 Sistemas de gestión de bases de datos.
+Herramienta (software) para la gestión (creación 
+y manipulación) de bases de datos.SGBD
+SGBD
+Modelo de Datos
+•Estructuras de datos
+•Operadores asociados
+Como ya se ha comentado, un sistema de gestión de bases de datos es una herramienta de 
+software que sirve para gestionar (crear y manipular) bases de datos.
+Un SGBD se construye basándose en un modelo de datos. Un modelo de datos es una propuesta 
+teórica de SGBD.
+En un modelo de datos se proponen un tipo de estructuras de datos para organizar los datos en 
+la base de datos, y un lenguaje para manipular dichas estructuras. 
+Los fabricantes de sistemas de gestión de bases de datos utilizan la propuesta de un modelo para 
+construir sus productos.
+13
+
+14
+2 Sistemas de gestión de bases de datos.
+Familias de SGBD:
+jerárquicos jerárquico registro (segmento), árbol
+en red  red registro, lista (set)
+relacionales relacional registro (tupla), tabla (relación)
+objeto‐ relacional +         registro (tupla), tabla (relación) +
+relacionales         OO constructores de tipos
+OO OO constructores de tipos
+SGBD modelo estructuras
+tiempo
+A lo largo de la historia de la tecnología de bases de datos, se han propuesto varios modelos de 
+datos que han dado lugar a las distintas familias de sistemas de gestión de bases de datos.
+Como se puede observar, cada familia se basa en un modelo de datos distinto, y cada modelo 
+propone unas estructuras de datos distintas.
+En el dibujo aparecen las familias en orden cronológico.
+En la familia relacional, los sistemas de gestión de bases de datos se basan en el modelo 
+relacional de datos. En este modelo los datos se organizan en tablas (relaciones) y existen 
+lenguajes algebraicos (Álgebra Relacional) o lógicos (SQL) para manipular estas estructuras.
+14
+
+15
+2 Sistemas de gestión de bases de datos.
+Funciones de un SGBD
+•Definición de datos
+•Manipulación de datos 
+(consulta y actualización)
+•Gestión y administración
+Componentes de un SGBD
+•Lenguajes de definición de 
+esquemas (DDL)
+•Lenguaje de manipulación 
+(DML)
+•Herramientas para la gestión
+Si un SGBD debe servir para crear y manipular (consultar y actualizar) bases de datos, debe tener 
+componentes para realizar estas funciones: un lenguaje de definición de los datos en sus 
+distintos esquemas (Data Description Language) y un lenguaje de manipulación de datos (Data 
+Manipulation Language).
+Además, el SGBD debe tener componentes para realizar las tareas de administración: copias de 
+seguridad, definición de usuarios, …
+15
+
+16
+2 Sistemas de gestión de bases de datos.
+SGBD
+AA
+BB
+A
+B
+tiempo
+Ejecución concurrente
+(intercalada) de los procesos A y B
+Ejecución paralela de los 
+procesos A y B
+n CPU paralelismo
+monousuario (SGBD de PC)
+multiusuario (concurrencia)
+1 CPU
+Es importante diferenciar entre los SGBDs que trabaja en modo concurrente y los SGBDs que 
+trabaja en modo paralelo, como se ilustra en el dibujo.
+Todos los SGBD actuales son multiusuario (ejecución concurrente) y muchos de ellos contemplan 
+el paralelismo (ejecución paralela).
+16
+
+17
+1 Características de la tecnología de bases de datos.
+2 Sistemas de gestión de bases de datos (SGBD).
+3 Transferencia de datos en un SGBD.
+4 Arquitecturas básicas de SGBD.
+Sistemas de Gestión de bases de Datos.
+17
+
+18
+3 Transferencia de datos en un SGBD.
+Tecnología de bases de datos (SGBD):
+•Gran volumen de datos
+•Persistencia en el tiempo
+Almacenamiento en memoria 
+secundaria (discos)
+tecnología actual
+•Jerarquía de almacenamiento
+•Transferencia de datos
+estudio
+La tecnología de bases de datos permite gestionar grandes volúmenes de datos almacenados en 
+memoria secundaria. Con la tecnología informática actual esto significa el uso de 
+almacenamiento en disco.
+Por este motivo, para entender bien el funcionamiento de un SGBD es importante revisar la 
+jerarquía de almacenamiento de datos en un computador (memoria principal y memoria 
+secundaria) y las técnicas de gestión asociadas (transferencia de datos).
+18
+
+19
+3 Transferencia de datos en un SGBD.
+Jerarquía de almacenamiento en un computador:
+Almacenamiento primario: memoria principal y memorias caché.
+• CPU opera directamente.
+• Acceso rápido.
+• Capacidad limitada.
+Almacenamiento secundario: discos magnéticos, discos ópticos, cintas.
+• CPU no puede operar directamente.
+• Acceso lento.
+• Capacidad alta.
+Como es bien sabido, en un computador existen dos tipos de almacenamiento de características 
+muy distintas: almacenamiento primario y almacenamiento secundario.
+Las diferencias entre ambos tipos de almacenamiento van a determinar el funcionamiento del 
+SGBD ya que la base de datos va a estar almacenada en memoria secundaria (disco), pero sólo 
+en memoria principal se podrán consultar y actualizar los datos.
+19
+
+20
+3 Transferencia de datos en un SGBD.
+Almacenamiento de los datos de una base de datos en disco:
+Fichero: los datos de una base de datos se almacenan en disco 
+organizados en ficheros con registros.
+Registro: colección de valores de datos bajo una misma estructura.
+• Los valores de un registro hacen referencia a un mismo objeto y 
+representan sus propiedades.
+• Los registros deben almacenarse en disco de un modo que haga 
+posible su localización de la forma más eficaz cuando sea 
+necesario.
+Usualmente, cada relación de una base de datos relacional se guarda en disco en un fichero. 
+Cada tupla de la relación se guarda en un registro del fichero. Estos conceptos se estudian en 
+profundidad en el Tema 5.
+20
+
+21
+3 Transferencia de datos en un SGBD.
+• Superficie
+• Pista 
+• Cilindro
+• Bloque o página (formateo)
+Dispositivo de almacenamiento secundario de acceso directo.
+ Cabeza de
+lectura/escritura Pista
+Brazo
+.
+.
+.
+.
+.
+.
+paquete de discos
+cilindro
+Disco:
+21
+
+22
+3 Transferencia de datos en un SGBD.
+Bloque:
+•Unidad de direccionamiento.
+•Unidad de transferencia de datos entre memoria secundaria y 
+memoria principal.
+bloque
+Pistas: círculos concéntricos 
+(superficie de almacenamiento)
+superficie
+dirección del bloque: [superficie + ] pista + bloque
+De todas las característica de un disco (dispositivo de almacenamiento secundario) interesa 
+destacar el concepto de bloque como unidad de direccionamiento en el disco y como unidad de 
+transferencia entre los dos niveles de la jerarquía de almacenamiento: primario y secundario.
+22
+
+23
+Administrador 
+de E/S del SO
+3 Transferencia de datos en un SGBD.
+Transferencia de datos entre memoria principal y disco:
+ Cabeza de
+lectura/escritura Pista
+Brazo
+.
+.
+.
+.
+.
+. paquete de discos
+cilindro
+dirección del bloque
++
+dirección del buffer
+buffer buffer buffer
+Memoria Principal
+lectura
+escritura
+Software
+buffer
+Acceso a los datos
+Memoria Secundaria
+bloque
+Buffer: espacio 
+para un bloque
+Cualquier software que gestione datos almacenados en disco deberá realizar (o solicitar) tareas 
+de transferencia de datos entre memoria secundaria y memoria principal.
+Según el concepto de bloque, esta transferencia de datos se hará siempre en unidades del 
+tamaño de un bloque.
+23
+
+24
+3 Transferencia de datos en un SGBD.
+4
+Aplicación 1
+Esquema externo1
+Esquema lógico
+Esquema físico
+2.1
+2.2
+2.3
+1
+3
+SGBD
+datos
+buffers  SGBD
+bloque(s)
+área 1consulta sobre las 
+estructuras de datos del 
+esquema externo1
+correspondencia 
+entre esquemas
+solicita lectura de 
+bloque(s) de 
+datos del disco
+solicitud del usuario
+transferencia de datos
+operación del SGBD
+BD
+En el diagrama se ilustran los pasos seguidos en un SGBD para satisfacer una operación de 
+consulta de un usuario:
+(1) El  usuario solicita una consulta sobre la base de datos, formulada sobre su esquema 
+externo, o bien directamente sobre el esquema lógico de la base de datos (el esquema 
+externo no es obligatorio).
+(2) El  SGBD debe consultar los esquemas de la base de datos para traducir la consulta del 
+usuario en una petición de lectura de bloques del disco. El SGBD traduce la consulta sobre el 
+esquema externo en una consulta sobre el esquema lógico, y posteriormente, consultado el 
+esquema físico, en una operación (u operaciones) de lectura de bloques del disco.
+(3) El  SGBD solicita la ejecución de esas operaciones de lectura de bloques de disco. Estos 
+bloques, que contienen los datos solicitados por el usuario, son transferidos al área de 
+memoria principal (buffers) asignada al SGBD.
+(4) El  SGBD debe transferir los datos solicitados por el usuario de los bloques (en memoria 
+principal) al área de trabajo del programa (o herramienta) desde la que se realizó la 
+consulta.
+Es importante observar que una operación de consulta no modifica el contenido (estado) de la 
+base de datos. Los bloques son transferidos de disco a memoria principal sin afectar a la base de 
+datos.
+Si el SGBD es un sistema relacional (por ejemplo Oracle), la consulta consistirá en una instrucción 
+SELECT (SQL), que como es sabido puede seleccionar datos de una o varias filas de una o varias 
+tablas de la base de datos. Para satisfacer esta consulta se deberán recuperar los registros que
+contienen esas filas.
+24
+
+25
+3 Transferencia de datos en un SGBD.
+Para entender el paso (2) sobre la correspondencia entre esquemas, realizada por el SGBD, 
+véase el siguiente ejemplo.
+Supóngase una base de datos sobre la docencia en la Universidad. En el esquema lógico de esta 
+base de datos existirá, entre otras, una tabla Profesor con la información sobre los profesores de 
+la Universidad. Este esquema lógico, con la definición de las tablas, tendrá su correspondiente 
+esquema físico en el que se elige la implementación de cada tabla en el SGBD que vaya a 
+soportar la base de datos (no se presenta). Como la Universidad consta de muchos 
+departamentos, es probable que se decida definir un esquema externo para cada 
+departamento, con el fin de ofrecer una “vista parcial” de la base de datos (con los datos 
+propios) a cada uno de ellos.
+Uno de estos esquemas externos corresponderá al departamento DSIC. En él existirán vistas
+(tablas virtuales) que muestren los datos, relevantes para el DSIC, de cada tabla del esquema 
+lógico. Una de estas vistas será la vista Profesor‐DSIC en la que se muestra información sólo de 
+los profesores del DSIC.
+En el ejemplo se observa como el usuario formula una consulta sobre el esquema externo del 
+DSIC (vista Profesor‐DSIC). El SGBD debe traducir esta consulta en una consulta sobre el 
+esquema lógico (tabla Profesor). Posteriormente esta consulta debe ser traducida en una (o 
+varias) operaciones de petición de bloques de datos.
+25
+
+26
+3 Transferencia de datos en un SGBD.
+4
+Aplicación 1
+Esquema externo1
+Esquema lógico
+Esquema físico
+2.1
+2.2
+2.3
+1
+3
+SGBD
+datos
+buffers  SGBD
+bloque(s)
+área 1actualización sobre las 
+estructuras de datos del 
+esquema externo1
+correspondencia 
+entre esquemas
+solicita lectura de 
+bloque(s) de 
+datos del disco
+solicitud del usuario
+transferencia de datos
+operación del SGBD
+BD
+5
+solicita escritura de 
+bloque(s) de datos en 
+el disco
+En el diagrama se ilustran los pasos seguidos en un SGBD para satisfacer una operación de 
+actualización (inserción, borrado o modificación) de un usuario:
+En una operación de actualización, los bloques con los datos a actualizar deben ser primero 
+leídos (transferidos a memoria principal). Sólo estando en memoria principal el SGBD podrá 
+ejecutar las operaciones de actualización requeridas por el usuario. Por este motivo, los pasos 
+(1), (2), y (3)  coinciden con los mismos pasos en el diagrama para una operación de consulta.
+(4) El SGBD ejecuta sobre los datos (en memoria principal) las actualizaciones requeridas por el 
+usuario. La actualización se realiza a partir de datos proporcionados por el usuario.
+(5) El SGBD solicita la escritura en disco de los bloques actualizados para de esta forma actualizar 
+la base de datos.
+Es importante observar que la operación de actualización del usuario se ejecuta en el paso (4) 
+pero la actualización de la base de datos en el disco no tiene lugar hasta el paso (5).
+Si el SGBD es un sistema relacional (por ejemplo Oracle), la actualización consistirá en una 
+instrucción INSERT, DELETE o UPDATE (SQL), que, como es sabido, puede actualizar datos de una 
+o varias filas de una tabla de la base de datos.
+26
+
+27
+3 Transferencia de datos en un SGBD.
+ El SGBD sólo puede operar sobre los buffers de memoria principal que tiene 
+asignados.
+ Para poder manipular (leer o actualizar) datos de la BD, los bloques de disco 
+donde se encuentran almacenados los datos deben ser leídos (transferidos del 
+disco a los buffers del SGBD). Esto lo realiza el SGBD en cooperación con el SO 
+del computador.
+ En el caso de una operación de actualización, los bloque donde se encuentran 
+los datos actualizados deben ser escritos (transferidos del buffer del SGBD al 
+disco) para actualizar la BD. Esto puede hacerse inmediatamente después de la 
+operación de actualización o en algún momento posterior.
+ La decisión de cuándo un bloque actualizado es transferido del buffer al disco 
+depende de la política de transferencia de bloques del SGBD (Tema 3).
+Una actualización puede no ser registrada en la BD en disco (paso 5) 
+hasta tiempo después de que se ejecutó la operación de actualización 
+(paso 4). 
+27
+
+28
+1 Características de la tecnología de bases de datos.
+2 Sistemas de gestión de bases de datos (SGBD).
+3 Transferencia de datos en un SGBD.
+4 Arquitecturas básicas de SGBD.
+5 Objetivos de un SGBD.
+Sistemas de Gestión de bases de Datos.
+28
+
+29
+Red
+Arquitectura centralizada:
+4 Arquitecturas básicas de SGBD.
+Programas de 
+aplicación SGBD Control de 
+pantalla
+SOFTWARE
+Sistema Operativo
+Dispositivos 
+de E/S
+CPU Controlador 
+de disco
+Controlador 
+de memoria
+Pantalla Pantalla Pantalla
+29
+
+30
+4 Arquitecturas básicas de SGBD.
+ Uso de terminales sin capacidad de procesamiento conectadas 
+por red al servidor central.
+ Las terminales sólo realizan la función de visualización.
+ Toda la funcionalidad del sistema (SGBD, ejecución de 
+programas de las aplicaciones, procesamiento de la interfaz, …)  
+la realiza el servidor central.
+Arquitectura centralizada:
+30
+
+31
+4 Arquitecturas básicas de SGBD.
+Arquitectura cliente‐servidor:
+Red
+Servidor 
+de web
+SGBD Servidor 
+de e‐mail
+Servidor de 
+ficheros
+Servidor 
+de…
+Esquema lógico
+Cliente Cliente Cliente
+31
+
+32
+4 Arquitecturas básicas de SGBD.
+Arquitectura cliente‐servidor:
+Esquema físico
+Red
+Red de 
+comunicaciones
+…Cliente 1
+(sitio 1)
+Cliente 2
+(sitio 2)
+Cliente n
+(sitio n)
+32
+
+33
+4 Arquitecturas básicas de SGBD.
+Arquitectura cliente‐servidor:
+ Servidores especializados con funciones específicas 
+conectados en red.
+ Máquinas cliente con capacidad de procesamiento para la 
+ejecución de programas de aplicación.
+ Las máquinas cliente proporcionan al usuario las interfaces 
+necesarias para utilizar los servidores (software cliente).
+33
+
+34
+4 Arquitecturas básicas de SGBD.
+Arquitectura cliente‐servidor para SGBD:
+Programas de 
+interfaz
+Programas de 
+aplicación (Visual, 
+C++, Java, …)
+Procesamiento 
+de consultas 
+(SQL)
+Procesamiento 
+de 
+transacciones
+ClienteServidor
+Red
+Red de 
+comunicaciones
+…Cliente 1
+(sitio 1)
+Cliente 2
+(sitio 2)
+Cliente n
+(sitio n)
+Esquema lógico
+34
+
+35
+4 Arquitecturas básicas de SGBD.
+Laboratorio de la asignatura BDASI:
+SQL 
+Developer
+BD 
+(ciclismo)
+SGBD 
+Oracle
+35
+
+36
+1 Características de la tecnología de bases de datos.
+2 Sistemas de gestión de bases de datos (SGBD).
+3 Transferencia de datos en un SGBD.
+4 Arquitecturas básicas de SGBD.
+5 Objetivos de un SGBD.
+Sistemas de Gestión de bases de Datos.
+36
+
+37
+Sistemas de Gestión de bases de Datos.
+Objetivo 1: Procesar correctamente transacciones 
+en un entorno concurrente.
+ Seguridad en bases de datos: Tema 7.
+ Procesamiento de transacciones y mantenimiento de la 
+integridad: Tema 2.
+ Recuperación de la base de datos: Tema 3.
+ Control de la concurrencia en bases de datos: Tema 4.
+37
+
+38
+Objetivo 2: Procesar eficientemente transacciones 
+en un entorno concurrente.
+Sistemas de Gestión de bases de Datos.
+ Implementación de bases de datos: Tema 5.
+ Diseño físico de una base de datos relacionales: Tema 8.
+ Optimización de consultas en bases de datos: Tema 6.
+38

--- a/src/data/lessonSummaries/text/dbd-tema-2.txt
+++ b/src/data/lessonSummaries/text/dbd-tema-2.txt
@@ -1,0 +1,1024 @@
+Diseño y Gestión de Bases de 
+Datos
+Tema 2
+Procesamiento de transacciones y 
+mantenimiento de la integridad
+Profesoras: Laura Mota y Pedro Valderas
+1
+
+2
+Procesamiento de transacciones y mantenimiento de la integridad.
+ Revisar el concepto de transacción en bases de datos.
+ Revisar la definición de transacciones en SQL.
+ Revisar las estrategias de comprobación de restricciones de 
+integridad durante el procesamiento de transacciones.
+ Revisar el tratamiento de la integridad en SQL.
+Objetivos:
+2
+
+3
+1 Concepto de transacción.
+2 Operaciones y estados de una transacción.
+3 Propiedades del procesamiento de transacciones.
+4 Definición de transacciones en SQL.
+5 Concepto de restricción de integridad.
+6 Comprobación de restricciones en SQL.
+Procesamiento de transacciones y mantenimiento de la integridad.
+3
+
+4
+ Consultar el valor de las filas de una o varias tablas: SELECT
+ Insertar filas en una tabla: INSERT
+ Borrar filas de una tabla: DELETE
+ Modificar el valor de las filas de una tabla: UPDATE
+1 Concepto de transacción.
+Acceso a bases de datos relacionales (consulta o 
+actualización): lenguaje SQL
+La manipulación (consulta y actualización) de bases de datos relacionales se realiza con el 
+lenguaje estándar SQL.
+La consulta se realiza con la instrucción SELECT (seleccionar filas de una o varias tablas), y la 
+actualización con las instrucciones INSERT (insertar filas en una tabla), DELETE (borrar filas de 
+una tabla) y UPDATE (modificar filas de una tabla).
+La operación de consulta actúa sobre una o varias tablas, las operaciones de actualización actúan 
+sobre una única tabla.
+4
+
+5
+1 Concepto de transacción.
+Empleado (dni: char(10), nombre: char(60), salario: real, dpto: char(5))
+CP:  {dni} VNN:  {dpto}
+CAj: {dpto} Departamento   f(dpto)=código
+Departamento (código: char(5), nombre: char(50), ubicación: char(15))
+CP: {código} VNN:  {nombre}
+R1: “A todo departamento pertenece al menos un empleado”
+dptosalarionombredni
+d22000Juan García23125679
+d11500Pedro Ruíz65743983
+d11000Luis Cerdá37418739
+ubicaciónnombrecódigo
+Planta1Comprasd1
+Planta2Ventasd2
+Las restricciones de integridad (RI): CP , VNN, CAj, R1, se 
+satisfacen en la base de datos.
+Empleado Departamento
+En el ejemplo se presenta el esquema lógico de una base de datos relacional con dos tablas: una 
+tabla de empleados (Empleado) y una tabla de departamentos (Departamento). La clave ajena 
+en la tabla Empleado expresa que todo empleado debe pertenecer a un departamento de la 
+organización, y la restricción de integridad R1 (se verá más adelante su definición en SQL) 
+expresa que a todo departamento de la organización debe pertenecer al menos un empleado.
+Se observa que, en la extensión actual (estado) de la base de datos, estas restricciones de 
+integridad se cumplen (se satisfacen).
+Comentario: las flechas rojas incluidas en la transparencia simplemente denotan con qué fila de 
+la tabla Departamento se relaciona cada fila de la table Empleado, no debe confundirse con la 
+existencia de punteros.
+5
+
+6
+1 Concepto de transacción.
+Empleado (dni: char(10), nombre: char(60), salario: real, dpto: char(5))
+CP:  {dni} VNN:  {dpto}
+CAj: {dpto} Departamento   f(dpto)=código
+Departamento (código: char(5), nombre: char(50), ubicación: char(15))
+CP: {código} VNN:  {nombre}
+R1: “A todo departamento pertenece al menos un empleado”
+Actualización de la BD:
+“Crear un nuevo departamento, <d3, Personal, Planta3>, y 
+asignarle el empleado de DNI 65743983 (ya existente en la base 
+de datos)”
+Supóngase que se desea crear (dar de alta) un nuevo departamento en la organización, tal como 
+expresa el requerimiento de actualización de la base de datos que plantean los usuarios.
+La base de datos, una vez actualizada, quedaría como se muestra en la transparencia.
+6
+
+7
+1 Concepto de transacción.
+1) Inserción en Departamento: <d3, Personal, Planta3>
+2) Modificación en Empleado: modificación del atributo dpto del 
+empleado con DNI  65743983 (nuevo valor: d3)
+ERROR: la restricción R1 no se cumple
+Hay un departamento sin profesores
+dptosalarionombredni
+d22000Juan García23125679
+d11500Pedro Ruíz65743983
+d11000Luis Cerdá37418739
+ubicaciónnombrecódigo
+Planta1Comprasd1
+Planta2Ventasd2
+Planta3Personald3
+Empleado Departamento
+7
+
+8
+1 Concepto de transacción.
+1) Modificación en Empleado: modificación del atributo dpto del 
+empleado con DNI  65743983 (nuevo valor: d3)
+2) Inserción en Departamento:  <d3, Personal, Planta3>
+ERROR: la restricción de CAj no se cumple
+Hay un empleado cuyo departamento no existe
+dptosalarionombredni
+d22000Juan García23125679
+d31500Pedro Ruíz65743983
+d11000Luis Cerdá37418739
+ubicaciónnombrecódigo
+Planta1Comprasd1
+Planta2Ventasd2
+Empleado Departamento
+8
+
+9
+1 Concepto de transacción.
+1) Inserción en Departamento: <d3, Personal, Planta3>
+2) Modificación en Empleado: modificación del atributo dpto del 
+empleado con DNI  65743983 (nuevo valor: d3)
+1) Modificación en Empleado: modificación del atributo dpto del 
+empleado con DNI  65743983 (nuevo valor: d3)
+2) Inserción en Departamento:  <d3, Personal, Planta3>
+¡Necesidad del concepto de transacción!
+ERROR: la restricción R1 no se cumple
+ERROR: la restricción de CAj no se cumple
+Es obvio que esta actualización de la base de datos exige operaciones de actualización sobre las 
+dos tablas: la inserción de una nueva fila en Departamento y la modificación de una fila en 
+Empleado.
+Es importante recordar que, aunque las tablas son estructuras de datos independientes, están 
+relacionadas entre sí por restricciones de integridad (clave ajena y restricción R1), y que el SGBD 
+debe asegurar en todo momento el cumplimiento de estas restricciones.
+Cualquier intento de ejecutar las dos operaciones de actualización (en cualquier orden) fracasa 
+porque las relaciones entre las dos tablas, establecidas por las restricciones de integridad, lo 
+impide.
+Surge de esta forma el concepto de TRANSACCIÓN como unidad de ejecución (ejecución 
+conjunta) de varias operaciones sobre las tablas de la base de datos: interesa el efecto global del 
+conjunto de operaciones, no el efecto individual de cada una de ellas. 
+Para utilizar este concepto, será necesario poder indicar al SGBD qué conjunto de operaciones 
+constituyen una transacción, para que, de esta forma, el SGBD pueda considerar su efecto global 
+antes de comprobar las restricciones de integridad definidas en el esquema de la base de datos.
+9
+
+10
+1 Concepto de transacción.
+INICIO
+INSERT  INTO  Departamento  VALUES  ('d3', 'Personal', 'Planta3');
+UPDATE  Empleado  SET dpto='d3'  WHERE  dni='65743983');
+FIN
+ La transacción se procesa como una operación atómica.
+ Las restricciones se comprueban al final de la transacción.
+ La transacción se rechaza si alguna restricción se viola.
+Si el SGBD ejecuta las dos operaciones de actualización como una unidad de ejecución 
+(transacción) y comprueba las restricciones de integridad después de observar su efecto global, 
+la base de datos puede ser actualizada sin ningún problema.
+10
+
+11
+1 Concepto de transacción.
+INICIO
+INSERT  INTO  Departamento  VALUES  ('d3', 'Personal', 'Planta3');
+UPDATE  Empleado  SET dpto='d3'  WHERE  dni='65743983);
+FIN
+ubicaciónnombrecódigo
+Planta1Comprasd1
+Planta2Ventasd2
+Planta3Personald3
+dptosalarionombredni
+d22000Juan García23125679
+d31500Pedro Ruíz65743983
+d11000Luis Cerdá37418739
+Las RI se satisfacen en la base de datos: CP , VNN, CAj, R1
+Empleado Departamento
+En el nuevo estado de la base de datos, después de ejecutar la transacción, se cumplen las dos 
+restricciones de integridad (clave ajena y restricción R1).
+11
+
+12
+1 Concepto de transacción.
+Secuencia de operaciones de acceso a la base 
+de datos (consulta o actualización) que 
+constituyen una unidad de ejecución.
+TRANSACCIÓN
+Las operaciones de acceso a una BD se 
+organizan en transacciones
+Procesar correctamente una transacción significa:
+(a) todas las operaciones de la transacción se ejecutan con éxito y sus cambios
+(actualizaciones) quedan grabados permanentemente en la base de datos, 
+o bien
+(b) la transacción no tiene ningún efecto en la base de datos.
+Si definimos el concepto de transacción como “unidad de ejecución”, la ejecución de 
+transacciones debe respetar este significado, es decir, ejecutar una transacción significará o 
+ejecutar todas sus operaciones o no ejecutar ninguna de ellas. 
+Hay que observar que cuando se dice “ejecutar todas sus operaciones” se refiere a dejar los 
+cambios de esas operaciones grabados en la BD en disco. Recuérdese a este respecto, el 
+desajuste temporal entre la ejecución de una operación de actualización (en memoria principal) 
+y la actualización de la base de datos (en memoria secundaria), como se muestra en el diagrama 
+siguiente (pasos 4 y 5). Este desajuste temporal entre los pasos 4 y 5 estará en el centro del 
+funcionamiento del SGBD, como se verá en temas posteriores.
+12
+
+13
+1 Concepto de transacción.
+Aplicación 1
+Esquema externo1
+Esquema lógico
+Esquema físico
+BD
+2.1
+2.2
+2.3
+1
+3
+SGBD
+datos
+buffers  SGBD
+bloque(s)
+área 1
+actualización sobre las 
+estructuras de datos 
+del esquema externo1
+correspondencia 
+entre esquemas
+solicita lectura de 
+bloque(s) de datos 
+del disco
+solicita escritura de 
+bloque(s) de datos en 
+el disco
+actualiza datos en 
+el buffer
+solicitud del usuario
+transferencia de datos
+operación del SGBD
+Actualización 
+de la BD:
+4
+5
+Recuérdese el desajuste temporal entre los pasos 4 y 5.
+13
+
+14
+1 Concepto de transacción.
+2 Operaciones y estados de una transacción.
+3 Propiedades del procesamiento de transacciones.
+4 Definición de transacciones en SQL.
+5 Concepto de restricción de integridad.
+6 Comprobación de restricciones en SQL.
+Procesamiento de transacciones y mantenimiento de la integridad.
+14
+
+15
+2 Operaciones y estados de una transacción.
+ Base de datos: colección de elementos de datos con nombre.
+ Elemento de datos: atributo, fila, tabla, etc. (granularidad del 
+elemento).
+ Operaciones de acceso a la BD: lectura y escritura.
+Modelo simplificado para estudiar el procesamiento de 
+transacciones:
+Estas simplificaciones no quitan generalidad al estudio del 
+procesamiento de transacciones en un SGBD.
+Insert, Delete, UpdateSelect
+El concepto de transacción es universal en bases de datos, es decir es independiente del tipo de 
+bases de datos (modelo de datos) que se esté utilizando.
+En una base de datos relacional, las estructuras de datos son tablas y las operaciones de 
+manipulación tienen la sintaxis precisa del lenguaje SQL: SELECT, INSERT, DELETE y UPDATE.
+Para simplificar el estudio de la ejecución de transacciones y sus efectos en la base de datos es 
+interesante hacer una simplificación e independizarse de la estructura tabla y del lenguaje SQL. 
+Esto no significa que los ejemplos que aparecerán en las explicaciones no puedan ser sobre 
+bases de datos relacionales.
+Para no hablar de estructuras de datos concretas (como la tabla del modelo relacional) se 
+hablará de elementos de datos (por ejemplo, una fila de una tabla); en cada modelo de datos 
+estos elementos cambian.
+Para no hablar de un lenguaje concreto (como el lenguaje relacional SQL), se hablará de 
+operaciones generales de acceso a bases de datos. Las operaciones de acceso a una base de 
+datos pueden ser operaciones de consulta (lectura) u operaciones de actualización (escritura). 
+Las operaciones de consulta no cambian el contenido de la base de datos, sólo leen datos. Las 
+operaciones de actualización cambian el contenido de la base de datos.
+Las operaciones de actualización pueden ser, a su vez, operaciones de inserción de nuevos 
+datos, u operaciones de eliminación o de modificación de datos existentes. Es decir cualquier 
+operación de actualización significa escribir en la base de datos.
+Con la idea de simplificar el estudio de la ejecución de transacciones, se pueden considerar sólo 
+dos tipos de operaciones sobre la base de datos: lectura de datos, y escritura de datos.
+15
+
+16
+(1) escribir(X):
+• (2) determinar la dirección del bloque que contiene o debe contener el elemento X.
+• (3) copiar el bloque del disco a un buffer de memoria principal (si el bloque no está 
+ya en la memoria principal).
+• (4) copiar la variable X del programa del usuario al elemento de datos X en el buffer.
+• (5) copiar el bloque actualizado del buffer al disco.
+2 Operaciones y estados de una transacción.
+Operaciones de acceso a datos en una transacción:
+(1) leer(X):
+• (2) determinar la dirección del bloque que contiene el elemento X.
+• (3) copiar el bloque del disco a un buffer de memoria principal (si el bloque no está 
+ya en memoria principal).
+• (4) copiar el elemento de datos X del buffer a la variable X del programa del 
+usuario.
+En la transparencia aparecen los pasos que sigue el SGBD para la ejecución de una operación de 
+consulta (leer) y una operación de actualización (escribir) a la base de datos.
+Estos pasos coinciden con los pasos que se vieron en los diagramas de las operaciones de lectura 
+y actualización en el Tema 1.
+De nuevo, es importante fijarse en los pasos 3, 4 y 5 de ambas operaciones.
+16
+
+17
+2 Operaciones y estados de una transacción.
+Operaciones adicionales en una transacción:
+• inicio: el usuario indica al SGBD el comienzo de la transacción.
+•f i n (confirmación parcial): el usuario indica al SGBD que la 
+transacción ha finalizado (el usuario da por buena la 
+transacción que ha definido).
+• anulación:el usuario anula la transacción que está definiendo. 
+•c o n f i r m a c i ó n: el SGBD confirma definitivamente la transacción 
+que el usuario ha finalizado con confirmación. 
+• anulación: el SGBD anula la transacción que el usuario ha 
+finalizado con confirmación.
+Operaciones 
+de usuario
+Acciones del 
+SGBD
+Acciones del SGBD después de la 
+comprobación de las RI
+Las operaciones leer(X) y escribir(X) constituyen el contenido de las transacciones del usuario. 
+Para definir una transacción harán falta también dos operaciones con las que el usuario pueda 
+indicar al SGBD el inicio y el final de la transacción ya que es preciso delimitar claramente el 
+conjunto de operaciones que constituyen la transacción.
+Para flexibilizar la definición de transacciones se contemplan dos formas de finalizar una 
+transacción por parte del usuario: finalización con confirmación parcial (el usuario da por buena 
+la transacción que ha ejecutado), o finalización con anulación (el usuario rechaza la transacción 
+que está ejecutado).
+Por otro lado, es necesario recordar que el SGBD considera el efecto global de la transacción 
+confirmada (por el usuario) antes de comprobar las restricciones de integridad del esquema. 
+Según el resultado de esta comprobación, el SGBD puede confirmar definitivamente o anular
+(rechazar) la transacción del usuario.
+Una transacción confirmada definitivamente por el SGBD debe quedar grabada en la base de 
+datos en disco. Una transacción anulada por el usuario o por el SGBD no debe tener ningún 
+efecto sobre la base de datos. (Estos aspectos se estudiarán con más detalle en el Tema 4).
+17
+
+18
+2 Operaciones y estados de una transacción.
+activa confirmada 
+(a)
+anulada 
+(b) terminada
+confirmada 
+parcialmentefininicio
+anulación anulación
+confirmación
+usuario
+SGBD
+usuario
+SGBD
+SGBD
+usuario
+operaciones del usuario o del SGBD
+estados de la transacción
+sujeto de la operación
+leer
+escribir
+(a) todas las operaciones de la transacción se 
+ejecutan con éxito y sus cambios quedan 
+grabados permanentemente en la BD.
+(b) la transacción no tiene ningún efecto en la BD.
+En este diagrama se muestran los estados y las transiciones de estado por las que puede pasar 
+una transacción durante su ejecución.
+Una transacción puede estar en los siguientes estados:
+• Activa: el usuario inicia la transacción (operación inicio) y solicita operaciones de lectura o 
+escritura sobre la base de datos
+• Confirmada parcialmente: el usuario finaliza la transacción (operación fin) dándola por 
+buena (transacción confirmada parcialmente por el usuario).
+• Anulada:e l usuario finaliza la transacción anulándola (operación anulación); o bien el SGBD
+anula la transacción que está activa (por la ocurrencia de errores) o anula la transacción que 
+ya ha sido confirmada por el usuario (por la violación de alguna restricción de integridad).
+• Confirmada: el SGBD confirma definitivamente una transacción finalizada con confirmación 
+por el usuario (comprobación válida de restricciones de integridad).
+18
+
+19
+2 Operaciones y estados de una transacción.
+fin
+terminada
+usuariousuario
+anulación
+anulada
+(b)
+SGBD
+NO
+confirmada
+(a)confirmación
+SGBD
+SI
+SGBD
+Verificación RI
+activainicio
+leer
+escribir
+confirmada 
+parcialmente
+(a) todas las operaciones de la transacción se 
+ejecutan con éxito y sus cambios quedan 
+grabados permanentemente en la BD.
+(b) la transacción no tiene ningún efecto en la BD.
+Después que ha finalizado una transacción con confirmación del usuario (confirmada 
+parcialmente), el SGBD comprueba las restricciones de integridad del esquema sobre la base de 
+datos resultante de su ejecución.
+Si el resultado de esta comprobación es afirmativo (se satisfacen todas las restricciones de 
+integridad) el SGBD confirma definitivamente la transacción. En este caso el SGBD debe asegurar 
+que los cambios de la transacción son (o serán) grabados en la base de datos en disco (objetivo 
+(a)).
+Si el resultado de esta comprobación es negativo (se viola alguna de las restricciones de 
+integridad) el SGBD anula la transacción. En este caso el SGBD debe asegurar que la transacción 
+no deja ningún efecto sobre la base de datos (objetivo (b)).
+19
+
+20
+2 Operaciones y estados de una transacción.
+activa
+inicio
+terminadaanulada
+(b)
+anulación
+SGBD
+usuario
+usuario
+comprobaciones,
+errores, …
+voluntariamente
+leer
+escribir
+(a) todas las operaciones de la transacción se 
+ejecutan con éxito y sus cambios quedan 
+grabados permanentemente en la BD.
+(b) la transacción no tiene ningún efecto en la BD.
+Si la transacción está activa y el usuario o el SGBD anula la transacción, el SGBD debe asegurar
+que la transacción no deja ningún efecto sobre la base de datos (objetivo (b)). 
+20
+
+21
+1 Concepto de transacción.
+2 Operaciones y estados de una transacción.
+3 Propiedades del procesamiento de transacciones.
+4 Definición de transacciones en SQL.
+5 Concepto de restricción de integridad.
+6 Comprobación de restricciones en SQL.
+Procesamiento de transacciones y mantenimiento de la integridad.
+21
+
+22
+3 Propiedades del procesamiento de transacciones.
+Propiedades que debe cumplir la ejecución de transacciones:
+ Atomicidad: una transacción es una unidad de ejecución (o se ejecutan 
+todas sus operaciones o no se ejecuta ninguna de ellas). 
+ Consistencia: una transacción debe conducir la BD de un estado 
+consistente a otro estado consistente (estado consistente: se cumplen 
+todas las restricciones de integridad del esquema).
+ Aislamiento: una transacción debe ejecutarse como si se ejecutase de 
+forma aislada (en solitario).
+ Persistencia: los cambios de una transacción confirmada por el SGBD 
+deben quedar grabados permanentemente en la BD.
+Propiedades ACID= Atomicity+Consistency+Isolation+Durability
+Tema 2
+Tema 4
+Tema 3
+Tema 2
+La ejecución correcta de transacciones en un SGBD debe respetar el concepto de transacción 
+como “unidad de ejecución”.
+Esto significa el cumplimiento de cuatro propiedades:
+• Atomicidad: es la esencia del concepto de transacción, o se ejecutan todas sus operaciones o 
+no se ejecuta ninguna (la transacción tiene un carácter atómico).
+• Consistencia: sólo se deben admitir transacciones que conduzcan a la base de datos a un 
+estado consistente, es decir en el que se cumplen todas las restricciones de integridad del 
+esquema. (Tema 2)
+• Aislamiento: las transacciones de usuario se deben ejecutar como si se ejecutasen de forma 
+aislada, sin la interferencia de otras transacciones de usuario. Los protocolos de control de la 
+concurrencia de los SGBD aseguran este objetivo. (Tema 4)
+• Persistencia: el SGBD debe asegurar (definición de transacción) que los efectos de una 
+transacción confirmada definitivamente por el sistema quedarán grabados en la base de 
+datos en disco. (Tema 3)
+22
+
+23
+1 Concepto de transacción.
+2 Operaciones y estados de una transacción.
+3 Propiedades del procesamiento de transacciones.
+4 Definición de transacciones en SQL.
+5 Concepto de restricción de integridad.
+6 Comprobación de restricciones en SQL.
+Procesamiento de transacciones y mantenimiento de la integridad.
+23
+
+24
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+• INICIO: START TRANSACTION* (o inicio implícito).
+• FIN (confirmación del usuario): COMMIT [WORK ] 
+(transacción confirmada parcialmente)
+• ANULACIÓN (anulación del usuario):  ROLLBACK [WORK ]   
+(transacción anulada)
+En SQL no se pueden anidar las transacciones.
+El inicio implícito de una transacción se realiza cuando se ejecuta una instrucción 
+SQL ( de DML) y no está ninguna transacción activa en ese momento.
+*En SQL92 no existía la instrucción START, el inicio siempre era implícito.
+El lenguaje SQL es el lenguaje estándar para los SGBD relacionales.
+En la transparencia se presenta la sintaxis que SQL ofrece para las operaciones de usuario en la 
+definición de transacciones: inicio, fin y anulación.
+El inicio implícito de una transacción tiene lugar cuando después del inicio de la sesión de 
+usuario, o después del final de una transacción, el usuario solicita una operación de 
+manipulación (DML) sobre la base de datos, esta operación le indica al SGBD el inicio de la 
+siguiente transacción.
+24
+
+25
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+• ANULACION:  ROLLBACK [WORK ] [TO SAVEPOINT marca_savepoint]
+ Las marcas de savepoint permiten el establecimiento de partes 
+opcionales dentro de una transacción que podrán ser posteriormente 
+(dependiendo de la lógica de la transacción) deshechas sin deshacer la 
+transacción completa.
+ Una marca de savepoint se establece en una transacción con la sentencia 
+SAVEPOINT marca_savepoint.
+ Se pueden establecer varias marcas de savepoint dentro de una 
+transacción.
+En SQL existe una variante de la operación de anulación de una transacción (ROLLBACK): 
+ROLLBACK TO SAVEPOINT marca_savepoint.
+Las marcas de savepoint las define el usuario estratégicamente a lo largo de la transacción con la 
+instrucción SAVEPOINT.
+Estas marcas permiten al usuario hacer anulaciones parciales de una transacción con la 
+instrucción ROLLBACK TO SAVEPOINT marca_savepoint (anular hasta una marca de savepoint).
+Esta variante tiene utilidad cuando las transacciones se ejecutan embebidas en programas 
+donde la lógica del programa (estructuras condicionales) puede aconsejar deshacer parte de una 
+transacción.
+Las marcas de savepoint y la instrucción ROLLBACK TO SAVEPOINT permiten definir varias 
+transacciones en una, la ejecución de cada una de ellas dependerá de las condiciones del 
+contexto de ejecución. Puede verse como la definición de partes opcionales en una transacción.
+25
+
+26
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+• ROLLBACK [WORK]: finaliza la transacción y se deshacen todas las operaciones 
+que se hayan ejecutado desde su inicio. 
+• ROLLBACK TO SAVEPOINT marca_savepoint: se deshacen todas las 
+operaciones ejecutadas desde el establecimiento de marca_savepoint y la 
+marca de savepoint es borrada. La transacción continúa en la instrucción 
+siguiente al ROLLBACK ejecutado (no finaliza la transacción).
+26
+
+27
+START TRANSACTION
+…
+…
+SAVEPOINT marca1
+…
+…
+SAVEPOINT marca2
+…
+…
+IF …  THEN ROLLBACK TO SAVEPOINT marca2
+…
+…
+IF …  THEN ROLLBACK TO SAVEPOINT marca1
+…
+COMMIT
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+27
+
+28
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+• SET TRANSACTION modo [,modo] …
+modo:= nivel de aislamiento
+modo de acceso
+área de diagnóstico
+Con la instrucción SET TRANSACTION el usuario puede dar al SGBD directrices
+sobre el procesamiento de transacciones durante su sesión de usuario.
+Sesión de usuario: espacio de tiempo comprendido entre la conexión del 
+usuario al SGBD y la desconexión.
+La instrucción SET tiene distintas variantes en SQL y sirve para que el usuario pueda dar al SGBD 
+directrices de funcionamiento durante su sesión de usuario.
+Una sesión de usuario es el espacio de tiempo comprendido entre la conexión del usuario al 
+SGBD y su desconexión.
+La variante SET TRANSACTION sirve para dar al SGBD directrices relativas a la ejecución de las 
+transacciones. Esta instrucción se debe ejecutar entre transacciones y el alcance de la directriz 
+es la transacción siguiente.
+28
+
+29
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+SET TRANSACTION modo [,modo] …
+ El nivel de aislamiento especifica el nivel de control de la concurrencia 
+que debe realizar el SGBD. 
+ El área de diagnóstico especifica el número máximo de condiciones de 
+diagnóstico (errores o excepciones) que pueden registrarse relativas a la 
+ejecución de las últimas instrucciones SQL:
+SET TRANSACTION DIAGNOSTICS SIZE  número
+ El modo de acceso especifica el tipo de operaciones que se pueden 
+ejecutar en una transacción: READ ONLY prohíbe operaciones de 
+actualización de la base de datos:
+SET TRANSACTION {READ ONLY READ WRITE}
+La instrucción SET TRANSACTION tiene tres argumentos (opcionales) cuyo significado se explica 
+en la transparencia.
+El argumento nivel de aislamiento se estudiará con más detalle en el Tema 10.
+29
+
+30
+4 Definición de transacciones en SQL.
+Definición de transacciones en SQL (operaciones de usuario):
+SET TRANSACTION modo [,modo] …
+ La instrucción SET TRANSACTION no se puede ejecutar dentro de una 
+transacción. 
+ La instrucción SET TRANSACTION debe ejecutarse antes del inicio de la 
+transacción.
+ Alcance: la ejecución de la instrucción SET TRANSACTION establece el 
+modo de ejecución de la siguiente transacción.
+ Existen unos valores por defecto para los tres modos: READ WRITE, 
+SERIALIZABLE, y un tamaño del área de diagnóstico indeterminada.
+30
+
+31
+1 Concepto de transacción.
+2 Operaciones y estados de una transacción.
+3 Propiedades del procesamiento de transacciones.
+4 Definición de transacciones en SQL.
+5 Concepto de restricción de integridad.
+6 Comprobación de restricciones en SQL.
+Procesamiento de transacciones y mantenimiento de la integridad.
+31
+
+32
+5 Concepto de restricción de integridad.
+Propiedad que la base de datos debe satisfacer 
+en cualquier instante de su historia.
+Restricción de 
+Integridad
+ La BD evoluciona por la ejecución de transacciones de usuario.
+ Las transacciones se consideran unidades de ejecución (atomicidad).
+ Las restricciones “se deben” comprobar después de la ejecución de 
+cada transacción (consistencia).
+Estado 1
+(consistente)
+Estado 2
+(consistente)
+Estado 3
+(consistente)
+T1 T2
+Comprobación 
+de RI
+Comprobación 
+de RI
+Como se comentó en el Tema 1, el sistema de información de una organización contiene toda la 
+información relacionada con su actividad. Con la tecnología actual, el núcleo de cualquier 
+sistema de información es una (o varias) bases de datos. Es decir una base de datos reúne (de 
+forma estructurada) todos los datos producidos durante la actividad de la organización.
+En cualquier organización existen reglas de funcionamiento que se deben cumplir en cualquier 
+instante de tiempo. Estas reglas se traducen, en la base de datos, en forma de restricciones de 
+integridad.
+Una restricción de integridad es una regla (o norma) de la organización que la base de datos 
+debe cumplir en cualquier instante de tiempo.
+(Por ejemplo, la regla: “todo empleado debe pertenecer a un departamento de la organización” 
+se representa en el ejemplo, al principio de este tema, con una definición de clave ajena en la 
+tabla Empleado).
+Como la base de datos sólo evoluciona por la ejecución de transacciones de usuario, las 
+restricciones de integridad “deberán” ser comprobadas en cada nuevo estado de la base de 
+datos, es decir, después de la ejecución de cada transacción.
+32
+
+33
+Propiedades ACID:
+ Atomicidad: una transacción es una unidad de ejecución (o se ejecutan 
+todas sus operaciones o no se ejecuta ninguna de ellas). 
+ Consistencia: una transacción debe conducir la BD de un estado 
+consistente a otro estado consistente (estado consistente: se cumplen 
+todas las restricciones de integridad del esquema).
+ Aislamiento: una transacción debe ejecutarse como si se ejecutase de 
+forma aislada (en solitario).
+ Persistencia: los cambios de una transacción confirmada por el SGBD 
+deben quedar grabados permanentemente en la BD.
+5 Concepto de restricción de integridad.
+La comprobación de restricciones de integridad tiene que ver con las propiedades de 
+Atomicidad y Consistencia del principio ACID de la ejecución de transacciones.
+33
+
+34
+1 Concepto de transacción.
+2 Operaciones y estados de una transacción.
+3 Propiedades del procesamiento de transacciones.
+4 Definición de transacciones en SQL.
+5 Concepto de restricción de integridad.
+6 Comprobación de restricciones.
+Procesamiento de transacciones y mantenimiento de la integridad.
+34
+
+35
+6 Comprobación de restricciones en SQL.
+Comprobación de restricciones en SQL:
+Desde un punto de vista teórico, las restricciones de integridad se deben 
+comprobar cuando termina una transacción, en la práctica esta comprobación 
+se puede relajar. Para ello, cada restricción de integridad del esquema tiene dos 
+propiedades:
+ Modo: define cuándo se comprueba la restricción y qué se hace si se 
+viola.
+ Inmediato.
+ Diferido.
+ Propiedad de cambio: determina la posibilidad de cambiar o no el modo
+definido.
+ Diferible.
+ No diferible.
+Estas propiedades se definen para cada restricción pudiendo ser diferentes de una a otra y se 
+especifican en la creación de las tablas junto a la definición de cada restricción de integridad en 
+una cláusula que ya se introdujo en Bases de Datos (UD2.3) y que se denominó 
+cuándo_comprobar. Recordamos la definición de una restricción de integridad (a nivel de 
+atributo) en la notación BNF para ilustra dónde se incluiría la cláusula.
+[CONSTRAINT nombre_restricción]
+{NOT NULL | UNIQUE | PRIMARY KEY | CHECK(condición_búsqueda) |
+REFERENCES nom_relación [(nom_atributo)]
+[ON DELETE {CASCADE| SET NULL| SET DEFAULT| NO ACTION}]
+[ON UPDATE {CASCADE| SET NULL| SET DEFAULT| NO ACTION}]
+[cuándo_comprobar]
+35
+
+36
+6 Comprobación de restricciones en SQL.
+Comprobación de restricciones en SQL:
+Modo inmediato:
+ ¿Cuándo se comprueba? Después de cada operación SQL que pueda violar 
+la restricción.
+ ¿Qué hace el SGBD si se viola? Anula la instrucción SQL que ha provocado 
+la violación y la transacción continúa.
+Modo diferido:
+ ¿Cuándo se comprueba? Después de cada transacción que contenga una 
+operación SQL que pueda violar la restricción.
+ ¿Qué hace el SGBD si se viola? Anula la transacción entera.
+Existen dos modos de comprobación: inmediato y diferido con el significados que se expone en 
+la transparencia.
+Según el concepto de transacción, la comprobación de las restricciones de integridad se debería 
+hacer al final de la transacción (modo diferido). La transacción es una unidad de ejecución y lo 
+que importa es su efecto global.
+La propuesta de dos modos de comprobación de la integridad responde a la búsqueda de una 
+mayor flexibilidad en la ejecución de transacciones. Anular operaciones individuales de una 
+transacción ofrece al usuario la oportunidad de corregir el error sin tener que esperar a la 
+finalización de la transacción y su posible anulación.
+36
+
+37
+6 Comprobación de restricciones en SQL.
+Comprobación de restricciones en SQL:
+Propiedad de cambio diferible:
+ El modo de una restricción (inmediato o diferido) se puede cambiar 
+dinámicamente durante la ejecución de una transacción. El cambio es 
+local a la transacción, no modifica la definición de la restricción.
+Propiedad de cambio no diferible:
+ El modo de una restricción no se puede cambiar dinámicamente durante 
+la ejecución de una transacción.
+Cada restricción de integridad tiene un modo de comprobación inicial definido en el esquema de 
+la base de datos. Este modo se puede cambiar dinámicamente o no durante la ejecución de las 
+transacciones. Para poder cambiar el modo, la restricción debe haber recibido esa propiedad de 
+cambio en su definición.
+37
+
+38
+6 Comprobación de restricciones en SQL.
+Propiedad del cambio: diferible/no diferible
+[[NOT] DEFERRABLE]
+Comprobación de restricciones en SQL: sintaxis
+Cláusula cuándo_comprobar
+[INITIALLY {IMMEDIATE  |  DEFERRED}] 
+Inmediato Diferido
+Modo
+UD2.3 BDA
+En esta transparencia se presenta la cáusula cuándo_comprobar con la notación BNF que se usa 
+para definir instrucciones SQL.
+38
+
+39
+6 Comprobación de restricciones en SQL.
+La semántica de cada una de las versiones de la cláusula es: 
+1. Sin  cláusula: si no se especifica nada en la definición, la restricción se define como 
+no diferible y con modo inmediato. (Valor por defecto).
+2. DEFERRABLE INITIALLY IMMEDIATE: define la restricción como diferible y con modo 
+inmediato.
+3. DEFERRABLE INITIALLY DEFERRED: define la restricción como diferible y con modo 
+diferido.
+4. NOT DEFERRABLE INITIALLY IMMEDIATE: define la restricción como no diferible y con 
+modo inmediato. (Coincide con los valores por defecto).
+5. NOT DEFERRABLE INITIALLY DEFERRED: esta versión está prohibida.
+6. DEFERRABLE : define la restricción como diferible y con modo inmediato.
+7. NOT DEFERRABLE: define la restricción como no diferible y con modo inmediato.
+8. INITIALLY IMMEDIATE: define la restricción como no diferible y con modo inmediato.
+9. INITIALLY DEFERRED: define la restricción como diferible y con modo inicial diferido.
+Comprobación de restricciones en SQL: sintaxis
+Teniendo en cuenta que en la sintáxis BNF:
+• los corchetes ([ ]) denotan partes opcionales,
+• la llaves ({ }) elementos de los que se debe elegir uno, y
+• la barra vertical (|) separa las distintas opciones posibles, 
+la cláusulacuándo_comprobar de una restricción de integridad se puede escribir de nueve 
+formas posibles. En la transparencia se incluyen todas ellas y se explica el comportamiento que 
+implican.
+39
+
+40
+6 Comprobación de restricciones en SQL.
+Comprobación de restricciones en SQL: cambio de modo
+La instrucción SQL que permite cambiar, localmente en una transacción, el modo 
+de una restricción definida como diferible (DEFERRABLE) es: 
+SET CONSTRAINT {restricción1, ... | ALL} {IMMEDIATE | DEFERRED}
+ Cada restricción especificada en la lista debe ser diferible y la opción ALL hace 
+referencia a todas las restricciones diferibles del esquema de la base de datos.
+ El alcance del cambio producido por la instrucción SET CONSTRAINT es la 
+transacción en la que se incluye o el fragmento de transacción hasta la siguiente 
+aparición de la instrucción.
+ Si se incluye la instrucción en medio de la transacción con la opción 
+IMMEDIATE, las restricciones afectadas por la instrucción son comprobadas 
+cuando se ejecuta ésta, si alguna de estas restricciones falla, la instrucción SET 
+falla y el modo de las restricciones permanece sin modificar.
+La variante de la instrucción SET de la forma SET CONSTRAINT permite cambiar dinámicamente 
+(durante la ejecución de la transacción) el modo de comprobación de una (o varias) restricción 
+de integridad, siempre que ésta se haya definido con la propiedad DEFERRABLE.
+40
+
+41
+6 Comprobación de restricciones en SQL.
+Empleado (dni: char(10), nombre: char(60), salario: real, dpto: char(5))
+CP:  {dni} VNN:  {dpto}
+CAj: {dpto} Departamento   f(dpto)=código
+Departamento (código: char(5), nombre: char(50), ubicación: char(15))
+CP: {código} VNN:  {nombre}
+R1: “A todo departamento pertenece al menos un empleado”
+Ejemplo:
+Sea el esquema lógico de la base de datos relacional del ejemplo inicial del tema.
+41
+
+42
+6 Comprobación de restricciones en SQL.
+Ejemplo:
+CREATE TABLE Empleado
+(dni char(10) CONSTRAINT cp_emp PRIMARY KEY
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+nombre varchar2 (60) ,
+salario number,
+dpto char(5) CONSTRAINT dpto_nulo NOT NULL
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+CONSTRAINT caj_emp_dpto REFERENCES Departamento (codigo)
+DEFERRABLE INITIALLY DEFERRED);
+CREATE TABLE Departamento
+(codigo char(5) CONSTRAINT cp_dpto PRIMARY KEY
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+nombre varchar2(50) CONSTRAINT nombre_dep_nulo NOT NULL
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+ubicacion varchar2 (15));
+CREATE ASSERTION R1 CHECK (NOT EXISTS
+(SELECT * FROM Departamento D
+WHERE NOT EXISTS (SELECT * FROM Empleado E
+WHERE E.dpto=codigo)))
+DEFERRABLE INITIALLY DEFERRED;
+Esta es la definición del esquema lógico anterior en el lenguaje SQL.
+En los sistemas de gestión de bases de datos actuales no es posible la definición de asertos por lo 
+que la restricción R1 debería ser controlada por programa.
+42
+
+43
+6 Comprobación de restricciones en SQL.
+Ejemplo: 
+INSERT INTO Departamento VALUES (' d3 ','Personal','Planta3');
+SGBD: comprobación de las RI: cp_dpto, nombre_dep_nulo
+UPDATE Empleado SET dpto = 'd3' WHERE  dni = ' 65743983';
+SGBD: comprobación de la RI: dpto_nulo
+COMMIT WORK;
+SGBD: comprobación de las RI: caj_emp_dpto, R1
+SGBD CONFIRMAR (transacción)
+Transacción confirmada por el SGBD: sus cambios serán grabadosen la 
+BD (a)
+RI en modo 
+diferido
+RI en modo 
+inmediato
+En las transparencias siguientes se presentan ejemplos de ejecución de transacciones (SQL) 
+sobre la base de datos de ejemplo, con la indicación de la comprobación de la integridad. 
+Obsérvese el modo de comprobación de cada restricción y su efecto en la ejecución de la 
+transacción.
+43
+
+44
+6 Comprobación de restricciones en SQL.
+Instrucción anulada por el SGBD (si los cambios ya han sido grabados son 
+deshechos): la transacción puede continuar.
+INSERT INTO Departamento (codigo, ubicacion) VALUES ('d5 ', 'Planta2')
+SGBD: comprobación de la RI: cp_dpto, 
+comprobación de la RI: nombre_dep_nulo
+SGBD ANULAR (instrucción)
+…
+Ejemplo: 
+RI en modo 
+inmediato
+44
+
+45
+6 Comprobación de restricciones en SQL.
+Transacción anulada por el SGBD: si los cambios ya han sido grabados son 
+deshechos (b).
+INSERT INTO Departamento VALUES ('d8 ', 'Proyectos', 'Planta1');
+SGBD: comprobación de las RI: cp_dpto, nombre_dep_nulo
+…
+COMMIT WORK;
+SGBD: comprobación de las RI: R1
+SGBDANULAR (transacción)
+Ejemplo: 
+RI en modo 
+diferido
+RI en modo 
+inmediato
+45
+
+46
+6 Comprobación de restricciones en SQL.
+Las restricciones caj_emp_dpto y R1 son diferibles y con modo diferido. Si 
+se cambiase su modo a inmediato no se podría actualizar la base de datos.Ejemplo: 
+CREATE TABLE Empleado
+(dni char(10) CONSTRAINT cp_emp PRIMARY KEY
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+nombre varchar2 (60) ,
+salario number,
+dpto char(5) CONSTRAINT dpto_nulo NOT NULL
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+CONSTRAINT caj_emp_dpto REFERENCES Departamento (codigo)
+DEFERRABLE INITIALLY DEFERRED);
+CREATE TABLE Departamento
+(codigo char(5) CONSTRAINT cp_dpto PRIMARY KEY
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+nombre varchar2(50) CONSTRAINT nombre_dep_nulo NOT NULL
+NOT DEFERRABLE INITIALLY IMMEDIATE,
+ubicacion varchar2 (15));
+CREATE ASSERTION R1 CHECK (NOT EXISTS
+(SELECT * FROM Departamento D
+WHERE NOT EXISTS (SELECT * FROM Empleado E
+WHERE E.dpto=codigo)))
+DEFERRABLE INITIALLY DEFERRED;
+Las dos restricciones del esquema que se han definido como DEFERRED (y por lo tanto con la 
+opción de DEFERRABLE) son la restricción de clave ajena y la restricción R1. El modo DEFERRED 
+para ambas restricciones asegura que se pueda actualizar la base de datos, y dar de alta un 
+nuevo departamento.
+46
+
+47
+6 Comprobación de restricciones en SQL.
+Restricciones diferibles: 
+CREATE SCHEMA esquema1
+...
+CREATE ASSERTION  R1  CHECK ( …  ) 
+DEFERRABLE  INITIALLY  INMEDIATE
+...
+Para ilustrar el usos de la propiedad DEFERRABLE, se va a usar un ejemplo genérico, donde 
+aparece definida una restricción R1, con modo de comprobación IMMEDIATE y con la propiedad 
+DEFERRABLE.
+47
+
+48
+6 Comprobación de restricciones en SQL.
+Restricciones diferibles: 
+Instrucción(1)‐SQL
+...
+Instrucción(i)‐SQL (relevante para R1)
+SGBD: comprobación de R1
+...
+COMMIT WORK
+SGBD: otras comprobaciones de RI
+Transacción T1
+ANULAR
+transacción
+CONFIRMAR transacción
+se viola alguna
+se satisfacen todas
+satisface R1
+viola R1
+ANULAR
+instrucción(i)
+En la transparencia, se muestra que, como el modo inicial de R1 es IMMEDIATE, cuando se 
+ejecuta una instrucción SQL, relevante para R1, el sistema comprueba la restricción y, en caso de 
+violación, anula la instrucción (deshaciendo sus cambios) y la transacción puede continuar.
+Una operación es relevante para una restricción de integridad si su ejecución puede violar la 
+restricción.
+48
+
+49
+6 Comprobación de restricciones en SQL.
+SET CONSTRAINT R1 DEFERRED
+Instrucción(1)‐SQL
+...
+Instrucción(i)‐SQL (relevante para R1)
+...
+COMMIT WORK
+SGBD: comprobación de R1 y otras RI
+Transacción T2
+ANULAR
+transacción
+CONFIRMAR transacción
+se viola alguna
+se satisfacen todas
+Restricciones diferibles: 
+En la transparencia, se muestra como el usuario cambia el modo de comprobación de R1 
+(instrucción SET). Cuando se ejecuta la instrucción SQL, relevante para R1, el sistema no hace 
+ninguna comprobación, la restricción R1 se comprueba al final de la transacción, y, en caso de 
+violación, se rechaza la transacción completa.
+Los SGBDs hacen una comprobación de la integridad inteligente, sólo comprueban aquellas 
+restricciones que son relevantes para las operaciones que se ejecutan en la transacción.
+49

--- a/src/data/lessonSummaries/text/ggo-tema-1.txt
+++ b/src/data/lessonSummaries/text/ggo-tema-1.txt
@@ -1,0 +1,157 @@
+Introducción al Gobierno de TI
+
+Contenido
+§Gobierno§Gobierno corporativo§Gobierno de TI
+
+Gobierno
+
+Gobierno corporativo§El gobierno corporativo fijaexpectativas claraspara la conducta de la entidad que está siendo gobernada, y dirige, controlae influenciafuertemente en dicha entidad para cumplir estas expectativas(Allen, 2005).   
+§El gobierno establece: (Mueller,2008)oCadenas de responsabilidad, autoridad y comunicación.oMedición, políticas, estándares y mecanismos de control para permitir a las personas llevar a cabo sus roles y responsabilidades.
+
+Gobierno corporativo
+§Para la OCDE (2016) el gobierno es el sistema por que cual se dirigen y controlan las empresas, especificando su estructura, la distribución de derechos y responsabilidadesentre los diversos componentes de la empresa, y el establecimiento de reglas y procedimientospara tomar decisiones en los asuntos corporativos.
+
+Gobierno Corporativo
+§Actividad:
+Dirección general
+Consejo de administraciónAsamblea de accionistas
+Tienen su capital invertido . Evalúan rendimientos y riesgos de las inversiones
+
+Gobierno Corporativo
+§Actividad:
+Dirección general
+Consejo de administraciónAsamblea de accionistas
+Propietarios, inversionistas y consejeros externos. Determinan estrategias a seguir y supervisan las acciones del grupo directivo
+
+Gobierno Corporativo
+§Actividad:
+Dirección general
+Consejo de administraciónAsamblea de accionistas
+Grupo gerencial (presidente, gerente, directores,...).Encargado de la dirección general de la empresa, departamentos o subdivisiones.
+
+Gobierno Corporativo
+§Actividad:
+Dirección general
+Consejo de administraciónAsamblea de accionistas
+¿Dónde participa el CIO ?
+
+Gobierno Corporativo
+§Actividad:
+Dirección general
+Consejo de administraciónAsamblea de accionistas
+¿Dónde participa el CIO ?
+≃CIO
+
+Gobierno Corporativo
+§Actividad:
+Dirección general
+Consejo de administraciónAsamblea de accionistas
+No todos los directivos están al mismo nivel
+≃CIO
+
+Gobierno TI§A partir del año 2000 las organizaciones se enfrentan a una complejidad cada vez mayor con avances vertiginosos en nuevas tecnologías.
+
+Gobierno corporativo
+(Weill y Ross, 2004)
+
+Gobierno TI§El gobierno de TI se centra en el uso de la tecnología para satisfacer los objetivos de la organizaciónfijados por la dirección (Hamakery Hutton, 2004)
+§Parenty Reich (2007) distinguen dos formas de gobierno de TI:oGobierno del riesgode las TI (Visión defensiva)oGobierno del valorde las TI (Visión estratégica)
+
+Gobierno TI§Dahlbergy Kivijarvi(2006) indican que el gobierno de TI debe ser integral e incluiroProcesos y estructura de gobiernooAlineamientode negociooOperaciones de TIoMedición del desempeñooEstrategia de valor
+§El IT GovernanceInstituteindica que el gobierno de TI asegura: oGestionan riesgosoAlineamientocon el negociooGestionan el desempempeñooGestionan recursosoEntrega valoral negocio
+
+Gobierno TI
+§El IT GovernanceInstituteindica que el gobierno de TI asegura: oGestionan riesgosoAlineamiento con el negociooGestionan el despempeñooGestionan recursosoEntrega valor al negocio
+AsignaturaTema 1Tema 2Tema 3Tema 4Tema 5
+¿Quién?¿El CIO, el consejo, la dirección?
+
+Gobierno TI§El gobierno de TI es la capacidad de organización que ejerceel consejo, la dirección ejecutiva y la gestión de TIpara controlar la formulación e implementación de la estrategia de TI y de esta manera asegurar la fusión de los negocios y de TI. (Van Grembergen, 2002)§El gobierno de TI es responsabilidadde la junta directiva (o consejo de administración)y la dirección ejecutiva. Es una parte integral del gobierno de la empresay consiste en las estructuras de dirección, organización y procesos que aseguren que la organización sostiene y extiende las estrategias y objetivos de la organización.  (IT Governance Institute, 2001)
+
+Gobierno de TI frente a Gestión de TI (Peterson, 2003)
+!"#$B&##
+'E$&BF*F$+B
+I$-&.
+'E$&BF*F$+B
+/0F&EB*1
+OBF&EB*1
+PE&#&BF 4"F"E&
+!"#
+$%&%'()(&G
+!"#
++I-(.&%&/(
+Prestación de servicios y productos para la organización interna de TI y la gestión de las operaciones actuales
+Es específico de la organización, y no pueden ser externalizados
+
+Gobierno TIEntonces ¿Cual es el papel del CIO en la Gobernanza de TI?
+Twoquestionsthenarise: Are boardspreparedtoasktherightquestionsofmanagement, and in particular theCIO?Are CIOspreparedtotakeonthisbroaderresponsibility?
+IftheCIO doesnotstep up, othersmaysupplanthisorherrole.
+
+58
+¿Cuantos proyectos de TI tienen resultados positivos en el negocio?
+...todavía no es suficiente!
+La mitad o menosMás de la mitad
+!"#$%#
+
+11 September 2008IT Governance Event - UCISA 60
+Mitigar el riesgo: Garantizar la seguridad y la continuidad de las operaciones comerciales internas, y reducir al mínimo la exposición al factor de riesgo externo
+Maximizar la rentabilidad: Mejorar los resultados empresariales;  Aumentar los ingresos y las ganancias, flujo de caja, la reducción del costo de la operación
+Mejorar el rendimiento: Mejorar de extremo a extremo el rendimiento operaciones comerciales.  Aumentar  la satisfacción de cliente y empleados
+Aumentar la agilidad: Habilitar la organización empresarial y las operaciones para adaptarse a las cambiantes necesidades del negocio
+el CIO debe combinar entre muchas prioridades que compiten
+
+11 September 2008IT Governance Event - UCISA 61
+Mitigar el riesgo: Garantizar la seguridad y la continuidad de las operaciones comerciales internas, y reducir al mínimo la exposición al factor de riesgo externo
+Maximizar la rentabilidad: Mejorar los resultados empresariales;  Aumentar los ingresos y las ganancias, flujo de caja, la reducción del costo de la operación
+Mejorar el rendimiento: Mejorar de extremo a extremo el rendimiento operaciones comerciales.  Aumentar  la satisfacción de cliente y empleados
+Aumentar la agilidad: Habilitar la organización empresarial y las operaciones para adaptarse a las cambiantes necesidades del negocio
+el CIO debe combinar entre muchas prioridades que compiten
+Cuadro de mando
+Gestión de riesgos
+Bedell
+Arquitecturas
+
+62
+Necesidades, problemas y desafíos
+Procedure, Audits, MetricsControl
+StrategicTacticalOperations
+Demand IT andBusinessResources
+Supply
+Capital, Capacity, PrioritiesPlanning
+Alignment Flexibility
+EfficiencyQuality
+Lack of Business aligned strategy
+Reduce costs across business 
+Ineffective project Management
+Deployment Complexity through lack of standard & legacy
+No Audit Trails 
+Management of Service Changes
+Must reduce IT costs by 30%
+Lack of IT resource transparency
+Missed targets due to lack of steering control 
+Deployment Complexity in number of project
+Cannot aggregate need and distribute ROI
+No means of governing outsourced contracts
+No means of capturing demands
+No means of prioritization of business need
+No means of reporting SLA
+Making new outsourcing decisions
+Do thethingsright
+Do thingsright
+
+Who are the Decision Makers? 
+Business and IT CollaborationIT DecisionBusiness Decision
+De-centralised
+Centralized
+Federal
+Business Exec.
+Business Exec./Mgt.
+Business Mgt.
+IT Exec.
+IT Exec./Mgt.
+IT Management
+Business and IT Exec.
+Business and ITExec./Mgt.
+Business and IT Mgt.
+Non-CooperativeCooperative
+
+Introducción al Gobierno de TI

--- a/src/data/lessonSummaries/text/ggo-tema-2.txt
+++ b/src/data/lessonSummaries/text/ggo-tema-2.txt
@@ -1,0 +1,46 @@
+Entrega de Valor
+
+IntroducciónNo existe una definición totalmente aceptada de valor de TI
+
+Introducción
+
+IntroducciónPara IT Governance Institute (ITGI) en un documento denominado “Reunión Informativa sobre Gobernabilidad TI”, los principios básicos del valor de la TIson: oentregar a tiempo, odentro del presupuesto y ocon los beneficios prometidos
+
+ITILITIL4 define valor como:“Los beneficios , utilidad e importancia percibidos de algo”La gestión de serviciosde ITIL 4 consiste en ”un conjunto de capacidadesorganizadas especializadas para proporcionar valor a los clientesen forma de servicios”
+
+ITILEl primer principio de ITIL es “centrarse en el valor”. Para ello se recomienda:oConocercomo utilizan los consumidores los serviciosoIncentivar al personal a concentrarse en el valoroCentrarse en el valordurante las actividades operacionales normales, así como durante las iniciativas de mejoraoIncluir el foco en el valoren cada paso de cualquier iniciativa de mejora.
+
+ValITEl marco ValIT del ITGI
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSILos principiosde ValIT se pueden agrupar en dos grandes bloques:oLas inversiones basadas en las TSI: Cartera de inversionesoPrácticas para la entrega de valor: Monitorización de métricas clave de las inversiones
+
+ValIT—Definition of Key Terms Used in Val IT
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSI
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSIrecibe demandas estratégicas y desarrolla el modelo conceptual del servicio para representar el servicio de TI o empresarial nuevo o mejorado que se solicita. El modelo conceptual del servicio es el puente entre la empresa y TI, ya que proporciona el contexto empresarial para el servicio junto con los atributos arquitectónicos de alto nivel.
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSIrecibe el modelo conceptual del servicio y diseña y desarrolla el modelo lógico del servicio con requisitos más detallados que describen cómo se diseñará el servicio de TI o empresarial recientemente solicitado y sus componentes. El modelo lógico del servicio puede considerarse como lo que tradicionalmente se expresa en términos de TI como el "diseño del sistema".
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSIrecibe el plano lógico del servicio después de que haya pasado por el proceso de desarrollo, prueba y aprobación de lanzamiento. Es responsable de las tareas para realizar la transición del servicio a la producción y hacerlo consumible por la empresa, incluida la creación de la entrada del catálogo de servicios.
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSIproporciona un marco para integrar la monitorización, la administración, la resolución y otros aspectos operativos asociados con los servicios realizados y/o aquellos en construcción. También proporciona una descripción general integral del negocio de las operaciones de TI y los servicios que prestan estos equipos.
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSI
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSI
+GobiernoGestión1 . Objetivo: Embeber en la organización las prácticas de gestión de valor logrando el valor óptimo a partir de las inversiones de TSI3. Objetivo: Asegurar valoren inversiones individualizadas basadas en TSI2. Objetivo: Asegurar el valoróptimo a lo largo de la cartera de inversiones en TSI
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSI
+
+ValITEl marco ValIT del ITGI tiene como objetivofacilitar la creación de valor de negocio a partir de las inversiones basadas en las TSIVal IT se centra en la decisión de invertir (¿estamos haciendo lo correcto?) y la realización de beneficios (¿estamos obteniendo beneficios?), mientras que COBITestá enfocado en la ejecución(¿lo estamos haciendo correctamente, y lo estamos logrando bien?).
+
+4 pasos para demostrar el valor de TI para el negociooPrimero, asegure la alineación entre el negocio y la TIoEntregue resultados comerciales, no proyectos de TIoIdentificar métricas de TI que demuestren el éxito empresarialoComparta la historia del impacto de TIMary Pratt, CIO.com, 2022
+
+6 steps to measure the business value of ITo1. Analysis of business goals and businessenvironmento2. Analysis of stakeholderso3. Modeling the business capabilitieso4. Model the business-IT relationshipso5. Measure the value propositiono6. Planning the communicationWolfgang Herrmann CIO.de, 2023
+
+Análisis de Valor
+
+Análisis de Valor
+
+Entrega de Valor

--- a/src/data/lessonSummaries/text/ggo-tema-3.txt
+++ b/src/data/lessonSummaries/text/ggo-tema-3.txt
@@ -1,0 +1,101 @@
+Alineación de negocio y SI/TILlanos CuencaAndrés Boza
+
+Introducción§La estrategia del negocio se va concretando creándose así una infraestructura del negocio Estrategiade negocio
+Infraestructurade negocio
+
+Introducción§La estrategia de SI/TI igualmente se concreta creándose una infraestructura de SI/TIEstrategiade negocioEstrategia de SI/TI
+Infraestructurade SI/TIInfraestructurade negocio
+
+Introducción§Surge la necesidad de alinear el negocio con SI/TI
+Estrategiade negocioEstrategia de SI/TI
+Infraestructurade SI/TIInfraestructurade negocio
+
+Alineación entre negocio y SI/TIEl riesgode incorporar los sistemas y tecnología de informaciónen las organizaciones se ha incrementado, debido principalmente, a que la planificación estratégica de esta no existe. La influencia de SI/TIes determinanteya que puede dar un valor añadido a servicios, productos y competencia, cambiando la manera en como se llevan a cabo los negocios
+Es importante por tanto:-Determinar la estrategia de SI/TI, y-Que esté de acuerdo con la estrategia de negocio
+
+Alineación entre negocio y SI/TIEl problema de poner de acuerdo la estrategia de SI/TI con la estrategia de negocio, se aborda desde dos perspectivas:
+DescripciónPlanificación estratégica de SI/TIHace referencia a cómo incorporar la TI en las organizaciones.
+AlineaciónGrado en el cual la estrategia de SI/TI soporta y es soportadapor la estrategia de negocio, mediante un proceso dinámico, en el cual los cambios en alguno de los elementos del proceso implican cambios en algún otro componente
+
+Modelo de alineamiento estratégico§El Modelo de alineamiento estratégico (SAM-StrategicAlignmentModel)  de Henderson y Venkatramandescribe las relaciones entre la estrategia de la organización y la de SI/TI. §Distingue 4 perspectivas:oEjecución estratégicaoTransformación tecnológicaoPotencial competitivooNivel de servicio
+
+Nota: Similar a la planificación estratégica de SI/TI
+Modelo de alineamiento estratégico
+
+Modelo de alineamiento estratégico
+
+Modelo de alineamiento estratégico
+
+Modelo de alineamiento estratégico
+
+Alcancede negocio
+Gobiernode negocioCompetencias
+Infraestructuraadministrativa
+ProcesosHabilidades
+Alcancede tecnología
+CompetenciasGobierno
+Arquitectura
+ProcesosHabilidades
+Estrategia de negocioEstrategia de TI
+Infraestructura organizacional y procesosInfraestructura de TI y procesos
+Ajuste estratégico
+Integración funcionalTecnología de informaciónNegocio
+ExternoInterno
+(Henderson y  Venkatraman., 1993)
+Modelo de alineamiento estratégico
+
+Herramientas definición estrategia§Las organizaciones utilizan múltiples herramientas para la definición de su estratégica de negocio.
+oAnálisis DAFOoAnálisis PESTELoFuerzas de Portero…
+Estrategiade negocio
+
+Herramientas definición estrategia§Las organizaciones utilizan múltiples herramientas para la definición de su estratégica de negocio.
+oAnálisis DAFOoAnálisis PESTELoFuerzas de Portero… »Pueden ser utilizadas para la estrategia de SI/TI
+Estrategiade negocio
+Estrategia de SI/TI
+
+Proceso dirección estratégica
+Identificar amenazas y oportunidadesAnalizar el entorno
+Analizar los recursos internosIdentificar fortalezas y debilidades
+Establecer misión, objetivosFormular EstrategiaImplementar EstrategiaEvaluar y controlar los resultados
+Stakeholders
+
+Misión y Visión
+§Misión:oLa declaración de misión trata creencias fundamentales e identifica mercados objetivos y productos fundamentales.oEs la razón de la existencia de la empresa.§Visión:oDefine los objetivosa medio y largo plazo (de 3 a 10 años). Debe orientarse al mercado.
+Establecer misión, objetivos
+
+Proceso dirección estratégica
+Identificar Amenazas y OportunidadesAnalizar el entorno
+Analizar los recursos internosIdentificar Fortalezas y Debilidades
+Establecer misión, objetivosFormular EstrategiaImplementar EstrategiaEvaluar y controlar los resultados
+Stakeholders
+
+Análisis DAFO
+Identificar Amenazas y OportunidadesAnalizar el entorno
+Analizar los recursos internosIdentificar Fortalezas y Debilidades
+Análisis DAFO
+
+Análisis DAFO§Análisis DAFO (SWOT -Strengths, Weaknesses, Opportunities, Threats)
+
+Proceso dirección estratégica
+Identificar amenazas y oportunidadesAnalizar el entorno
+Analizar los recursos internosIdentificar fortalezas y debilidades
+Establecer misión, objetivosFormular EstrategiaImplementar EstrategiaEvaluar y controlar los resultados
+Stakeholders
+Análisis 5 fuerzas de Porter
+
+5 Fuerzas de PorterAnálisis 5 fuerzas de Porter
+
+5 Fuerzas de Porter
+§Las fuerzas competitivas según M.Porter:1. El poder negociador de los proveedores2. El poder negociador de los clientes3. La entrada de nuevas empresas4. La aparición de productos sustitutivos5. El posicionamiento de los competidores
+Análisis 5 fuerzas de Porter
+
+Proceso dirección estratégica
+Identificar amenazas y oportunidadesAnalizar el entorno
+Analizar los recursos internosIdentificar fortalezas y debilidades
+Establecer misión, objetivosFormular EstrategiaImplementar EstrategiaEvaluar y controlar los resultados
+Stakeholders
+Análisis 5 fuerzas de Porter
+
+Recordad que laalineación entre negocio y SI/TIPermite:-Determinar la estrategia de SI/TI, y-Que esté de acuerdo con la estrategia de negocio
+
+Alineación de negocio y SI/TILlanos CuencaAndrés Boza

--- a/src/data/lessonSummaries/text/index.ts
+++ b/src/data/lessonSummaries/text/index.ts
@@ -1,0 +1,53 @@
+import admeavSlideT0 from './admeav-slide-t0.txt?raw';
+import admeavSlideT1 from './admeav-slide-t1.txt?raw';
+import admeavSlideT2 from './admeav-slide-t2.txt?raw';
+import dbdPresentacion from './dbd-presentacion.txt?raw';
+import dbdTema1 from './dbd-tema-1.txt?raw';
+import dbdTema2 from './dbd-tema-2.txt?raw';
+import ggoTema1 from './ggo-tema-1.txt?raw';
+import ggoTema2 from './ggo-tema-2.txt?raw';
+import ggoTema3 from './ggo-tema-3.txt?raw';
+import sadSession0 from './sad-session-0.txt?raw';
+import sadSession1 from './sad-session-1.txt?raw';
+import sadSession2 from './sad-session-2.txt?raw';
+import sadSession3 from './sad-session-3.txt?raw';
+import snlpChapter1 from './snlp-chapter-1.txt?raw';
+import snlpChapter2 from './snlp-chapter-2.txt?raw';
+import snlpChapter3 from './snlp-chapter-3.txt?raw';
+import snlpChapter4 from './snlp-chapter-4.txt?raw';
+import snlpChapter5 from './snlp-chapter-5.txt?raw';
+import snlpChapter6 from './snlp-chapter-6.txt?raw';
+
+export const lessonSummaryText: Record<string, string> = {
+  'admeav-slide-t0': admeavSlideT0,
+  'admeav-slide-t1': admeavSlideT1,
+  'admeav-slide-t2': admeavSlideT2,
+  'dbd-presentacion': dbdPresentacion,
+  'dbd-tema-1': dbdTema1,
+  'dbd-tema-2': dbdTema2,
+  'ggo-tema-1': ggoTema1,
+  'ggo-tema-2': ggoTema2,
+  'ggo-tema-3': ggoTema3,
+  'sad-session-0': sadSession0,
+  'sad-session-1': sadSession1,
+  'sad-session-2': sadSession2,
+  'sad-session-3': sadSession3,
+  'snlp-chapter-1': snlpChapter1,
+  'snlp-chapter-2': snlpChapter2,
+  'snlp-chapter-3': snlpChapter3,
+  'snlp-chapter-4': snlpChapter4,
+  'snlp-chapter-5': snlpChapter5,
+  'snlp-chapter-6': snlpChapter6,
+};
+
+export const englishLessonIds = new Set<string>([
+  'admeav-slide-t0',
+  'admeav-slide-t1',
+  'admeav-slide-t2',
+  'snlp-chapter-1',
+  'snlp-chapter-2',
+  'snlp-chapter-3',
+  'snlp-chapter-4',
+  'snlp-chapter-5',
+  'snlp-chapter-6',
+]);

--- a/src/data/lessonSummaries/text/sad-session-0.txt
+++ b/src/data/lessonSummaries/text/sad-session-0.txt
@@ -1,0 +1,61 @@
+Serviciosy AplicacionesDistribuidasMUIINF –ETSINF -UPV
+
+ContactJosé M.  Bernabéu Aubánbernabeu@upv.es
+Tutorías bajo demanda
+
+E.g., Security, resource optimization, application development
+Course Objectives•Understand main concepts of distributed systems•Identify approaches to design distributed services•Develop awareness of main challenges•Develop practical skills with hands on labs
+
+25% 25%
+25%
+GradingTheory Exam
+Lab Project
+Seminars/Lab Exam
+Seminar quizes
+
+In-classroomOn-lineAll TuesdaysLast class: December 16Mixed theory/Seminars
+Fridays:Last session: December 16Mixed Seminars/Labs/Tests
+Calendar & Classes4.5 credit Theory/Seminars1.5 credits Labs
+Flexible hours in classroom (Tuesdays)
+Exams: December 19, during class (remote). Poliformat
+
+SyllabusPreliminary
+
+Topics
+Architectures…, CoordinationSLA, QoS, Cloud
+Approaches, ConceptsNATS, Prometheus, STEP, APISIX, Docker
+01
+03
+02
+04
+Foundations
+Security
+Deployment
+Technologies
+
+Labs
+
+•Simple illustrative service•Integrate some software pieces •Queues•Inverse proxy•Authenticator•Development  
+Design, Implement, Deploy
+•Groups of 3•Typescript/ Golang•Use git•Hand in complete repo in tgzformat
+What How
+
+ImplementationProject development
+Packaging for deploymentEditing
+TechnologiesTypescript/Golang
+Docker
+Git
+VSCode
+
+QUIZ
+
+-Otros-…
+-Nivel
+-Requeridopara Desarrollo y entrega -Aconsejablepara desarrollo
+-Full time?
+-Nivel
+QuienesInformática
+Typescript
+Trabajo
+Git Linux
+Golang

--- a/src/data/lessonSummaries/text/sad-session-1.txt
+++ b/src/data/lessonSummaries/text/sad-session-1.txt
@@ -1,0 +1,94 @@
+Introduction: from Monoliths to Distributed SystemsServicios y Aplicaciones Distribuidas
+
+Welcome and Objectives•Set expecta)ons and outcomes for the course.•Understand monoliths: strengths, weaknesses, and limits.•Recognize mo)va)ons for distributed architectures.•Preview the course structure and prac)cal focus.
+
+What Is a Monolith?
+•Single deployable applica)on containing UI, business logic, and data access.•All parts share the same run)me and are released together.•Op)mized for simplicity and speed in early product stages.
+
+Monolith Deployment Model
+•All-or-nothing deployments: even small changes ship the whole app.•Build, test, and release pipelines handle one artifact.•Acceptable with compact teams and limited feature sets; problematic at scale.
+
+Why Monoliths Work Early
+•Rapid iteration: one repo, one CI/CD pipeline, one artifact.•Simple onboarding and local development close to production.•End-to-end tests run in a single environment.
+
+Modular Monoliths
+•Well-deﬁned internal modules with clear interfaces.•Single compila)on and deployment unit for opera)onal simplicity.•Good stepping stone toward future extrac)ons.
+
+Stress Signals in Monoliths
+•Eroding module boundaries and increasing merge conﬂicts.•Longer builds and slower feedback loops.•Coordina)on boQlenecks: unrelated changes delay releases.
+
+Regression Testing Burden
+•Small features trigger broad regression testing.•Risk of breaking unrelated areas slows release cadence.•Bundled, infrequent releases increase failure blast radius.
+
+Single Artifact Operational Risk
+•Incidents force rollbacks that revert unrelated features.•Tight coupling across domains raises deployment risk.•Discourages continuous delivery practices.
+
+When Monoliths Still Fit
+•Small teams and constrained domains.•Low traﬃc or internal tools with modest SLAs.•Prototypes or short-lived products.
+
+Transition Triggers•Sustained traﬃc growth and performance hotspots.•Need for independent release cadence per domain.•Rising incident frequency )ed to deployment coupling.•Long lead )mes and coordina)on overhead.
+
+Distributed System: Definition
+•Independent computers collaborate over a network.•Present a single coherent system to users.•Coordinate to share resources and tolerate partial failures.
+
+Core Properties•Concurrency and parallelism for throughput.•Fault tolerance via replication and graceful degradation.•Scalability through vertical and horizontal strategies.•Transparency to hide distribution details from users.
+
+Transparency in Practice
+•Users should not care which node handled the request.•Loca)on, replica)on, and failure handling are invisible.•Achieved with load balancers, caches, smart clients.
+
+Resource Sharing & Elasticity
+•Pool compute, storage, and bandwidth across nodes.•Cloud plaWorms enable elas)c scaling up and down.•Op)mize cost/performance by matching capacity to load.
+
+Concurrency vs Parallelism
+•Concurrency: multiple tasks progress at once (interleaving).•Parallelism: tasks execute simultaneously on different cores/nodes.•Introduce coordination: locks, optimistic control, idempotency.
+
+Fault-Tolerance Mindset
+•Design for failure: assume components will fail.•Techniques: retries with backoff, circuit breakers, timeouts.•Graceful degradation and redundancy to keep service usable.
+
+Scalability Basics
+•Ver)cal scaling: add CPU/RAM to a single node.•Horizontal scaling: add more nodes/instances.•Horizontal favored for resilience and elas)city; requires statelessness.
+
+The Network Tax
+•Distributed calls incur latency and serializa)on overhead.•Poten)al for packet loss and retries.•Mi)gate with batching, eﬃcient protocols, and careful API design.
+
+Consistency Realities
+•Replicated state causes conflicts and stale reads.•Eventual consistency is common for availability and speed.•User experience patterns: versioning, conflict resolution, read-your-writes.
+
+Security Surface Area
+•More services and endpoints increase attack surface.•Strong authN/authZ, transport security, and secret management are mandatory.•Adopt zero-trust networking principles.
+
+Operational Complexity
+•Requires mature CI/CD, automated tes)ng, and IaC.•Health checks, metrics, logs, and tracing for observability.•On-call readiness and incident response playbooks.
+
+Driver: Independent Releases
+•Teams ship without wai)ng on unrelated components.•Service boundaries map to business domains.•Reduces coordina)on overhead and accelerates delivery.
+
+Driver: Targeted Scaling
+•Scale hotspots (e.g., checkout) independently of cold paths (e.g., admin).•Aligns cost with actual demand.•Avoids scaling the entire system unnecessarily.
+
+Example Domain Split
+•Orders, Payments, Products, Users, Notifications as separate domains.•Each owns its storage, APIs, and scaling policies.•Technology aligns with business boundaries.
+
+Migration Path
+•Start from modular monolith and iden)fy seams.•Extract the most independent or painful domains ﬁrst.•Establish plaWorm capabili)es: gateway, discovery, observability.
+
+Trade-Offs to Acknowledge
+•Agility and resilience vs added latency and coordina)on.•Opera)onal costs rise with more moving parts.•Architecture is economics: pay costs to unlock beneﬁts.
+
+Key Takeaways (1)
+•Monoliths are pragmatic and effective early on.•They become a liability with growth and coordination bottlenecks.•Recognize stress signals and plan ahead.
+
+Key Takeaways (2)
+•Distributed systems enable independence and scaling.•They introduce latency, consistency, security, and operational challenges.•Discipline and tooling are essential to succeed.
+
+Common Misconceptions
+•“Microservices are faster” — network overhead is real.•“Use many languages” — polyglot increases ops and hiring costs.•“More services is beQer” — follow domains and team boundaries.
+
+Looking Ahead
+•Next: deﬁne microservices precisely and contrast with distributed systems.•Discuss organiza)onal and technical implica)ons.•Iden)fy when NOT to adopt microservices.
+
+Discussion
+•Where has a monolith been a bottleneck in your experience?•Which domains would benefit most from independent deployments?
+
+Closing
+•You now have the vocabulary for why distributed systems exist.•Keep trade-offs in mind—they guide the rest of the course.

--- a/src/data/lessonSummaries/text/sad-session-2.txt
+++ b/src/data/lessonSummaries/text/sad-session-2.txt
@@ -1,0 +1,100 @@
+Microservices: Definition, Benefits, and Trade-OffsServicios y Aplicaciones Distribuidas
+
+Context
+•Monolith strengths met growth limits.•Need for team autonomy and independent releases.•Microservices emerged as an organiza:onal & technical response.
+
+What Is a Microservice?
+•Small, independently deployable service.•Owns a narrowly scoped capability / bounded context.•Loosely coupled, highly cohesive; communicates over the network.
+
+Monolith vs Microservices
+•Monolith: one deployable; fewer moving parts.•Microservices: many deployables; higher autonomy.•Trade-off: simplicity vs independent evolution.
+
+Principle: Bounded Context
+•Use domain-driven design (DDD) to define boundaries.•Each service owns a coherent domain capability.•Interfaces between contexts are explicit and stable.
+
+Independent Deployability
+•Each service ships on its own cadence.•Avoid shared databases and shared libraries that force lockstep.•Contracts and backward compa:bility are essen:al.
+
+Organizational Alignment
+•Team structure mirrors system structure.•Service ownership maps to long-lived teams.•Cognitive load must match team capacity.
+
+Microservices vs SOA
+•Smaller units, stricter autonomy than traditional SOA.•Operational culture: DevOps, CI/CD, automation.•Lightweight protocols vs heavy ESB-centric designs.
+
+Communication Styles Overview
+•Synchronous: REST, gRPC; simple request/response.•Asynchronous: events, queues, streams; decoupled timing.•Hybrid patterns blend both.
+
+Synchronous Comms: REST
+•Human-friendly, widely supported, cacheable over HTTP .•Great for CRUD and resource-centric APIs.•Beware mul:-hop latency and cascading failures.
+
+Synchronous Comms: gRPC
+•Contract-first with protobuf; strong typing and speed.•Bi-directional streaming, efficient binary transport.•Couples clients to schemas—manage versioning carefully.
+
+Asynchrony: Messaging & Events
+•Queues (task distribution) and topics (pub/sub).•Decouples producers and consumers; smooths traffic spikes.•Requires idempotency and explicit ordering choices.
+
+Data Ownership: per Service?
+•Each service owns its schema and storage.•Avoid shared databases that create hidden coupling.•Integrate via APIs/events, not cross-service SQL.
+
+Consistency & CQRS Basics
+•Accept eventual consistency between services.•CQRS separates writes (commands) and reads (queries).•Projec:ons/read models serve low-latency queries.
+
+Sagas & Distributed Transactions
+•Long-lived workflows coordinated via messages.•Compensating actions instead of global 2-phase commit.•Orchestration vs choreography styles.
+
+API Gateways
+•Single entry point for external clients.•Cross-cutting concerns: authN/Z, rate limiting, TLS.•Request shaping: routing, aggregation, protocol translation.
+
+Service Discovery
+•Dynamic environments require discovery.•Registries or DNS + health checks.•Config and secrets management are foundational.
+
+Observability in Microservices
+•Three pillars: logs, metrics, traces.•Correlate requests across services (trace IDs).•SLOs and error budgets guide priori:es.
+
+Testing Strategies
+•Contract tests to protect APIs between teams.•Pyramid: unit ≫ component/integration ≫ end-to-end.•Test data and environments must be automatable.
+
+CI/CD per Service
+•Pipeline per service with clear promotion stages.•Canary and blue-green deployments reduce risk.•Automate rollbacks; keep artifacts immutable.
+
+Security Fundamentals
+•Zero-trust: authenticate and authorize every request.•mTLS for service-to-service encryption.•Secret management and least privilege.
+
+Service Mesh (Brief Overview)
+•Oﬄoad retries, :meouts, and mTLS.•Uniform telemetry and policy enforcement.•Beware added complexity—adopt when ready.
+
+Containers & Orchestration
+•Containers package runtime; orchestration manages fleet.•Kubernetes: scheduling, scaling, self-healing.•Declarative manifests and controllers.
+
+Platform 
+•Platform team provides paved roads (golden paths).•Templates, scaffolding, and guardrails reduce toil.•Self-service + sensible defaults speed teams.
+
+Costs & Trade-Offs
+•Operational overhead: more services, more things to run.•Latency and partial failures are everyday realities.•People costs: skills, on-call, coordination.
+
+Common Anti-Patterns
+•Nanoservices: spli^ng too far, cha_y networks.•Shared database across 'services' (hidden coupling).•Logic in the gateway/ESB recrea:ng a central bo_leneck.
+
+When NOT to Use Microservices
+•Small team, simple domain, low scale.•Unclear boundaries or volatile requirements.•Lack of platform/observability maturity.
+
+Migration Strategies: Strangler
+•Wrap the monolith; route new capabilities to services.•Gradually replace parts behind stable interfaces.•Continuously measure progress and outcomes.
+
+Migration: Domain Extraction
+•Identify seams via DDD context maps and change cadence.•Extract independent or painful domains first.•Establish contract and data ownership before cutover.
+
+Case Study: E-Commerce Split
+•Orders, Payments, Catalog, Users, No:ﬁca:ons.•Independent scaling and release cadences.•Clear contracts and resilience pa_erns.
+
+Case Study: Lessons Learned
+•Invest early in observability and platform tooling.•Keep boundaries aligned to business outcomes.•Resist premature decomposition and tech sprawl.
+
+Discussion Prompts
+•Which domains in your system change most frequently?•Where are teams blocked by centralized releases?•What platform gaps would slow a microservices migration?
+
+Key Takeaways
+•Microservices trade simplicity for autonomy and speed.•Bounded contexts and independent deployability are non-negotiable.•Success requires platform maturity and discipline.
+
+Closing & Next Session
+•Preview: Communica:on deep-dive (sync vs async).•Hands-on lab setup reminder.•Q&A and reading list.

--- a/src/data/lessonSummaries/text/sad-session-3.txt
+++ b/src/data/lessonSummaries/text/sad-session-3.txt
@@ -1,0 +1,99 @@
+Cloud Deployment and Service ModelsServicios y Aplicaciones Distribuidas
+
+Cloud Computing Recap
+•Shared pool of compute, storage, networking on demand.•On-demand self-service, broad access, elasticity.•Measured service: pay for what you use.
+
+Why Service Models Matter
+•They define the abstraction level you consume.•Control vs convenience trade-off changes per model.•Impacts agility, cost, and who is responsible for what.
+
+IaaS: Definition & Scope
+•Virtualized compute, storage, networking primitives.•You manage OS, runtime, middleware, data, apps.•Examples: EC2, Azure VMs, Google Compute Engine.
+
+IaaS: Benefits and Challenges
+•Benefits: flexibility, compatibility, fine-grained control.•Challenges: patching, capacity planning, more ops toil.•Mitigation: golden images, IaC, autoscaling groups.
+
+PaaS: Definition & Scope
+•Deploy code; platform manages runtime, scaling, and OS.•Opinionated buildpacks and service bindings.•Examples: Heroku, Azure App Service, AWS Elastic Beanstalk.
+
+PaaS: Benefits and Challenges
+•Benefits: faster delivery, less undifferentiated heavy lifting.•Challenges: platform constraints, vendor features vary.•Mitigation: 12-factor practices, clear SLOs, platform guardrails.
+
+SaaS: Definition & Scope
+•Complete application delivered as a service.•Provider manages everything; you configure and consume.•Examples: Gmail, Salesforce, GitHub, Slack.
+
+SaaS: Benefits and Challenges
+•Benefits: fastest time to value, minimal ops burden.•Challenges: customization limits, data/control constraints.•Mitigation: evaluate APIs, export paths, compliance posture.
+
+IaaS vs PaaS vs SaaS (Responsibilities)•IaaS: you manage OS → app; provider manages hardware.•PaaS: you manage code & data; provider manages runtime & OS.•SaaS: you manage config & users; provider runs the app.
+
+Choosing the Right Model
+•Drivers: time-to-market, control needs, compliance, skills.•Workload traits: variability, latency needs, statefulness.•Evolve per service—mixed models across a portfolio.
+
+Cloud Providers Overview
+•Major hyperscalers: AWS, Azure, Google Cloud.•All offer IaaS/PaaS/SaaS building blocks.•Differ in strengths, ecosystem, and pricing models.
+
+AWS: Strengths & Focus Areas
+•Breadth/depth of services; rich ecosystem.•Mature IaaS (EC2, VPC), serverless (Lambda), data (S3).•Marketplace, partners, and global footprint.
+
+Azure: Strengths & Focus Areas
+•Enterprise integration with Microsoft stack.•Hybrid tooling (Azure Arc), strong identity (Entra ID/AAD).•Windows/.NET first-class, growing Linux/K8s support.
+
+Google Cloud: Strengths & Focus Areas
+•Data, analytics, and ML leadership (BigQuery, Vertex AI).•Innovations in containers and SRE practices.•High-performance networking.
+
+Multi-Cloud and Portability
+•Reasons: resilience, data locality, negotiation leverage.•Costs: duplicated ops, lowest-common-denominator designs.•Pragmatic approach: portable apps; non-portable data/analytics.
+
+Public Cloud: Definition & Benefits
+•Shared infrastructure operated by a provider.•Elasticity, global reach, rapid innovation.•Lower upfront capex; pay-as-you-go.
+
+Public Cloud: Risks & Trade-Offs
+•Shared tenancy and noisy-neighbor effects.•Potential egress and premium managed-service costs.•Compliance and data residency constraints.
+
+Private Cloud: Definition & Benefits
+•Dedicated infrastructure for one organization.•Control, customization, and data locality.•Predictable performance and governance.
+
+Private Cloud: Risks & Trade-Offs
+•Higher capex and ops burden vs public cloud.•Slower access to new managed services.•Risk of under/over-provisioning capacity.
+
+Hybrid Cloud: Definition & Benefits
+•Combine public and private across one architecture.•Burst capacity and place workloads where they fit.•Data gravity respected; latency-sensitive parts stay close.
+
+Hybrid Cloud: Risks & Trade-Offs
+•Complex networking, identity, and policy management.•Operational duplication across environments.•Hidden latency and failure modes across links.
+
+Community Cloud (Brief)
+•Shared by organizations with common concerns.•Often compliance-driven (sector-specific).•Niche, but relevant in regulated domains.
+
+Use Case: Web Applications
+•Stateless tiers fit PaaS/serverless; databases managed.•CDN, WAF, and auto-scaling patterns are common.•Blue-green/canary releases reduce risk.
+
+Use Case: Big Data & Analytics
+•Object storage as data lake; serverless query engines.•Batch and streaming pipelines (managed services).•Governance: catalogs, lineage, access controls.
+
+Use Case: AI/ML Workloads
+•Managed notebooks, training, and inference endpoints.•Access to accelerators (GPUs/TPUs) on demand.•Feature stores and MLOps pipelines.
+
+Use Case: Backup & DR
+•Cross-region replication and immutable backups.•Tiered storage classes to optimize cost.•Test restores and document RTO/RPO.
+
+Cloud Cost Models
+•On-demand, reserved/committed use, and spot/preemptible.•Per-request/serverless pricing vs provisioned capacity.•Data egress and managed service premiums matter.
+
+FinOps Basics
+•Visibility: tagging, allocation, showback/chargeback.•Optimization: rightsizing, autoscaling, schedules.•Governance: budgets, alerts, guardrails.
+
+Shared Responsibility Model
+•Provider secures the cloud; you secure what you run.•Responsibility shifts by service model (IaaS→SaaS).•Document controls: identity, network, data, app.
+
+Compliance & Data Residency
+•Regions and availability zones influence data location.•Certifications (ISO, SOC) ≠ compliance out-of-the-box.•Design for audits: logging, retention, access reviews.
+
+Vendor Lock-In & Portability
+•Managed services speed delivery but deepen coupling.•Containers and open standards improve portability.•Make exit plans: backups, data export formats.
+
+Key Takeaways
+•Pick the right abstraction per workload (IaaS/PaaS/SaaS).•Public, private, and hybrid each trade control vs agility.•Governance, cost, and security must be intentional.
+
+Closing & Next Session
+•Next: Synchronous vs Asynchronous Communication.•Prepare: API examples, messaging fundamentals.•Q&A and reading list.

--- a/src/data/lessonSummaries/text/snlp-chapter-1.txt
+++ b/src/data/lessonSummaries/text/snlp-chapter-1.txt
@@ -1,0 +1,99 @@
+CHAPTER 1
+Introduction to Signals and 
+Natural Language Processing 
+with DL
+
+Revised Approach to Official Syllabus
+The oficial syllabus is a list of contents, the order of topic study may not 
+follow the listed order in the official program, as we'll adapt to best 
+support your learning.
+Be prepared for a dynamic and application-driven approach to NLP and 
+a more practical, hands-on learning experience.
+Bring your laptop to classroom and try continuously.
+
+Key Changes and Principles
+1. Flexibility: 
+1. Official syllabus serves as a guideline 
+2. Content and order may be adjusted for improved pedagogy 
+2. Non-chronological Official Program: 
+1. The official program lists content topics, not a strict chronological order 
+2. Topics will be covered in an order that best supports practical learning 
+3. Coordination with Other Courses: 
+1. LSTM section streamlined (leveraging prior knowledge from “IA image” course) 
+2. Focus on application rather than re-explanation 
+4. Practical Focus: 
+1. Emphasis on hands-on, applied learning 
+2. Earlier introduction of practical applications 
+5. Dynamic Progression: 
+1. Course will advance alongside practical applications 
+2. Order of topics may be altered to facilitate this approach 
+6. Learning Objectives: 
+1. Prioritize practical, applicable skills in NLP 
+2. Ensure students can implement and use NLP techniques effectively
+
+Signals to handle
+SPEECH
+MUSIC
+OTHER SOUNDS
+nature / industry
+TEXT 
+LLM
+
+Signals Processing
+• Sound and Audio Signals
+How to process and analyze various types of audio signals, including environmental 
+sounds, complex audio scenes, industrial signals. Techniques to extract meaningful 
+features from raw audio data, enabling machines to understand and classify different 
+sound types.
+• Speech Processing and Recognition
+Delve into the specifics of speech signal processing, focusing on the extraction of 
+features. Understand how to build and train deep learning models for automatic 
+speech recognition (ASR) to convert spoken language into written text and explore 
+applications like voice-controlled systems and transcription services.
+• Music Analysis & Synthesis
+Discover how deep learning can be used for music genre classification, beat tracking, 
+and music recommendation systems. This involves feature extraction techniques that 
+capture the rhythm, harmony, and timbre of music. Also, music generation.
+
+Natural Language Processing 
+Processing Language
+Explore the processing of written language starting from its most basic representation: 
+ASCII text. Understand the challenges of converting raw text into numerical formats that 
+can be fed into neural networks. Techniques such as tokenization, embedding (e.g., 
+Word2Vec), and sequence modeling with Recurrent Neural Networks (RNNs) and 
+Transformers will be covered.
+Language Understanding and Generation:
+Learn how to apply deep learning models to tasks like sentiment analysis, machine 
+translation, and text generation. This includes understanding the syntactic and semantic 
+aspects of language and building models that can understand and generate coherent 
+text.
+
+Applications for Sound Signals
+• Speech to text (Speech recognition)
+• Singing voice detection
+• Spoken Language Identification
+• Speaker Identification (Voice Biometrics)
+• Speech emotion recognition (Sentiment Analysis in Speech)
+• Speech Enhancement (Noise & Interference removal)
+• Musical gender classification
+• Music recommendation
+• Song recognition ( 1. exactly the same recording  2. other version/cover)
+• Querying by humming
+• Sound to score or MIDI
+• Song key recognition
+• Text to speech (Speech synthesis)
+• Speech imitation (Voice cloning)
+• Music Synthesis (based on ML)
+
+Applications in Language Processing
+• Language identification
+• Extract important information
+• Mood
+• Summarization
+• Improvement of writing style
+• Grammar mistake detection and correction 
+• Translation
+• Word prediction / sentence completion
+• Computer coding completion
+• Topic classification
+• LLM

--- a/src/data/lessonSummaries/text/snlp-chapter-2.txt
+++ b/src/data/lessonSummaries/text/snlp-chapter-2.txt
@@ -1,0 +1,190 @@
+CHAPTER 2
+Features Extraction
+
+What is Feature Extraction in audio signals ?
+Definition:
+Feature extraction is the process of transforming raw audio signals into a set 
+of informative and compact representations (features) that can be used as 
+input to a machine learning model.
+Purpose:
+It involves selecting and computing features that capture the essential 
+characteristics of the sound or speech signal, reducing the complexity of the 
+data while preserving important information.
+
+Common Features
+Spectrograms:
+Visual representations of the spectrum of frequencies in a signal as it varies over time.
+Mel-Frequency Cepstral Coefficients (MFCCs):
+Features that represent the short-term power spectrum of a sound, often used in speech 
+and audio processing.
+Chroma Features:
+Capture the 12 different pitch classes and are useful in music analysis.
+Zero-Crossing Rate:
+The rate at which the signal changes sign, indicating the noisiness or percussiveness of a 
+signal.
+Pitch and Formants:
+Fundamental frequency and resonant frequencies in speech analysis.
+
+Why is Feature Extraction Necessary?  (i)
+Dimensionality Reduction:
+Raw audio signals are high-dimensional and can be noisy. Feature 
+extraction reduces the dimensionality, making it computationally feasible to 
+process the data.
+Improving Model Performance:
+By extracting relevant features, models can learn more efficiently and 
+accurately, focusing on the aspects of the signal that are most important for 
+the task.
+Noise Reduction:
+It helps to filter out irrelevant or redundant information, enhancing the 
+signal-to-noise ratio, which is crucial for tasks like speech recognition.
+
+Why is Feature Extraction Necessary?  (ii)
+Capturing Important Characteristics:
+Different features capture different properties of the sound, such as 
+frequency content, temporal structure, and timbre, which are important for 
+distinguishing between different types of sounds or speech patterns.
+Facilitating Learning:
+Extracted features provide a more structured and meaningful representation 
+of the data, which can help deep learning models converge faster and 
+achieve better generalization.
+Domain-Specific Insights:
+In speech processing, certain features like MFCCs are known to be effective 
+in capturing the properties of human speech, aiding in tasks like speaker 
+recognition and emotion detection.
+
+LIBROSA Library
+
+LIBROSA Library
+• It is a library with audio functions and tools
+• It is available for many languages ​​including Python
+• Among it, we have spectrogram, MEL & MFCC calculation functions
+• It also has functions for plotting spectrograms
+• Example of use:
+• https://librosa.org/doc/main/auto_examples/plot_display.html
+
+Spectrogram
+• The audio signal is divided into overlapping segments 
+called "windows".
+• Each segment is transformed from the time domain to 
+the frequency domain using the Fourier Transform.
+• This process results in a series of frequency spectra.
+• These spectra are then arranged sequentially to form a 
+time-frequency representation.
+• The amplitude of each frequency component is 
+typically displayed as a color intensity or grayscale 
+value.
+
+Spectrogram
+• A spectrogram provides a comprehensive view of how the frequency content of a 
+signal changes over time.
+• This allows for detailed analysis of how different frequencies evolve, which is 
+crucial for understanding complex audio signals like speech and music.
+• It helps in identifying transient events (e.g., sudden noises) and patterns (e.g., 
+musical notes, speech phonemes) that occur at specific times.
+• It separates the time-domain and frequency-domain aspects of the signal, 
+providing a clearer understanding of how different frequencies contribute to the 
+overall signal over time.
+
+Spectrogram
+
+Problem with RAW spectrogram in AI
+• Traditional spectrograms use a linear frequency scale, which can be too detailed 
+in the high-frequency range where human hearing is less sensitive.
+• This results in an uneven representation of frequencies, with too much detail in 
+frequencies that are less perceptually relevant.
+• Raw spectrograms can include noise and less relevant frequency information, 
+which can negatively impact the performance of machine learning models.
+• A Raw spectrogram includes almost the same samples that a PCM signal, so the 
+number of input parameters to a NN is not reduced. 
+• We are looking for a Dimensionality Reduction as an input of the NN.
+
+MEL Scale
+
+MEL Scale advantages
+• Mel-spectrograms help to focus on features that are important for perception and 
+recognition tasks.
+• By using a perceptual scale, Mel-spectrograms provide features that are more robust and 
+informative for tasks like speech recognition and music classification.
+• Models trained on raw spectrograms may struggle with generalization and are not 
+consistently relevant across different audio conditions or environments.
+• Mel-spectrograms can improve generalization by providing a representation that aligns 
+more closely with human auditory processing. This can lead to better performance and 
+robustness in machine learning models.
+• In summary
+• Align more closely with human auditory perception.
+• Reduce dimensionality and computational complexity.
+• Capture perceptually relevant features while discarding less useful high-frequency details.
+
+MEL Spectrogram
+
+MEL Spectrogram in Librosa
+• Documentation
+• https://librosa.org/doc/main/generated/librosa.filters.mel.html#libro
+sa.filters.mel
+• How to call the function
+• mel_spec = librosa.feature.melspectrogram(y=audio, 
+sr=sr, n_mels=NMELS)
+
+MEL Cepstrum (MFCC)
+• MEL Cepstrum Parameters (MFCCs) are an alternative to MEL bands
+• They provide a compact representation of the audio signal's power spectrum by applying a series of 
+transformations.
+• These coefficients can be thought of as capturing the "envelope" of the log MEL spectra.
+• They represent the main components of the spectral content in a lower-dimensional space (Dim. Reduction)
+• Computation:
+• The logarithm of the MEL parameters is taken to compress the dynamic range and emphasize variations.
+• The Discrete Cosine Transform (DCT) is applied to the log Mel spectra to obtain the MFCCs.
+• Normally, only the 10 to 15 first MFCC parameters are keep as an input for NN  (HF are discarded)
+• The DCT decorrelates the features and compresses the information into a set of coefficients.
+• MFCCs are generally more robust to variations in recording conditions and background noise compared to MEL.
+• Very use full in speech recognition, but also used for general audio purposes
+
+MEL Cepstrum (MFCC)
+• Tutorial
+• https://haythamfayek.com/2016/04/21/speech-processing-for-machine-learning.html
+• How to call the function
+• mfcc = librosa.feature.mfcc(y=signal, 
+sr=sample_rate, n_mfcc=num_mfcc, n_fft=n_fft)
+
+Espectrograma MFCC
+MEL
+MFCC
+First 13 param.
+
+Other features
+• Zero Crossing Rate
+• the rate at which the signal changes from positive to negative or back.
+• Harmonics and Percusive decomposition
+• Harmonics are characteristics that represents the sound color
+• Percusive components represents the sound rhythm and emotion
+• Tempo BMP (beats per minute)
+• Dynamic programming beat tracker.
+• Spectral Centroid
+• indicates where the ”centre of mass” of the spectrum of a sound is located and is calculated as the 
+weighted mean of the frequencies present in the sound.
+• Spectral Contrast
+• measures the difference in amplitude between peaks and valleys in the audio spectrum
+• Spectral Rolloff
+• is a measure of the shape of the signal spectrum. It represents the frequency below which a specified 
+percentage of the total spectral energy, e.g. 85%, lies
+• Chroma Frequencies
+• Interesting and powerful representation for music audio in which the entire spectrum is projected onto 12 
+bins representing the 12 distinct semitones (or chroma) of the musical octave.
+https://www.kaggle.com/code/andradaolteanu/
+work-w-audio-data-visualise-classify-recommend
+
+Applications of feature extraction in Audio
+1. Speech Recognition: Extracting MFCCs and other features for automatic speech 
+recognition systems.
+2. Music Analysis: Analyzing music files to extract features for genre classification, music 
+recommendation, and tempo estimation.
+3. Sound Event Detection: Detecting and classifying sound events in environmental 
+audio, such as identifying bird species in bird songs.
+4. Emotion Recognition: Analyzing speech features for emotion detection and sentiment 
+analysis.
+5. Instrument Recognition: Identifying musical instruments from audio recordings.
+6. Voice Biometrics: Extracting voice features for speaker identification and verification.
+7. Anomaly Detection: Detecting unusual or abnormal sounds in audio streams, such as 
+in industrial settings.
+8. Audio Synthesis: Using extracted features to synthesize new audio content, like 
+generating music or voice.

--- a/src/data/lessonSummaries/text/snlp-chapter-3.txt
+++ b/src/data/lessonSummaries/text/snlp-chapter-3.txt
@@ -1,0 +1,612 @@
+CHAPTER 3
+Development of DNN Models
+with KERAS
+
+What is KERAS?
+• Keras is an open source neural network library written in high-level Python.
+• It is capable of running on top of TensorFlow (and other libraries)
+• It is specifically designed to enable experimentation in a relatively short time with 
+Deep Learning networks.
+• Its strengths are focused on being user-friendly, modular and extensible.
+• Keras contains several implementations of the building blocks of neural networks 
+such as:
+• Layers
+• Activation functions
+• objective functions
+• mathematical optimizers
+
+MultiLayer Perceptrons
+(MLP)
+
+Structure
+
+Structure
+
+Use (i)
+• Import in Python   (example)
+• import tensorflow.keras as kr
+• From here all the functions have this prefix:
+kr.function
+• Instead of
+tensorflow.keras.function
+
+Use (ii)
+• Start a model (layer structure)
+• model = tf.models.Sequential()
+• “model” is the object where the layers will fit
+
+Use (iii)
+• Adding a layer of perceptrons (densely connected)
+• model.add(kr.layers.Dense(n_neurons))
+• Notes:
+• The number of inputs to each neuron will be the number of outputs of the previous layer.
+• If it is the first layer, you must tell it how many inputs it has (parameters).
+• You can doit in two ways (explicit or implicit)
+explicit 
+• model.add(InputLayer(input_shape=(n,))
+• model.add(kr.layers.Dense(n_neurons)
+implicit 
+• model.add(kr.layers.Dense(n_neuronas, input_shape=(n,))
+• If it is the last layer, n_neurons must match the number of classes.
+• model.add(kr.layers.Dense(n_classes)
+
+Use (iv)
+• After addding the layer the activation function must be added
+• model.add(kr.layers.Activation('softmax'))
+• softmax
+• softplus
+• relu
+• selu
+• sigmoid
+• ... 
+• CUSTOM
+
+Use (v)
+• Compact way of adding the layer and the activation function at the 
+same time
+• model.add(kr.layers.Dense(n_neuronas)),activation='softmax')
+
+Use (vi)
+• Example for a network of only one layer (plus the input)
+• Number of parameters = 50
+• Number of classes = 10
+• model.add(kr.layers.Dense(10,input_shape=(50,),activation=‘softmax')
+
+Use (vii)
+• Example (3 layer + input)
+• model.add(kr.layers.Dense(30,input_shape=(20,), activation='relu')
+• model.add(kr.layers.Dense(50, activation='relu’)
+• model.add(kr.layers.Dense(10, activation=‘softmax’)
+• Notes:
+• First layer should inform about the number of inputs
+• Last layer neuron number = number of clases
+• Next layer should be softmax activation
+• In the other layers activation function has more liberty
+
+Use (viii)
+• An optimizator shoul be defined in every network
+• OPTIMIZER=kr.optimizers.Adam(learning_rate=0.0001)
+• Compilation of the network
+• model.compile(loss='categorical_crossentropy', 
+optimizer=OPTIMIZER, metrics=['accuracy'])
+• Training start
+• history = model.fit(X_train, Y_train, batch_size=BATCH_SIZE, 
+epochs=NB_EPOCH, verbose=VERBOSE, validation_data=(X_test, 
+Y_test))
+
+Network evaluation
+• When the network is put into production, the output of an element must be 
+predicted. This is called inference.
+• The WAV file to be predicted is loaded
+• Its parameters are calculated (for example the MEL spectrogram) and stored in the 
+variable X_test
+• The function to predict an element is called
+• Y_pred = model.predict(X_test)   #inference, predices output
+
+Confusion Matrix
+• import seaborn as sns
+•
+from sklearn.metrics import confusion_matrix
+•
+Y_pred = model.predict(X_test)               #predecir (poner la red en producción)
+• Y_pred_classes = np.argmax(Y_pred,axis = 1) # pasa de categorical a one-hot los predichos
+• Y_true = np.argmax(Y_test,axis = 1) # pasa de categorical a one-hot la verdad de base
+•
+confusion_mtx = confusion_matrix(Y_true, Y_pred_classes)
+•
+f,ax = plt.subplots(figsize=(10, 10))
+•
+sns.heatmap(confusion_mtx, annot=True, linewidths=0.01,cmap="Greens",linecolor="gray", fmt= 
+'.1f',ax=ax)
+• plt.xlabel("Predicted Label")
+• plt.ylabel("True Label")
+• plt.title("Confusion Matrix")
+• plt.show()
+
+Hyperparameters
+
+Hiperparámetros (definición)
+• They are parameters external to the model (different from the 
+weights wi)
+• They are not learned directly from the dataset during the training 
+process.
+• Instead, they must be set before starting training and are used to 
+control the global configuration of the model.
+• Hyperparameters are essential for the optimization and fine-tuning of 
+the neural network model.
+
+Hyperparameters (some)
+1. Epochs
+2. Batch size
+3. Lost Function
+4. Optimizer
+5. Learning rate
+6. Regularization
+7. Network Architecture
+8. Features (quantity and type)
+
+1. Epochs
+• An epoch is one complete pass through the training dataset during training.
+• The number of epochs is the number of times the model will see the entire 
+dataset during training.
+• Too many epochs can lead to overfitting, while too few can result in an 
+undertrained model.
+• It is important to experiment with different EPOCHS values ​​during model 
+development to find the optimal number that balances the model's ability to 
+learn and generalize without overfitting.
+• This can be monitored by comparing learning performance using the ACCURACY
+of the training set and the validation set.
+
+2. Batch size
+• Indica el número de ejemplos de entrenamiento utilizados en una 
+iteración antes de actualizar los pesos del modelo.
+• Los modelos se entrenan de manera más eficiente en lotes en lugar 
+de elementos individuales o en lugar de todo el conjunto de test.
+1 < Tamaño del lote < Tamaño del conjunto de datos
+• El tamaño del lote afecta a la velocidad y la estabilidad del 
+entrenamiento.
+• Lote más grande: +rápido entrenam, +estable, +memoria necesaria
+• Lote más pequeño: +generalización (-overfitting)
+
+3. Lost function
+• Es la función que el modelo está tratando de minimizar durante el entrenamiento.
+• También conocida como función objetivo o función de costo
+• La elección de la función de pérdida depende del tipo de problema, como la 
+clasificación o la regresión
+• El objetivo del entrenamiento de una red neuronal es minimizar esta función de 
+pérdida para que el modelo haga predicciones más precisas.
+• Ejemplos:
+• loss = MeanSquaredError()            #la más sencilla y conocida utilizada en procesado de señal
+• loss = BinaryCrossentropy()           #utilizada en problemas de clasificación binaria (2 clases)
+• loss = CategoricalCrossentropy()  #utilizada en problemas de clasificación multiclase
+• loss = SparseCategoricalCrossentropy()   #clasificación por enteros (no se ha hecho categorical)
+
+4. Optimizer
+• Es el algoritmo utilizado para ajustar los pesos del modelo durante el entrenamiento 
+para minimizar la función de pérdida.
+• La elección del optimizador es crucial porque afecta cómo se actualizan los pesos 
+del modelo en cada iteración del proceso de entrenamiento.
+• Descenso de Gradiente Estocástico (SDG)
+• Uno de los optimizadores más simples. Actualiza los pesos en la dirección opuesta al gradiente 
+de la función de pérdida con respecto a los pesos
+• Adam (Adaptive Moment Estimation)
+• Combina el concepto de momento y la adaptación de la tasa de aprendizaje. Es conocido por su 
+eficiencia y es uno de los más utilizados en la práctica
+• RMSprop (Root Mean Square Propagation)
+• Ajusta la tasa de aprendizaje para cada parámetro individualmente basándose en la magnitud de 
+los gradientes
+
+5. Learning rate
+• Es un factor que multiplica la magnitud de las actualizaciones de los pesos durante 
+el entrenamiento en los optimizadores.
+• Una tasa de aprendizaje demasiado baja puede hacer que el modelo converja 
+lentamente o se quede atascado, mientras que una tasa de aprendizaje demasiado 
+alta puede hacer que el modelo oscile o no converja en absoluto.
+• La selección y ajuste adecuado de este hiperparámetro es crucial para lograr un 
+rendimiento óptimo del modelo en una tarea específica.
+• Ejemplo de uso
+• optimizer = SDG(learning_rate=0.001)
+• optimizer = Adam(learning_rate=0.005)
+• optimizer = RMSprop (learning_rate=0.002)
+
+6. Regularization
+• Es un conjunto de técnicas diseñadas para prevenir el sobreajuste (overfitting) y 
+mejorar la generalización del modelo
+• Introduce penalizaciones en la complejidad del modelo para controlar la 
+magnitud de los pesos.
+1. Regularización L1 y L2
+• son términos de penalización en la función de pérdida basados en la magnitud de los pesos. 
+L1 penaliza la suma de los valores absolutos de los pesos, mientras que L2 penaliza la suma 
+de los cuadrados de los pesos.
+• model.add(Dense(64, input_dim=100, activation='relu', 
+kernel_regularizer=l1(0.01)))
+2. Dropout:
+• Durante el entrenamiento, aleatoriamente se "apaga" (pone a cero) una fracción (%) de las 
+neuronas en una capa para evitar que dependan demasiado de ciertas características
+• model.add(Dense(64, input_dim=100, activation='relu'))
+• model.add(Dropout(0.5))
+
+7. Network Architecture
+• La elección de la arquitectura de la red puede tener un impacto 
+significativo en el rendimiento del modelo.
+• Se pueden considerar como hiperparámetros de una red:
+1. Número de Capas
+2. Número de Neuronas en Cada Capa
+3. Funciones de Activación
+4. Conexiones entre Neuronas  (densamente conectadas o conexiones más específicas)
+
+8. Features
+• De las señales que queremos clasificar extraemos una serie de 
+características (especialmente en sonido).
+• En el caso de espectrogramas, podemos consideran como 
+hiperparámetros.
+• El tamaño de ventana temporal
+• El tamaño de la FFT en espectrograma
+• El número de bandas MEL en espectrogramas MEL
+• El número de coeficientes Mel-Cepstrum MFCC
+
+Convolutional Networks for
+Audio
+
+Intro
+• They are used to recognize images
+• Why use them for sound?
+• Because sound is analyzed both in time and in 2D frequency
+• And the spectrogram can be seen as an image (also Mel / MFCC)
+• There are sounds that extend on the time axis
+• There are sounds with a large bandwidth that extend in frequency or leave a 
+harmonic pattern in frequency
+
+2D Filter
+
+RELU Activation Function for Edge detection
+• If the filter is gradient type, negative 
+numbers are removed from the result.
+• Helps to identify the edges of objects
+
+Pooling Layer
+• Reduce the size of the images (therefore the number of 
+parameters/weights to train)
+
+CNN Structure
+• Each filter applied to the image produces a convolution layer.
+• The weights of each filter are the parameters to be optimized.
+
+Flattening
+• It consists of converting 2D data into 1D data to be processed by a 
+network of 1D perceptrons.
+
+Final CNN Structure
+• After flattening we put a densely connected network
+• Finally the last layer is the number of classes
+
+Structure with 2 convolutional layer
+
+Convolution layer in Keras
+• The number of images stacked in each layer is called channels.
+• The number of output channels for each Conv2D layer is controlled by 
+the first argument
+• The next argument is the filter size
+• model.add(kr.layers.Conv2D(64,(3,3),activation='relu’))
+• In this layer therefore we will have 64x3x3 weights to optimize
+
+Example
+• Typically, as the width and height are 
+reduced (by pooling), it can be 
+computationally allowed to add more 
+output channels in each Conv2D layer.
+• The input size includes a third dimension for 
+RGB
+_________________________________________________________________
+ Layer (type)                                           Output Shape              Param #   
+=================================================================
+ conv2d (Conv2D)                                (None, 30, 30, 32)        896       
+                                                                 
+ max_pooling2d (MaxPooling2D)     (None, 15, 15, 32)       0         
+                                                                 
+ conv2d_1 (Conv2D)                            (None, 13, 13, 64)        18496     
+                                                                 
+ max_pooling2d_1 (MaxPooling2D)    (None, 6, 6, 64)         0         
+                                                                 
+ conv2d_2 (Conv2D)                                (None, 4, 4, 64)          36928     
+                                                                 
+=================================================================
+Total params: 56,320
+
+Flattening
+• Before moving from convolutional to dense, perform flattening
+• model.add(tf.layers.Flatten())
+
+Improving Generalization
+and Accuracy
+
+Definitions and solutions
+• Overfitting:
+• In machine learning, overfitting occurs when an algorithm fits too closely or even 
+exactly to its training data, resulting in a model that cannot make accurate 
+predictions or conclusions from any data other than the training data.
+• Generalization
+• The term generalization refers to the model's capability to adapt and react properly 
+to previously unseen, new data, which has been drawn from the same distribution as 
+the one used to build the model.
+• Techniques to improve Generalization on the training process:
+• Dropout
+• Regularization
+• Data augmentation
+• Data augmentation is the process of artificially generating new data from existing 
+data, primarily to train new machine learning (ML) models.
+
+Dropout
+• It is often used to prevent overtraining and generalize the network.
+• It consists of randomly disconnecting a % of neurons in each training 
+pass (EPOCH)
+• KERAS
+• model.add(tf.layers.Dropout(0.3))
+
+Regularization
+• Regularization is a technique used to reduce errors by fitting the function appropriately 
+on the given training set and avoiding overfitting.
+• The commonly used regularization techniques are : 
+• Lasso Regularization – L1 Regularization
+• Ridge Regularization – L2 Regularization
+• Elastic Net Regularization – L1 and L2 Regularization
+• L1 Regularization technique is called LASSO(Least Absolute Shrinkage and Selection 
+Operator) regression.
+• Lasso Regression adds the absolute value of magnitude of the coefficient as a penalty term to the 
+loss function(L).
+• Lasso regression also helps us achieve feature selection by penalizing the weights to 
+approximately equal to zero if that feature does not serve any purpose in the model.
+• L2 regularization technique is called Ridge regression.
+• Ridge regression adds the squared magnitude of the coefficient as a penalty term to the loss 
+function(L).
+
+Regularization in KERAS
+• 3 keyword arguments:
+• kernel_regularizer: Regularizer to apply a penalty on the layer's kernel
+• bias_regularizer: Regularizer to apply a penalty on the layer's bias
+• activity_regularizer: Regularizer to apply a penalty on the layer's output
+• Example
+layer = layers.Dense(
+units=64,
+kernel_regularizer=regularizers.l1_l2(l1=1e-5, l2=1e-4),
+bias_regularizer=regularizers.l2(1e-4),
+activity_regularizer=regularizers.l2(1e-5)
+)
+
+Data Augmentation with Librosa
+• https://www.kaggle.com/code/huseinzol05/sound-augmentation-
+librosa
+• Change pitch and speed
+• Change pitch only
+• Change speed only
+• Change volume / dynamic range
+• Add noise
+• Apply Filters
+• Shift silent
+
+Recursive Networks in Audio
+RNN
+
+Problem in sound
+• When defining a traditional DNN, the number of inputs is fixed in 
+advance.
+• Time series such as sound do not have a fixed duration.
+• It is difficult to work with sound in these cases.
+• In addition, there are cases where processing the entire sound 
+fragment at once would be very expensive (e.g. Style Recognition, 30 s)
+• A network that can be fed data little by little and that has memory 
+would be interesting.
+
+RNN Definition
+• It is a type of network architecture that implements some kind of 
+memory, and therefore, has a sense of time.
+• It is achieved by implementing a type of neurons that receive an input 
+from the output of a hidden layer of the previous temporal state that 
+is reinjected.
+
+RNN recursiveness
+
+Problems with simple RNN
+• Feedback causes the data from N past time interactions to lose importance.
+• The network gradually loses memory.
+• It is only valid for short time iterations.
+• “Gradient vanishing” problem.
+
+LSTM networks (Long-Short Term Memory)
+• They have a retention and forgetting mechanism.
+• They can preserve past information very well.
+• They can forget past information instantly if more relevant 
+information comes in.
+• They have a longer long-term memory than simple RNNs.
+
+LSTM
+The core idea is this cell state 
+Ct, it is changed slowly, with 
+only minor linear interactions. It 
+is very easy for information to 
+flow along it unchanged.
+ht-1
+Ct-1
+This sigmoid gate 
+determines how much
+information goes thru
+This decides what info
+Is to add to the cell state
+Output gate 
+Controls what 
+goes into output
+Forget  input
+gate      gate
+Why sigmoid or tanh:
+Sigmoid: 0,1 gating as switch.
+Vanishing gradient problem in
+LSTM is handled already.
+ReLU replaces tanh ok?
+
+it decides what component 
+is to be updated.
+C’t provides change contents
+Updating the cell state
+Decide what part of the cell
+state to output
+
+RNN vs LSTM
+
+How to use in KERAS
+• To introduce the fist layer LSTM
+• model.add(kr.layers.LSTM(64, input_shape=(timesteps, 
+features)))
+• The input parameters are two-dimensional, with the first coordinate 
+being considered time (to apply recursion).
+
+Encoder-Decoder
+Architectures
+
+Encoder-Decoder (background)
+• They are DNN architectures that are widely used in sequence-to-
+sequence problems.
+• For example, in: machine translation, text generation, text 
+summarization, and also in audio.
+• Encoder-Decoder networks are especially effective for tasks where 
+the input and output are of variable length.
+• They handle input and output sequences flexibly, capturing the 
+relevant information in the latent representation and generating 
+coherent output sequences.
+
+Structure
+• Encoder:
+• The task of the encoder is to transform the input (e.g., a sequence of words in 
+a language) into a lower-dimensional but more meaningful latent 
+representation or feature vector.
+• Each time step (or word) in the input is processed and encoded into an 
+internal representation. Important information is captured in the latent 
+representation.
+• Upon completion of the input sequence, the encoder produces a single vector 
+(or set of vectors) that captures the key information of the input.
+
+Structure
+• Decoder:
+• The decoder takes the latent vector generated by the encoder and uses it to 
+generate the desired output (for example, a sequence of words in another 
+language).
+• It starts by generating the first part of the output using the latent vector and 
+then, at each subsequent time step, incorporates information from the latent 
+vector and the output generated up to that point.
+• The output is generated step by step and is adjusted based on the 
+information learned by the encoder.
+
+Training
+• During the training phase, the network is fed known input-output 
+pairs.
+• The network learns to adjust the weights of its connections such that 
+the output generated by the decoder is as close as possible to the 
+desired output, taking into account the information captured by the 
+encoder.
+• A loss function is used to measure the discrepancy between the 
+generated output and the desired output. This function guides the 
+model during training to minimize error.
+
+U-Net
+• Famous encoder-
+decoder network
+• Convolucional layers 
+are employed
+
+Spleeter
+• It is a sound separation algorithm in songs based on the U-Net 
+architecture.
+• It is written in Python and Tensorflow.
+• It allows sounds to be separated in 3 ways:
+• Vocals (singing voice) / accompaniment separation (2 stems)
+• Vocals / drums / bass / other separation (4 stems)
+• Vocals / drums / bass / piano / other separation (5 stems)
+• Scientific References
+• https://www.theoj.org/joss-papers/joss.02154/10.21105.joss.02154.pdf
+• https://archives.ismir.net/ismir2019/latebreaking/000036.pdf
+
+Spleeter (Tech details)
+• It uses 12 U-Net layers, 6 for the encoder and 6 for the decoder.
+• The loss function is an L1-norm between the input spectrogram and 
+the output spectrograms.
+• Proprietary databases with separate instruments and the full mixture 
+were used to train.
+• It took 1 week to train on a GPU.
+• It can work in production at 100x on an RTX 2080 GPU
+• https://github.com/deezer/spleeter       (GITHUB)
+
+Spleeter (MS-DOS version)
+Usage: spleeter [options] <input_file_path>
+Options:
+    -m, --model         Spleeter model name
+                        (2stems, 4stems, 5stems-16kHz, ..., default: 2stems)
+    -o, --output        Output base file name
+                        (in the format of filename.ext, default: <input_file_path>)
+    -b, --bitrate       Output file bit rate
+                        (128k, 192000, 256k, ..., default: 256k)
+    --overwrite         Overwrite when the target output file exists
+    -h, --help          Display this help and exit
+    -v, --version       Display program version and exit
+
+DataBases / Corpus
+
+Environmental Sounds
+• ESC-50
+• https://github.com/karolpiczak/ESC-50
+• 50 types of environmental sounds
+• 40 examples per class
+• Total 2000 sounds of maximum 5 seconds duration
+• The 50 classes are grouped into 5 categories
+• Is it possible to work in one category only (10 classes per cat.)
+
+Musical Instruments
+• BASIC
+• https://github.com/seth814/Audio-Classification/
+• 10 different musical instruments
+• 30 samples of each instrument
+• IRMAS
+• 12 different musical instruments(including voice)
+• https://zenodo.org/records/1290750
+• 3,2 GB  (6705 files)
+
+Speech Emotion
+• CREMAD
+• https://www.kaggle.com/datasets/ejlok1/cremad/
+• It is a data set of 7,442 original clips from 91 actors.
+• 48 male and 43 female actors between the ages of 20 and 74
+• Actors spoke from a selection of 12 sentences.
+• The sentences have six different emotions
+• Anger, Disgust, Fear, Happy, Neutral, Sad
+
+Music separated tracks by instruments
+• MUSDB18
+• 4 separated tracks
+• 26 GB
+• https://sigsep.github.io/datasets/musdb.html
+
+Musical genres
+• GTZAN
+• 10 musical genres
+• 100 songs per genre
+• Features
+• https://www.kaggle.com/datasets/andradaolteanu/gtzan-dataset-
+music-genre-classification/data
+• Features computation
+• https://www.kaggle.com/code/gastngadea/generate-features-csv-
+files-from-gtzan-dataset/notebook
+
+Speech Emotion
+• https://www.kaggle.com/code/ashishsingh226/speech-emotion-
+recognition-using-lstm/notebook
+• Speech emotion / Mood with LSTM
+
+Musical Genres
+• https://www.kaggle.com/code/andradaolteanu/work-w-audio-data-
+visualise-classify-recommend
+• Mixed features (MFCC & More)
+• Clasic machine learning vs DNN
+• Comparison
+• Best:  XGBoost
+
+Genres of Popular Songs
+• https://kaavyamaha12.medium.com/training-a-tensorflow-model-
+for-predicting-the-genres-of-popular-songs-4286d87d71f6

--- a/src/data/lessonSummaries/text/snlp-chapter-4.txt
+++ b/src/data/lessonSummaries/text/snlp-chapter-4.txt
@@ -1,0 +1,911 @@
+CHAPTER 4
+Natural Language Processing
+Word Embeddings
+
+Summary
+1. Introduction
+2. Discrete text representations
+3. Distributed/Continuous text representations
+4. Word2vec
+5. GloVe
+6. fastText
+7. Examples in Python
+
+Definition of NLP
+• NLP is a branch of artificial intelligence that deals with the interaction 
+between computers and humans using the natural language.
+• The ultimate objective of NLP is to read, decipher, understand, and 
+make sense of the human languages in a manner that is valuable.
+• Most NLP techniques rely on machine learning to derive meaning 
+from human languages.
+• It sits at the intersection of computer science, artificial intelligence, 
+and computational linguistics
+
+Applications
+• Summarization
+• Document similarity
+• Sentiment classification
+• Spam classification
+• Translation
+• Chat Bots
+• Generative language
+• …
+
+The problem of Text Representation
+• Computers are brilliant when dealing with numbers.
+• They are faster than humans in calculations & decoding patterns by 
+many orders of magnitude.
+• But therefore …
+• But what if the data is not numerical?
+• What if it's language?
+• What happens when the data is in characters, words & sentences? How do 
+we make computers process our language?
+• How does Alexa, Google Home & many other smart assistants understand & 
+reply to our speech?
+
+Text Representation
+• The most basic step for the majority of NLP tasks is to convert words 
+into numbers for machines to understand & decode patterns within a 
+language.
+• We call this step text representation.
+• It plays a significant role in deciding features for your machine 
+learning model/algorithm.
+• Text representations can be broadly classified into two sections:
+• Discrete text representations
+• Distributed/Continuous text representations
+
+Discrete text representation
+• These are representations where words are represented by their 
+corresponding indexes to their position in a dictionary from a larger 
+corpus or corpora.
+• Representations that fall within this category are:
+• One-Hot encoding
+• Bag-of-words representation (BOW)
+• Basic BOW — CountVectorizer
+• Advanced BOW — TF-IDF
+
+One-Hot encoding
+• It is a type of representation that assigns 0 to all elements in a vector except for 
+one, which has a value of 1. This value represents a category of an element.
+• If i had a sentence, “I love my dog”, each word in the sentence would be 
+represented as below:
+I → [1 0 0 0], love → [0 1 0 0], my → [0 0 1 0], dog → [0 0 0 1]
+• The entire sentence is then represented as:
+sentence = [ [1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1] ]
+
+One-Hot encoding
+• The intuition behind one-hot encoding is that each bit represents a 
+possible category & if a particular variable cannot fall into multiple 
+categories, then a single bit is enough to represent it
+• As you may have grasped, the length of an array of word depends on 
+the vocabulary size. This is not scalable for a very large corpus which 
+could contain up to 100,000 unique words or even more.
+
+Implementation
+from sklearn.preprocessing import OneHotEncoder
+import itertools
+# two example documents
+docs = ["cat","dog","bat","ate"]
+# split documents to tokens
+tokens_docs = [doc.split(" ") for doc in docs]
+# convert list of of token-lists to one flat list of tokens
+# and then create a dictionary that maps word to id of word,
+all_tokens = itertools.chain.from_iterable(tokens_docs)
+word_to_id = {token: idx for idx, token in enumerate(set(all_tokens))}
+# convert token lists to token-id lists
+token_ids = [[word_to_id[token] for token in tokens_doc] for tokens_doc in tokens_docs]
+# convert list of token-id lists to one-hot representation
+vec = OneHotEncoder(categories="auto")
+X = vec.fit_transform(token_ids)
+print(X.toarray())
+OUTPUT
+[[0. 0. 1. 0.]
+[0. 1. 0. 0.]
+[0. 0. 0. 1.]
+[1. 0. 0. 0.]]
+
+One-Hot encoding
+Advantages of one-hot encoding:
+• Easy to understand & implement
+Disadvantages of one-hot encoding:
+• Explosion in feature space if number of categories are very high
+• The vector representation of words is orthogonal and cannot determine or 
+measure relationship between different words
+• Cannot measure importance of a word in a sentence but understand mere 
+presence/absence of a word in a sentence
+• High dimensional sparse matrix representation can be memory & 
+computationally expensive
+
+Bag-of-words representation
+• Bag-of-words (BOW) representation as the name suggests intutively, 
+puts words in a “bag” & computes frequency of occurrence of each 
+word.
+• It does not take into account the word order or lexical information for 
+text representation
+• The intuition behind BOW representation is that document having 
+similar words are similar irrespective of the word positioning
+
+Basic BOW — CountVectorizer
+• The CountVectorizer computes the frequency of occurrence of a word in a 
+document. It converts the corpus of multiple sentences (say product reviews) into 
+a matrix of reviews & words & fills it with frequency of each word in a sentence
+from sklearn.feature_extraction.text import 
+CountVectorizer
+text = ["i love nlp. nlp is so cool"]
+vectorizer = CountVectorizer()
+# tokenize and build vocab
+vectorizer.fit(text)
+print(vectorizer.vocabulary_)
+# Output: {'love': 2, 'nlp': 3, 'is': 1, 'so': 
+4, 'cool': 0}
+# encode document
+vector = vectorizer.transform(text)
+# summarize encoded vector
+print(vector.shape) # Output: (1, 5)
+print(vector.toarray())
+OUTPUT
+[[1 1 1 2 1]]
+
+Basic BOW — CountVectorizer
+Advantage of CountVectorizer:
+• CountVectorizer also gives us frequency of words in a text 
+document/sentence which One-hot encoding fails to provide
+• Length of the encoded vector is the length of the dictionary
+Disadvantages of CountVectorizer:
+• This method ignores the location information of the word. It is not possible to 
+grasp the meaning of a word from this representation
+• The intuition that high-frequency words are more important or give more 
+information about the sentence fails when it comes to stop words like “is, the, 
+an, I” & when the corpus is context-specific. For example, in a corpus about 
+covid-19, the word coronavirus may not add a lot of value
+
+Advanced BOW (TF-IDF)
+• To suppress the very high-frequency words & ignore the low-frequency words, there is a 
+need to normalize the “weights” of the words accordingly
+• TF-IDF representation: Term frequency-inverse document frequency
+• It is a product of 2 factors
+• Where, TF(w, d) is frequency of word ‘w’ in document ‘d’
+• IDF(w) is the inverse of document frequency is the log between total number of 
+documents N divided by the number of documents containing the word ‘w’
+•
+
+BOW vs TF-IDF
+BOW
+
+Advanced BOW (TF-IDF)
+• Intuition behind TF-IDF is that the weight assigned to each word not 
+only depends on a words frequency, but also how frequent that 
+particular word is in the entire corpus/corpora
+• It takes the CountVectorizer presented before & multiplies it by the 
+IDF score.
+• The resultant output weights for the words from the process is low 
+for very highly frequent words (like stop-words) & very low frequency 
+words (noise terms)
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+text1 = ['i love nlp', 'nlp is so cool', 
+'nlp is all about helping machines process language', 
+'this tutorial is on baisc nlp technique']
+tf = TfidfVectorizer()
+txt_fitted = tf.fit(text1)
+txt_transformed = txt_fitted.transform(text1)
+print ("The text: ", text1)
+# Output: The text:  ['i love nlp', 'nlp is so cool', 
+# 'nlp is all about helping machines process language', 
+# 'this tutorial is on basic nlp technique']
+idf = tf.idf_
+print(dict(zip(txt_fitted.get_feature_names(), idf)))
+OUTPUT 
+Advanced BOW (TF-IDF)
+{'about': 1.916290731874155, 'all': 1.916290731874155, 
+'basic': 1.916290731874155, 'cool': 1.916290731874155, 
+'helping': 1.916290731874155, 'is': 1.2231435513142097, 
+'language': 1.916290731874155, 'love': 1.916290731874155, 
+'machines': 1.916290731874155, 'nlp': 1.0, 'on': 
+1.916290731874155, 
+'process': 1.916290731874155, 'so': 1.916290731874155, 
+'technique': 1.916290731874155, 'this': 1.916290731874155, 
+'tutorial': 1.916290731874155}
+
+Advanced BOW
+• Note the weightage of word ‘nlp’. Since it is present in all the sentences, it 
+is given a low weightage of 1.0.
+• Similarly, the stop-word ‘is’ is also given a comparatively low weightage of 
+1.22 since it is present in 3 out of 4 sentences given.
+• Similar to CountVectorizer, there are various parameters that can be 
+tweaked to achieve desired results.
+• Some of the important parameters (apart from the text preprocessing 
+parameters like lowercase, strip_accent, stop_words etc.) are max_df, 
+min_df, norm, ngram_range & sublinear_tf.
+• The impact of these parameters on outputs weights is beyond scope of this 
+article & will be covered separately.
+
+Advanced BOW
+Advantages of TF-IDF representation:
+• Simple, easy to understand & interpret implementation
+• Builds over CountVectorizer to penalise highly frequent words & low 
+frequency terms in a corpus. So in a way, IDF achieves in reducing noise in our 
+matrix.
+Disadvantages of TF-IDF representation:
+• Positional information of the word is still not captured in this representation
+• TF-IDF is highly corpus dependent. A matrix representation generated out of 
+cricket data cannot be used for football or volleyball. Therefore, there is a 
+need to have high quality training data
+
+Conclussion of Discrete Representations
+Advantages of discrete representations:
+• Simple representations that are easy to understand, implement & interpret
+• Algorithms like TF-IDF can be used to filter out uncommon & irrelevant words 
+easily helping model train & converge faster
+Disadvantages of discrete representations:
+• The representation is directly proportional to vocabulary size. High vocabulary 
+size can lead to memory constraints
+• It does not leverage co-occurrence statistics between words. It assumes all 
+words are independent of each other
+• This leads to highly sparse vectors with few non zero values
+• They do not capture the context or semantics of the word. It does not 
+consider spooky & scary as similar but as two independent terms with no 
+commonality between them
+
+Applications of Discrete Representations
+• Discrete representations are widely used across both classical 
+machine learning & deep learning applications for solving 
+complicated use cases like:
+• document similarity
+• sentiment classification
+• spam classification
+• topic modeling
+• However, for more complex applications are not enought
+• Next, we will discuss distributed or a continuous text representation 
+of text & how it is better (or worse) than discrete representations.
+
+Distributed Text Representation
+• Distributed text representation is when the representation of a word is not 
+independent or mutually exclusive of another word and their 
+configurations often represent various metrics & concepts in data.
+• So the information about a word is distributed along the vector it is 
+represented as.
+• This is different from discrete representation where each word is 
+considered unique & independent of each others.
+• Some of the commonly used distributed text representations are:
+• Co-Occurrence matrix
+• Word2Vec
+• GloVe
+• BERT
+
+Co-Occurrence Matrix
+• The co-Occurrence matrix, as the name suggests, considers the co-
+occurrence of entities nearby each other.
+• The entity used could be a single word, could be a bi-gram or even a 
+phrase.
+• Predominantly, a single word is used for computing the matrix.
+• It helps us understand the association between different words in a 
+corpus.
+• Let's look at an example using CountVectorizer used beforehand 
+convert it into continuous representation.
+
+Co-Occurrence Matrix
+ssfrom sklearn.feature_extraction.textimport CountVectorizer
+docs = ['product_x is awesome',
+'product_x is better than product_y',
+'product_x is dissapointing','product_y beats product_x by miles', 
+'ill definitely recommend product_x over others']
+# Using in built english stop words to remove noise
+count_vectorizer = CountVectorizer(stop_words = 'english')
+vectorized_matrix = count_vectorizer.fit_transform(docs)
+# We can now simply do a matrix multiplication with the transposed
+# image of the same matrix
+co_occurrence_matrix = (vectorized_matrix.T* vectorized_matrix)
+print(pandas.DataFrame(co_occurrence_matrix.A, 
+columns=count_vectorizer.get_feature_names(),
+index=count_vectorizer.get_feature_names()))
+awesome  beats  better  definitely  dissapointing  ill  miles  \\
+awesome              1      0       0           0              0    0      
+0   
+beats                0      1       0           0              0    0      
+1   
+better               0      0       1           0              0    0      
+0   
+definitely           0      0       0           1              0    1      
+0   
+dissapointing        0      0       0           0              1    0      
+0   
+ill                  0      0       0           1              0    1      
+0   
+miles                0      1       0           0              0    0      
+1   
+product_x            1      1       1           1              1    1      
+1   
+product_y            0      1       1           0              0    0      
+1   
+recommend            0      0       0           1              0    1      
+0   
+               product_x  product_y  recommend  
+awesome                1          0          0  
+beats                  1          1          0  
+better                 1          1          0  
+definitely             1          0          1  
+dissapointing          1          0          0  
+ill                    1          0          1  
+miles                  1          1          0  
+product_x              5          2          1  
+product_y              2          2          0  
+recommend              1          0          1
+OUTPUT
+
+Co-Occurrence Matrix
+• The representation of each word is its corresponding row (or column) 
+in the co-occurrence matrix
+• If we want to understand the word associations to product_x, we can 
+filter for the column & analyse that product_x is being compared with 
+product_y & there are more positive adjectives associated to it than 
+negative ones.
+
+Co-Occurrence Matrix
+Advantages:
+• Simple representation for finding word associations
+• It considers the order of words in the sentence unlike discrete techniques
+• The representation coming out of this method is a global representation. i:e it uses 
+the entire corpus for generating the representation
+Disadvantages:
+• Similar to CountVectorizer & TF-IDF matrices, this too is a sparse matrix. This means 
+its not storage efficient & calculations are inefficient to run on top
+• Larger the vocabulary size, larger the matrix size (not scalable to large vocabulary)
+• Not all word associations can be understood using this technique. In the above 
+example, if you look at the product_x column, there is a row with name beats. It is 
+uncertain what is the context on beats in this scenario simply by looking at the 
+matrix
+
+Word2Vec
+• Word2Vec is a famous algorithm for representing word embeddings.
+• It was developed by Tomas Mikalov in 2013 at Google.
+• It's a prediction-based method for representing words rather than 
+count based technique like co-occurrence matrix.
+• Word embeddings are vector representation of a word.
+• Each word in the vocabulary is represented by a fixed vector size 
+while capturing its semantic & syntactic relation with other words
+
+Word2Vec
+• Word2vec is a neural network approach to learn distributed word 
+vectors in a way that:
+•  words used in similar syntactic or semantic context
+• lie closer to each other in the distributed vector space.
+• Distributed, in a way such that:
+• the result of a vector calculation vec(“Madrid”) — vec(“Spain”) + vec(“France”)
+• is closer to vec(“Paris”) than to any other word vector
+• The quality of the representations was measured by how well it 
+represents word similarity in the vector space using various distance 
+metrics.
+
+Word2Vec   (example vector dim.= 4)
+• As expected, “king”, “queen”, “prince” have similar scores for “royalty” and “girl”, “queen” have 
+similar scores for “femininity”.
+• An operation that removes “man” from “king”, would yield in a vector very close to “queen” ( 
+“king”- “man” = “queen”)
+• Vectors “king” and “prince” have the same characteristics, except for age, telling us how they 
+might possibly be semantically related to each other.
+
+Word2vec
+
+Word2Vec
+
+Word2Vec  - Word similarity
+• There are 2 ways to find the similarity between the vectors depending 
+if they are normalised or not:
+• If normalised: We can compute the simple dot product between the vectors 
+to find how similar they are
+• If not normalised: We can compute the cosine similarity between the vectors 
+using the below formula
+• cosine distance = 1 – cosine similarity
+
+Word2Vec  - Model Architecture (i)
+Word2Vec essentially is a shallow 
+2-layer neural network trained.
+• The input contains all the 
+documents/texts in our training 
+set. For the network to process 
+these texts, they are 
+represented in a 1-hot 
+encoding of the words.
+• The number of neurons present 
+in the hidden layer is equal to 
+the length of the embedding 
+we want. That is, if we want all 
+our words to be vectors of 
+length 300, then the hidden 
+layer will contain 300 neurons.
+
+Word2Vec  - Model Architecture (ii)
+• The output layer contains 
+probabilities for a target word 
+(given an input to the model, 
+what word is expected) given a 
+particular input.
+• At the end of the training 
+process, the hidden weights are 
+treated as the word 
+embedding. Intuitively, this can 
+be thought of as each word 
+having a set of n weights (300 
+considering the example 
+above) “weighing” their 
+different characteristics (an 
+analogy we used earlier).
+
+Word2Vec  - Model Architecture (iii)
+• At the end of the training 
+process, the hidden weights 
+are treated as the word 
+embedding.
+•  Intuitively, this can be 
+thought of as each word 
+having a set of n weights 
+(300 considering the 
+example above) “weighing” 
+their different characteristics 
+(an analogy we used earlier).
+
+Word2vec –Two Techniques
+• There are two main techniques of produce the vector respresentation
+of word (embedings).
+1. Continuous Bag of Words (CBOW)
+2. Skipgram
+
+Word2vec  - CBOW
+• CBOW predicts the target-word based on its surrounding words.
+• For example, consider the sentence, “The cake was chocolate flavoured”.
+• The model will then iterate over this sentence for different target words, such as:
+• “The ____ was chocolate flavoured” being inputs and “cake” being the target 
+word.
+• CBOW thus smoothes over the distribution of the information as it treats the 
+entire context as one observation. CBOW is a faster algorithm than skipgrams and 
+works well with frequent words.
+
+Word2vec - CBOW
+• CBOW aims to predict the target word based on its surrounding 
+context words within a fixed window size.
+• It works by summing or averaging the word vectors of the context 
+words to predict the target word.
+• For example, given the sentence "The cat sat on the ___", CBOW tries 
+to predict the target word "mat" based on the context words "The", 
+"cat", "sat", and "on".
+• CBOW is computationally efficient and tends to work well with 
+frequent words.
+
+Word2vec - Skipgram
+• Skipgram works in the exact opposite way to CBOW. Here, we take an 
+input word and expect the model to tell us what words it is expected 
+to be surrounded by.
+• Taking the same example, with “cake” we would expect the model to 
+give us “The”, “was”, “chocolate”, “flavoured” for the given instance.
+• The statistical interpretation of this is that we treat each context-
+target pair as a new observation. Skipgrams work well with small 
+datasets and can better represent less frequent words.
+
+Word2vec - Skipgram
+• Skipgram, on the other hand, works in the opposite way compared to 
+CBOW. It predicts the context words given a target word.
+• For each word in a sentence, Skip-gram tries to predict the context 
+words within a fixed window size.
+• It's particularly useful for capturing semantic relationships between 
+words and tends to perform better with smaller datasets or rare 
+words.
+• Using the same example as before, Skip-gram would predict "The", 
+"cat", "sat", and "on" based on the target word "mat".
+
+Word2vec –Comparison CBOW vs Skipgram
+
+CBOW vs Skipgram
+• https://kavita-ganesan.com/comparison-between-cbow-skipgram-
+subword/
+
+What is Gensim?
+• Gensim is a free open-source Python library for representing 
+documents as semantic vectors, as efficiently (computer-
+wise) and painlessly (human-wise) as possible.
+• Gensim is designed to process raw, unstructured digital texts (“plain 
+text”) using unsupervised machine learning algorithms.
+• https://radimrehurek.com/gensim/intro.html
+
+Word2vec  in  GenSim
+• GenSim has (among other things) a Python implementation of Word2Vec 
+which allow to load models and manipulate.
+• Intro
+• http://radimrehurek.com/gensim/models/word2vec.html
+• Examples of use
+• https://radimrehurek.com/gensim/auto_examples/tutorials/run_word2vec.html
+• Tutorial
+• http://radimrehurek.com/2014/02/word2vec-tutorial/
+• Tutorial
+• https://www.machinelearningplus.com/nlp/gensim-tutorial/
+• Tutorial
+• https://www.geeksforgeeks.org/nlp-gensim-tutorial-complete-guide-for-beginners/
+
+GenSim Tutorials in general
+• https://radimrehurek.com/gensim/auto_exa
+mples/index.html
+
+Word2vec –Loading pre-trained models
+• Gensim comes with several already pre-trained models, in the 
+Gensim-data repository.
+• We can import the downloader from the gensim library.
+• We can print the list of pre-trained models trained on large datasets 
+available to us. 
+• This also includes models like GloVe and fastext other than word2vec.
+• We can also download a model from our HD
+
+Word2vec - GenSim
+Load a model from your disk
+from gensim.models import Word2Vec
+model = Word2Vec.load(path/to/your/model)
+Load a model from the library provided
+import gensim.downloader as api
+print(api.info()['models'].keys())        #list avail. models
+model_twi = api.load("glove-twitter-25")  #load model
+model_twi = api.load("word2vec-google-news-300")  #load larger model
+
+Word2vec - GenSim
+Compute similarity
+model.similarity('france', 'spain’)
+Instead of handmade
+cosine_similarity = numpy.dot(model['spain'], 
+model['france'])/(numpy.linalg.norm(model['spain'])* 
+numpy.linalg.norm(model['france']))
+
+Word2vec - GenSim
+Most similar words
+model.most_similar("cat")
+Most similar of two
+print(model.most_similar(positive=['car', 'minivan'], topn=5))
+Which of the below does not belong in the sequence?
+print(wv.doesnt_match(['fire', 'water', 'land', 'sea', 'air', 'car']))
+Retrieve vocabulary
+for index, word in enumerate(model.index_to_key):
+    if index == 10:
+        break
+    print(f"word #{index}/{len(model.index_to_key)} is {word}")
+
+Word2vec –Saving models
+• We can save our existing models and load them again.
+
+Word2vec - Visualization
+• Word2Vec word embedding can usually be of sizes 100 or 300, and it is practically 
+not possible to visualise a 300 or 100 dimensional space with meaningful outputs.
+• Two or three dimensional representations are more practical
+• However, not two ramdom dimensions are useful
+• It is better to reduce dimensionality to 2 or 3 that are relevant
+• Principal component analysis (PCA) is a linear dimensionality reduction technique 
+with applications in exploratory data analysis, visualization and data 
+preprocessing.
+• The data is linearly transformed onto a new coordinate system such that the 
+directions (principal components) capturing the largest variation in the data can 
+be easily identified.
+• The idea is to use PCA to reduce the dimensionality and represent the word 
+through their vectors on a 2-dimensional o 3-dim plane.
+
+Word2vec - Visualization
+• Example
+• https://web.stanford.edu/class/cs224n/materials/Gensim%20word%
+20vector%20visualization.html
+• Sentiment Analisys
+• https://github.com/malinowakrew/text_classifier_sentiment/blob/m
+aster/text_classifier.ipynb
+
+Word2vec –Example code
+• https://colab.research.google.com/drive/1YkSrvfWR_EBFFrhV5E15Z6
+k5es4Kluom?usp=sharing
+
+Word2Vec Materials
+• TUTORIAL about how Word2Vec works.
+• https://medium.com/@zafaralibagh6/a-simple-word2vec-tutorial-
+61e64e38a6a1
+• Gensim Word2Vec Tutorial: An End-to-End Example
+• https://kavita-ganesan.com/gensim-word2vec-tutorial-starter-code/
+
+Word2Vec
+Advantages
+1. Capable of capturing relationships between different words including their 
+syntactic & semantic relationships
+2. The size of the embedding vector is small & flexible, unlike all the previous 
+algorithms discussed where the size of embedding is proportional to vocabulary 
+size
+3. Since its unsupervised, human effort in tagging the data is less
+Disadvantages
+1. Word2Vec cannot handle out-of-vocabulary words well. It assigns a random vector 
+representation for OOV words which can be suboptimal
+2. It relies on local information of language words. The semantic representation of a 
+word relies only on its neighbours & can prove suboptimal
+3. Parameters for training on new languages cannot be shared. If you want to train 
+word2vec in a new language, you have to start from scratch
+4. Requires a comparatively larger corpus for the network to converge (especially if 
+using skip-gram)
+
+Word2Vec –Cons & Solutions
+1. Global information is not preserved
+➢solved by GloVe
+2. Doesn’t work well for morphologically rich languages
+➢solved by FastText
+3. Lacks broad context awareness
+➢solved by LSTM, BERT, GPT
+
+Word2Vec - Laboratory Class 
+• Basic natural language processing techniques
+• How to train a model using Word2Vec and how to use the resulting word 
+vectors for sentiment analysis
+• https://www.kaggle.com/c/word2vec-nlp-tutorial/overview
+• Classifying questions on Stack Overflow into 3 categories depending on 
+their quality
+• https://github.com/shraddha-
+an/nlp/blob/main/word_embedding_classification.ipynb
+• Classifying Movie Plots by Genre
+• https://github.com/RaRe-Technologies/movie-plots-by-
+genre/tree/master/ipynb_with_output
+
+Word2Vec - Laboratory Class using Gensim 
+• Fake News Detection (using Word2Vec)
+• https://www.youtube.com/watch?v=ZrgVlfNduj8
+• Code
+• https://github.com/codebasics/nlp-
+tutorials/blob/main/16_word_vectors_gensim_text_classification/ge
+nsim_w2v_google.ipynb
+
+GloVe
+• Global Vectors for word representation is another famous embedding 
+technique used quite often in NLP .
+• Proposed in  2014 by Jeffery Pennington, Richard Socher & Christopher D 
+Manning from Stanford.
+• It tries to overcome the 2nd disadvantage of word2vec mentioned before 
+by trying to learn both local & global statistics of a word to represent it.
+• It tries to encompass the best of:
+• count-based technique (co-occurrence matrix) &
+• prediction-based technique (Word2Vec)
+• … and hence is also referred to as a hybrid technique for continuous word 
+representation
+
+GloVe - Mathematical Foundation
+• It is designed to generate word embeddings by capturing global statistical 
+information from a corpus. The key idea is to factorize the co-occurrence matrix 
+to learn word vectors.
+Key Concepts
+1.Co-occurrence Matrix:
+1. This matrix X is constructed from a corpus where each entry Xij​ represents the number of 
+times word j appears in the context of word i
+2. For example, if "cat" and "pet" often appear together, Xcat,pet pet​ will be high.
+2.Objective:
+1. Capture the ratio of co-occurrence probabilities between words to reflect semantic 
+relationships.
+
+GloVe - Co-occurrence Matrix
+• The co-occurrence matrix is a core component of the GloVe model. It records 
+how often pairs of words appear together within a specified context window.
+• Each cell (i, j) in the matrix represents the number of times Word i appears in the 
+context of Word j within a given window size.
+Word1 Word2 Word3 Word4
+Word1 0 2 3 0
+Word2 2 0 1 4
+Word3 3 1 0 5
+Word4 0 4 5 0
+
+The GloVe
+Loss
+Function
+
+Training GloVe
+• Co-occurrence Matrix: Construct a matrix capturing how often words 
+appear together in a corpus.
+• Objective: Learn word vectors by minimizing the difference between 
+their dot products and the logarithm of their co-occurrence counts.
+• Weighting Function: Balances the influence of word pairs, giving 
+appropriate importance to frequent and infrequent pairs.
+• Optimization: Use an algorithm like stochastic gradient descent to 
+adjust word vectors until the model converges.
+• Result: Word embeddings that effectively capture word meanings and 
+relationships
+
+Hyperparameters in GloVe
+• Vector Dimension (d):
+• Determines the size of the word embeddings.
+• Higher dimensions capture more semantic nuances but require more computation.
+• Context Window Size:
+• Defines the range of words considered for co-occurrence.
+• Larger windows capture broader context but may introduce noise.
+• Learning Rate:
+• Controls the step size during optimization.
+• Needs careful tuning to ensure convergence without overshooting.
+• Number of Iterations:
+• Specifies how many times the model processes the data.
+• More iterations can improve accuracy but increase training time.
+• Weighting Function Parameters:
+• Adjusts how co-occurrence frequencies influence training.
+• Balances the contribution of frequent and rare pairs.
+
+Advantages of GloVe over Word2Vec
+• Global context: Uses the entire corpus, capturing broader semantic 
+relationships.
+• Efficiency: Can be trained faster than Word2Vec for large datasets.
+• because it uses a precomputed co-occurrence matrix, leveraging the entire 
+corpus efficiently
+• GloVe's optimization involves just solving a matrix factorization problem
+• this reduces data processing and simplifies optimization compared to 
+Word2Vec's iterative neural network approach
+• Improved performance: Often shows better performance on word 
+analogy tasks.
+
+GloVe – Advantages & Disadvantages
+Advantages
+• It tends to perform better than word2vec in analogy tasks
+• It considers word pair to word pair relationship while constructing the vectors & 
+hence tend to add more meaning to the vectors when compared to vectors 
+constructed from word-word relationships
+• GloVe is easier to parallelise compared to Word2Vec hence shorter training time
+Disadvantages
+• Because it uses a co-occurrence matrix & global information, memory cost is 
+more in GloVe compared to word2vec
+• Similar to word2vec, it does not solve the problem of polysemous words since 
+words & vectors have a one-to-one relationship
+
+GloVe vs. Word2Vec: A Comparison Table
+
+Glove – Example 1
+import gensim.downloader as api
+# Lets download a 25 dimensional GloVe representation of 2 Billion tweets
+# Info on this & other embeddings : <https://nlp.stanford.edu/projects/glove/>
+twitter_glove = api.load("glove-twitter-25")
+# Example 1: Finding Similar Words
+twitter_glove.most_similar("modi",topn=10)
+# Example 1b: # To get the 25D vectors
+twitter_glove['modi']
+# Example 2: Word Analogy
+result = glove_vectors.most_similar(positive=['woman', 'king'], negative=['man'], 
+topn=1)
+print("\nResult of the analogy 'king - man + woman’:”)
+print(result)
+# Example 3: Similarity Between Words
+twitter_glove.similarity("modi", "india")
+# Example 4: Does Not Match
+odd_one_out = glove_vectors.doesnt_match(["breakfast", "lunch", "dinner", "car"])
+print(f"\nWord that doesn't match: {odd_one_out}")
+# twitter_glove.most_similar("modi",topn=10)
+[('kejriwal', 0.9501368999481201),
+ ('bjp', 0.9385530948638916),
+ ('arvind', 0.9274109601974487),
+ ('narendra', 0.9249324798583984),
+ ('nawaz', 0.9142388105392456),
+ ('pmln', 0.9120966792106628),
+ ('rahul', 0.9069461226463318),
+ ('congress', 0.904523491859436),
+ ('zardari', 0.8963413238525391),
+ ('gujarat', 0.8910366892814636)]
+# twitter_glove['modi']
+array([-0.56174 ,  0.69419 ,  0.16733 ,  0.055867, -0.26266 , -0.6303  ,
+       -0.28311 , -0.88244 ,  0.57317 , -0.82376 ,  0.46728 ,  0.48607 ,
+       -2.1942  , -0.41972 ,  0.31795 , -0.70063 ,  0.060693,  0.45279 ,
+        0.6564  ,  0.20738 ,  0.84496 , -0.087537, -0.38856 , -0.97028 ,
+       -0.40427 ], dtype=float32)
+# twitter_glove.similarity("modi", "india")
+0.73462856
+# twitter_glove.similarity("modi", "India")
+KeyError: "word 'India' not in vocabulary"
+OUTPUT
+
+Glove Twiiter 25
+• Pre-trained glove vectors based on 2B tweets, 27B tokens, 1.2M vocab, 
+uncased.
+• Read more:
+• https://nlp.stanford.edu/projects/glove/
+• https://nlp.stanford.edu/pubs/glove.pdf
+• https://huggingface.co/Gensim/glove-twitter-25
+
+Glove – Example 2
+import gensim.downloader as api
+from sklearn.model_selection import train_test_split
+from sklearn.svm import SVC
+from sklearn.metrics import accuracy_score
+import numpy as np
+# Load the pre-trained GloVe model
+glove_vectors = api.load("glove-wiki-gigaword-50")
+# Sample data: sentences and their labels
+sentences = [
+    "I love programming in Python",
+    "Python is great for data science",
+    "I enjoy watching movies",
+    "Movies are a great way to relax",
+]
+labels = [1, 1, 0, 0]  # 1: tech-related, 0: non-tech
+# Function to compute sentence vectors by averaging word vectors
+def sentence_vector(sentence, model):
+    words = sentence.lower().split()
+    word_vectors = [model[word] for word in words if word in model]
+    return np.mean(word_vectors, axis=0)
+# Convert sentences to vectors
+sentence_vectors = [sentence_vector(sentence, 
+glove_vectors) for sentence in sentences]
+# Split data into training and testing sets
+X_train, X_test, y_train, y_test = 
+train_test_split(sentence_vectors, labels, test_size=0.25, 
+random_state=42)
+# Train a simple classifier
+classifier = SVC(kernel='linear')
+classifier.fit(X_train, y_train)
+# Predict and evaluate
+predictions = classifier.predict(X_test)
+accuracy = accuracy_score(y_test, predictions)
+print(f"Accuracy: {accuracy * 100:.2f}%")
+
+Glove - Example 2
+Explanation
+• Data Preparation: Sentences are labeled based on whether they are 
+tech-related.
+• Vectorization: Each sentence is converted into a vector by averaging 
+its word vectors.
+• Classification: A Support Vector Machine (SVM) is trained on these 
+vectors to classify sentences.
+• Evaluation: The model's accuracy is tested on unseen data.
+
+What is fastText?
+• FastText is an open-source, free, lightweight library that allows users 
+to learn text representations and text classifiers.
+• It works on standard, generic hardware. Models can later be reduced 
+in size to even fit on mobile devices.
+• https://fasttext.cc/
+
+fastText resources
+• English word vectors
+• Trained from Wikepedia
+• Trained from Common Crawl 
+• https://fasttext.cc/docs/en/english-vectors.html
+• Word vectors for 157 languages
+• https://fasttext.cc/docs/en/crawl-vectors.html
+• Language identification
+• https://fasttext.cc/docs/en/language-identification.html
+
+FastTextvs Word2Vec
+• Word2Vec treats each word as a single unit
+• FastText breaks words into subword units (n-grams), allowing it to:
+• Handle out-of-vocabulary words
+• Better understand morphologically rich languagesLearn representations for rare words
+• Word2Vec learns representations for complete words only
+• FastText learns representations for both words and subwords (character n-grams)
+• Word2Vec: Faster training, smaller memory footprint
+• FastText: Slower training, larger memory requirements due to subword storage
+• Word2Vec: Better for languages with simple morphology (like English)
+• FastText: Better for languages with complex morphology (Finnish, Turkish, German)
+
+fastTextusage example
+• fastText Tutorial   &  Train Custom Word Vectors in fastText
+https://www.youtube.com/watch?v=Br-Ozg9D4mc
+• Code
+• https://github.com/codebasics/nlp-
+tutorials/blob/main/16_word_vectors_gensim_text_classification/gensim_w2v_g
+oogle.ipynb
+
+ADDITIONAL 
+LINKS
+
+Projects & Basic Applications
+• Mini projects
+• https://github.com/Storiesbyharshit/Natural-Language-Processing
+• Wine reviews (Mini Projects)
+• https://github.com/Storiesbyharshit/Natural-Language-
+Processing/blob/master/NLP-Wine-Reviews/Wine%20reviews.ipynb
+• Sentiment Analysis with LSTM
+• https://medium.com/@skillcate/sentiment-classification-using-neural-
+networks-a-complete-guide-1798aaf357cd
+
+NLP - Projects
+• Mini projects (Sentiment Analysis with BERT)
+• https://github.com/Storiesbyharshit/Natural-Language-
+Processing/blob/master/Sentiment-Analysis-with-BERT-
+Transformers/Sentiment%20Analysis%20with%20BERT.ipynb
+• NLP basic apps
+• https://github.com/YanSte/NLP-LLM-Basic-Applications
+• News Classification using GenSim
+• https://www.youtube.com/watch?v=ZrgVlfNduj8&list=PLeo1K3hjS3uuvuAXhYjV2l
+MEShq2UYSwX
+
+NLP –Tutorial Example Code
+• https://github.com/codebasics/nlp-
+tutorials/tree/main/9_bag_of_words
+
+NLP Course HuggingFace
+• https://huggingface.co/learn/nlp-course/chapter1/1

--- a/src/data/lessonSummaries/text/snlp-chapter-5.txt
+++ b/src/data/lessonSummaries/text/snlp-chapter-5.txt
@@ -1,0 +1,860 @@
+CHAPTER 5
+Natural Language Processing:
+Transformers  &
+Large Language Models
+
+Summary
+1. Limitations of Pre-Transformer Models (RNNs, LSTMs)
+2. Transformers
+• Introduction: Attention Is All You Need
+• Architecture of Transformers
+• Attention Mechanism
+• Multi-Head Attention
+• Training and Inference of Transformers
+• Why Do Transformers Work So Well?
+• Applications of Transformers
+3. Transformer-based Language Models Architectures
+• BERT
+• GPT
+• BART
+• T5
+4. Large Language Models (LLMs)
+
+Historical evolution to Transformers & LLM
+• Count-based models (Bag-of-Words, TF-IDF): Limitations in capturing word order and 
+context.
+• Word Embeddings (Word2Vec, GloVe): These models represent words as dense vectors, 
+capturing semantic relationships. Emphasize that they are still non-contextualized 
+models.
+• Recurrent Neural Networks (RNNs) and LSTMs: Introduce the idea of processing word 
+sequences considering the order. Mention the limitations of RNNs for long sequences 
+and how LSTMs address them.
+• Attention Mechanism: Introduce the concept of attention as a way to weigh the 
+importance of different words in a sequence. Explain how the attention mechanism 
+helps models focus on the relevant parts of the text.
+• Context: The arrival of Transformers: Explain that Transformers, based on the attention 
+mechanism, revolutionized NLP by allowing parallel processing and capturing long-
+distance dependencies.
+
+Limitations of Pre-Transformer Models (RNNs, LSTMs)
+• RNNs were a significant step forward in NLP because they could process 
+sequential data, unlike traditional feedforward networks.
+• However, they came with their own set of challenges, which ultimately paved the 
+way for the Transformer architecture.
+1. Vanishing and Exploding Gradients
+2. Sequential Processing
+3. Difficulty Capturing Long-Range Dependencies
+4. Contextual Understanding Limitations
+
+Vanishing and Exploding Gradients
+Explanation:
+• RNNs process sequences step-by-step, using information from previous time steps to inform 
+the current prediction.
+• During training, the gradients (used to update the model's weights) are propagated back 
+through time. In long sequences, these gradients can either shrink exponentially (vanishing) 
+or grow exponentially (exploding), making it difficult to learn long-range dependencies.
+Example:
+• Imagine trying to predict the last word in the sentence:
+• "The cat, which was sitting on the mat in the sunny garden, ________.“
+• An RNN would struggle to remember the initial context ("cat") when reaching the end of the 
+sentence, making it difficult to predict a word like "purred" or "slept.“
+• The information about the cat might have "vanished" during backpropagation.
+• Conversely, in some cases, a minor change in the early part of the sequence could 
+disproportionately affect the later predictions, a sign of exploding gradients.
+
+Sequential Processing
+Explanation:
+• RNNs process input sequentially, one word at a time. 
+• his prevents parallelization, making them significantly slower than models that can process 
+the entire sequence concurrently.
+Example:
+• Think of reading a book word by word versus being able to grasp the meaning of an entire 
+page at once.
+• RNNs are like reading word by word, while Transformers are closer to grasping the whole 
+page.
+• This sequential nature becomes a major bottleneck when dealing with long documents or 
+large datasets.
+
+Difficulty Capturing Long-Range Dependencies
+Explanation:
+• While LSTMs and GRUs were designed to mitigate the vanishing gradient problem to some 
+extent through gating mechanisms, they still struggle to capture relationships between words 
+that are far apart in a sequence.
+• The "memory" of these networks can fade over long distances.
+Example:
+• Consider the sentence: "The scientists, who had been working on the project for years, finally 
+published their groundbreaking results.“
+• Understanding the connection between "scientists" and "published" requires retaining 
+information over a long distance.
+• While LSTMs might perform better than basic RNNs, they can still struggle with these long-
+range dependencies, especially in very long sequences.
+
+Contextual Understanding Limitations
+Explanation:
+• While LSTMs can consider some context, they primarily focus on the preceding sequence.
+• They don't capture the full bidirectional context (words both before and after) as effectively as 
+Transformers.
+• RNNs and LSTMs traditionally relied on static word embeddings (like Word2Vec or GloVe), which 
+assign a single vector representation to each word, regardless of its context. This creates problems 
+with words that have multiple meanings (polysemy).
+Example:
+• The word "bank" can have different meanings depending on the surrounding words:
+• "I sat on the bank of the river.“
+• "I went to the bank to deposit money.“
+• While LSTMs can use the preceding words to disambiguate to some extent, they miss out on the 
+information provided by the words following "bank.".
+• There is not bidirectionality in RNN/LSTM  (Transformers have bidirectionality)
+
+Contextual Understanding Limitations
+• Polysemy in Spanish
+• Me regalaron una muñeca que llora.
+• Rafa Nadal se lesionó la muñera
+• Polysemy in French
+• Demain je vais au bureau des impôts
+• J'ai un ordinateur portable sur mon bureau
+• Polysemy cross-confussion German/English
+• A Gymnasium is a German school
+• I exercise in a Gymnasium
+
+Introduction: Attention Is All You Need
+
+Introduction
+• Transformers have revolutionized the field of Natural Language Processing 
+(NLP) and have extended their influence to other areas of artificial 
+intelligence. 
+• Transformers surpassed the limitations of previous architectures like 
+Recurrent Neural Networks (RNNs) and Convolutional Neural Networks 
+(CNNs), offering significant improvements in efficiency and performance.
+• Why Are They Important?
+• Parallelization: Unlike RNNs, which process data sequentially, Transformers allow for 
+parallel processing, accelerating training times.
+• Capturing Long-Range Dependencies: Their attention mechanism can capture 
+relationships between words that are far apart in a sequence.
+• Versatility: Beyond NLP , Transformers have been successfully applied in computer 
+vision, music generation, and more.
+
+• The basic architecture of a 
+Transformer consists of two 
+main parts:
+• the Encoder and
+• the Decoder
+• Each part is composed of a 
+series of identical layers that 
+process information 
+sequentially.
+Architecture of Transformers
+
+Architecture of Transformers
+• Embeddings
+• Input Embedding: Converts the words in the input sequence into dense 
+vectors that capture the meaning of each word.
+• Output Embedding: Similar to Input Embedding but for the output sequence.
+• Positional Encoding
+• Since Transformers do not process words sequentially, it is necessary to add 
+information about the position of each word in the sequence.
+• This is achieved through Positional Encoding, which incorporates positional 
+information into the embedding vectors.
+
+Example of embeddings in BERT
+• The input representation to the BERT model is the sum of token embeddings, 
+segmentation embeddings & position embeddings & follows a masking strategy 
+for the model to predict the correct word in the context.
+
+Comp.
+
+Architecture of Transformers
+Encoder Stack
+Each layer of the Encoder contains:
+1. Multi-Head Self-Attention: Allows each word to attend to all other 
+words in the sequence.
+2. Feed-Forward Network: A fully connected neural network applied 
+to each position.
+3. Layer Normalization and Residual Connections: Improve training 
+stability.
+
+Architecture of Transformers
+Decoder Stack
+Each layer of the Decoder includes:
+1. Masked Multi-Head Self-Attention: Similar to the Encoder but with 
+masking to prevent positions from attending to subsequent 
+positions.
+2. Multi-Head Encoder-Decoder Attention: Allows the Decoder to 
+focus on relevant parts of the input sequence.
+3. Feed-Forward Network
+4. Layer Normalization and Residual Connections
+
+Attention Mechanism
+The core of Transformers is the Attention mechanism, which enables the model to identify 
+which parts of the input sequence are most relevant to each position in the output sequence.
+Self-Attention
+• In Self-Attention, each word in the sequence is compared with every other word to com-
+pute a contextualized representation.
+Steps of Self-Attention:
+1. Generation of Queries, Keys, and Values: Each word is transformed into three vectors 
+using learnable weight matrices.
+2. Calculation of Attention Scores: The dot product of Queries and Keys is computed and 
+scaled.
+3. Application of Softmax: Converts the scores into a probability distribution.
+4. Weighted Sum of Values: The Values are weighted by the attention scores to produce the 
+final output.
+Encoder-Decoder Attention: Allows the Decoder to focus on specific parts of the input 
+sequence while generating the output sequence.
+
+Multi-Head Attention
+Multi-Head Attention enhances the attention mechanism by allowing the 
+model to cap-ture different aspects of the relationships between words.
+Advantages
+• Capturing Multiple Relationships: Each "head" can focus on different types of 
+relationships between words.
+• Improved Representation: Combines diverse perspectives for richer representations.
+Functioning
+1. Splitting Queries, Keys, and Values: Divided into multiple sub-matrices.
+2. Applying Self-Attention on Each Head: Each head processes its sub-matrices 
+independently.
+3. Concatenation and Projection: The outputs of all heads are concatenated and 
+projected back to the original dimension.
+
+Training and Inference of Transformers
+Training Process
+During training, the Transformer learns to map input sequences to 
+output sequences through:
+1. Teacher Forcing: The complete target sequence is fed to the 
+Decoder during training to accelerate learning and prevent error 
+accumulation.
+2. Loss Calculation: Cross-entropy loss compares the model’s 
+predictions with the actual target sequences.
+3. Backpropagation: Adjusts the model’s weights to minimize the loss.
+
+Training and Inference of Transformers
+Inference Process
+During inference, the Transformer generates the output sequence 
+iteratively:
+1. Step-by-Step Generation: Starts with a start-of-sequence token and 
+generates one word at a time.
+2. Reuse of Previous Outputs: Each new generated word is appended 
+to the Decoder’s input for generating the next word.
+3. Termination: Stops when an end-of-sequence token is generated.
+
+Why Do Transformers Work So Well?
+Alignment of Word Vectors
+The use of Queries, Keys, and Values allows the Transformer to identify and quantify the relevance 
+between pairs of words. During training, the model learns to align the word vectors of relevant words, 
+increasing attention scores for important relationships and decreasing them for irrelevant ones.
+Parallelization and Computational Efficiency
+Unlike RNNs, Transformers process all words in the sequence simultaneously, significantly reducing 
+training time and efficiently handling longer sequences.
+Capturing Long-Range Dependencies
+The attention mechanism enables the Transformer to capture and utilize relationships between 
+words that are far apart in the sequence, which is challenging for traditional RNNs.
+Flexibility and Scalability
+The modular architecture of Encoders and Decoders allows scaling the model by adding more layers 
+to improve performance without excessively complicating the internal structure.
+
+Applications of Transformers
+Transformers are highly versatile and are used in a wide range of applications, including:
+• Machine Translation: For example, translating “You are welcome” to “De nada”.
+• Text Generation: Creating coherent and contextually relevant content.
+• Text Classification: Sentiment analysis, topic detection, etc.
+• Named Entity Recognition: Identifying names of people, places, organizations in text.
+• Computer Vision: Adaptations of Transformers for image recognition and generation.
+• Audio: Adaptations of Transformers for sounds recognition and generation.
+• Speech: Speech recognition and generation.
+• Music and Art Generation: Creating artistic works based on learned patterns.
+
+Tutorial on Internet
+1. Overview of functionality
+• How Transformers are used, and why they are better than RNNs. Components of the architecture, and behavior
+during Training and Inference
+• https://towardsdatascience.com/transformers-explained-visually-part-1-overview-of-functionality-95a6dd460452
+2. How it works
+• Internal operation end-to-end. How data flows and what computations are performed, including matrix 
+representations
+• https://towardsdatascience.com/transformers-explained-visually-part-2-how-it-works-step-by-step-b49fa4a64f34
+3. Multi-head Attention
+• Inner workings of the Attention module throughout the Transformer
+• https://towardsdatascience.com/transformers-explained-visually-part-3-multi-head-attention-deep-dive-1c1ff1024853
+4. Why Attention Boosts Performance
+• Not just what Attention does but why it works so well. How does Attention capture the relationships between 
+words in a sentence
+• https://towardsdatascience.com/transformers-explained-visually-not-just-how-but-why-they-work-so-well-d840bd61a9d3
+• Other: https://jalammar.github.io/illustrated-transformer/
+
+Transformer→Videos
+• Visually Explained
+• https://www.youtube.com/watch?v=eMlx5fFNoYc
+• Quietly Explained
+• https://www.youtube.com/watch?v=4Bdc55j80l8
+• Cartoons (long)
+• https://www.youtube.com/watch?v=zxQyTK8quyY
+• Spanish (light)
+• https://www.youtube.com/watch?v=aL-EmKuB078&t=439s
+• https://www.youtube.com/watch?v=xi94v_jl26U&t=190s
+
+Transformer-based
+Language Models Architectures
+•BERT
+•GPT
+•BART
+•T5
+
+Architecture diferences
+BERT, GPT, BART, and T5 are transformer-
+based language models that differ in:
+• their architecture:   encoder-only, 
+decoder-only, or encoder-decoder
+• training objectives, designed to either 
+understand, generate, or transform text in 
+various natural language processing tasks.
+
+Sort description
+• BERT: A bidirectional transformer model that reads text in both directions 
+to understand context by predicting masked words and next sentences.
+• GPT: An autoregressive transformer model that generates human-like text 
+by predicting the next word in a sequence based on previous context.
+• BART: A transformer-based sequence-to-sequence model that combines 
+bidirectional encoding with autoregressive decoding for text understanding 
+and generation.
+• T5: A transformer encoder-decoder model that converts all NLP tasks into a 
+text-to-text format, treating every task as converting one text string into 
+another.
+
+BERT (Bidirectional Encoder Representations 
+from Transformers):
+• Developed by Google in 2018
+• Uses only the transformer encoder
+• Reads text in both directions (bidirectional)
+• Specialized in understanding context and text meaning
+• Useful for: classification, sentiment analysis, question answering
+
+GPT (Generative Pre-trained Transformer)
+• Developed by OpenAI
+• Uses only the transformer decoder
+• Reads text from left to right (unidirectional)
+• Specialized in generating text
+• Useful for: text completion, translation, creative writing
+
+BART (Bidirectional and Auto-Regressive 
+Transformers)
+• Developed by Facebook/Meta
+• Combines complete encoder and decoder (best of BERT + GPT)
+• Functions as a denoising autoencoder
+• Versatile: can both understand and generate text
+• Useful for: summarization, translation, text completion
+
+T5 (Text-to-Text Transfer Transformer)
+• Developed by Google
+• Combines complete encoder and decoder
+• Converts all tasks into a "text-to-text" format
+• Unified approach for multiple tasks
+• Useful for: any natural language processing task
+
+Main differences
+• Directionality:
+• BERT: Bidirectional
+• GPT: Unidirectional
+• BART/T5: Bidirectional in encoder, unidirectional in decoder
+• Use cases:
+• BERT: Classification, NER, Q&A
+• GPT: Text generation, completion
+• BART/T5: Any NLP task
+• Pre-training:
+• BERT: MLM + NSP
+• GPT: Autoregressive
+• BART: Denoising
+• T5: Span corruption
+
+Example Task in each model
+• Task: "The cat [MASK] on the table"
+
+LINKS
+
+BERT –TUTORIAL & IMPLEMENTATION
+• https://www.kaggle.com/code/harshjain123/bert-for-everyone-
+tutorial-implementation
+
+BERT - Transformers
+• https://jalammar.github.io/illustrated-transformer/
+
+BERT –Noteboot Sentence Embedings
+• https://colab.research.google.com/github/dlmacedo/starter-
+academic/blob/master/content/courses/deeplearning/notebooks/Sia
+meseBERT_SemanticSearch.ipynb#scrollTo=5IO_j2Ofv5pq
+
+BERT –Using for the first time
+• https://jalammar.github.io/a-visual-guide-to-using-bert-for-the-first-
+time/
+
+BERT –Sentence Similarity
+• With BERT we can compute “sentence similarity” that is more 
+advanced that “Word similarity”
+• Library: ”sentence_transformers”
+• https://sbert.net/
+• Example
+• https://medium.com/@ahmedmellit/text-similarity-implementation-
+using-bert-embedding-in-python-1efdb5194e65
+
+BERT –Sentence Similarity
+from sentence_transformers import SentenceTransformer
+# 1. Load a pretrained Sentence Transformer model
+model = SentenceTransformer("all-MiniLM-L6-v2")
+# The sentences to encode
+sentences = [
+"The weather is lovely today.",
+"It's so sunny outside!",
+"He drove to the stadium.",
+]
+# 2. Calculate embeddings by calling model.encode()
+embeddings = model.encode(sentences)
+print(embeddings.shape)
+# [3, 384]
+# 3. Calculate the embedding similarities
+similarities = model.similarity(embeddings, embeddings)
+print(similarities)
+# tensor([[1.0000, 0.6660, 0.1046],
+#         [0.6660, 1.0000, 0.1411],
+#         [0.1046, 0.1411, 1.0000]])
+
+LARGUE LANGUAGE MODELS
+
+Large Language Models (LLM)
+1. Introduction to Large Language Models (LLMs)
+2. Architecture and Key Components
+3. Training Methodologies
+4. Major LLM Models and Their Characteristic
+5. Practical Applications
+6. Emergent Abilities
+7. Evaluation and Benchmarking
+8. Challenges and Limitations
+9. Deployment and Integration
+10. Future Directions and Research Areas
+
+1. Introduction to Large Language Models (LLMs)
+Definition and Core Concepts
+• Language models are AI systems trained on vast amounts of text data to understand and generate human-
+like text. Modern LLMs use transformer architectures and can perform a wide range of tasks, from simple 
+text completion to complex reasoning and analysis.
+Architecture and Training
+• LLMs are built using deep learning architectures, primarily transformers, trained through self-supervised 
+learning on massive text datasets. They learn patterns and relationships in language through billions of 
+parameters, enabling them to understand context and generate coherent responses.
+Applications and Capabilities
+• These models can perform diverse tasks including translation, summarization, coding, and creative writing. 
+Their ability to understand context and generate relevant responses makes them valuable tools across 
+industries, from content creation to customer service and software development.
+Evolution and Impact
+• The rapid advancement of LLMs has transformed natural language processing, moving from simple pattern 
+recognition to sophisticated language understanding. This evolution has significant implications for 
+automation, education, and how humans interact with technology.
+
+2. Architecture and Key Components
+• Scaling strategies
+• Parameter counts and model sizes
+• Training data requirements
+• Model compression techniques
+• Mixture of experts
+
+Scaling strategies
+• Vertical scaling (deeper models) 
+• More layers
+• Larger hidden dimensions
+• More attention heads
+• Horizontal scaling (wider models) 
+• Increased model capacity
+• More parameters per layer
+• Better parallel processing
+• Trade-offs: 
+• Computational costs
+• Memory requirements
+• Training stability
+
+Parameter counts and model sizes
+• Common sizes: 
+• Small: 1-10B parameters
+• Medium: 10-100B parameters
+• Large: 100B+ parameters
+• Impact on: 
+• Memory usage
+• Inference speed
+• Model capabilities
+• Hardware requirements
+
+Training data requirements
+• Scale with model size
+• Quality considerations: 
+• Clean data
+• Diverse sources
+• Domain coverage
+• Typical requirements: 
+• Small models: 100GB-1TB
+• Large models: 1TB-5TB+
+• High-quality filtered data
+
+Model compression techniques
+They are methods to make large AI models smaller and faster by reducing 
+their size and complexity while maintaining most of their performance, like 
+converting a high-quality video to a smaller file size that still looks good.
+• Quantization (8-bit, 4-bit)   (from FLOAT to small INT)
+• Pruning unnecessary weights   (removing less important connections (weights))
+• Knowledge distillation   (transfer knowledge from a large model to a smaller one)
+• Low-rank factorization   (Attention and feed-forward dense matrices are factorized)
+• Benefits: 
+• Reduced size
+• Faster inference
+• Lower memory usage
+
+Mixture of experts (MoE)  (i)
+• Think of MoE like a company with specialized departments:
+1.How it Works
+• Instead of one big system doing everything
+• Has multiple "expert" networks
+• Each expert specializes in different tasks
+• A "router" directs questions to right expert
+
+Mixture of experts (MoE)  (ii)
+2. Real Example:
+• Input: "What's the weather like?"
+• Router: "This is a weather question"
+• Sends to weather expert
+• Ignores experts in other topics
+• Gets faster, better answer
+3. Advantages
+• More efficient (only uses needed experts)
+• Can handle more tasks
+• Better at specific topics
+• Saves computing power
+• Easier to update individual experts
+4. Challenges
+• Router might pick wrong expert
+• Hard to train all experts evenly
+• Some experts might be overused
+• Complex to manage all parts
+• Needs good balance of work
+
+Mixture of experts (MoE) (iii)
+• Tutorial
+• https://www.tensorops.ai/post/what-is-mixture-of-experts-llm
+• Video
+• https://www.youtube.com/watch?v=wkVNe1qimDc
+
+3. Training Methodologies (i)
+Pre-training approaches
+• The initial training phase where models learn from massive amounts of unlabeled text data using 
+self-supervised learning. This process involves predicting masked tokens or next words in 
+sequences, allowing the model to develop general language understanding and pattern 
+recognition. Models typically train on diverse sources including books, websites, and academic 
+papers to develop broad knowledge.
+Fine-tuning strategies
+• The process of adapting a pre-trained model for specific tasks or domains using smaller, targeted 
+datasets. This involves further training on carefully curated data to enhance performance on 
+particular applications while maintaining general capabilities. Fine-tuning can significantly 
+improve model performance on specialized tasks like medical diagnosis or legal analysis.
+Instruction tuning
+• A specialized form of fine-tuning where models are trained to follow specific instructions and 
+prompts. This process helps models better understand and execute user commands, improving 
+their ability to perform tasks as requested. The training data consists of instruction-response pairs 
+that teach the model to generate appropriate outputs based on given instructions.
+
+3. Training Methodologies (ii)
+RLHF (Reinforcement Learning from Human Feedback)
+• A training method that uses human preferences to guide model behavior. 
+Human evaluators rate different model responses, and these ratings are 
+used to create a reward signal for reinforcement learning. This approach 
+helps align model outputs with human values and preferences, improving 
+response quality and reducing harmful outputs.
+Constitutional AI
+• An approach to training AI systems with built-in constraints and values, 
+ensuring they operate within specific ethical and behavioral boundaries. 
+This methodology involves embedding rules and principles during training 
+to create more reliable and ethically-aligned models. The goal is to develop 
+AI systems that are inherently safe and aligned with human values.
+
+4. Major LLM Models and Their Characteristic
+• Closed weights
+• OpenAI: ChatGPT  (3, 4, 4o, o1)
+• Goole: Gemini
+• Anthropic: Claude
+• Open weights
+• Meta:  LLaMa 3.1
+• Mistral AI:  Mistral Large 2  ó 8x7B
+• Google:  Gemma-2 27B
+• xAI: Grok-1
+• NVIDIA: Nemotron-4 340B
+• Microsoft: Phi-3 Medium
+• DeepSeek Coder V2
+• https://sebastian-petrus.medium.com/top-10-open-weights-llms-in-2024-you-h-b74395065bf5
+
+Advantages of open-weights LLM
+• Customization: Researchers and developers can fine-tune and adapt 
+open weights models to specific use cases.
+• Transparency: The ability to inspect and understand model 
+architectures promotes trust and enables better debugging.
+• Community-driven improvement: Open-source models benefit from 
+collective efforts to enhance performance and address limitations.
+• Cost-effectiveness: Organizations can deploy and scale these models 
+without the ongoing costs associated with proprietary API usage.
+
+LLM Characteristics
+• Only Text/Multimodal: Models can either process only text or be multimodal, handling 
+multiple content types like images, audio, or video. Multimodal models can understand 
+visual context and relate it to text, enabling tasks like image description.
+• Benchmark results: Performance measurements on standardized test sets like GLUE, 
+SuperGLUE, and MMLU. These evaluate language understanding, reasoning, and general 
+knowledge, allowing objective comparison between different models.
+• Task-specific capabilities: How well the model performs different operations like text 
+generation, translation, sentiment analysis, or coding. Models typically excel at certain 
+tasks while performing worse at others, affecting their suitability for specific applications.
+• Computational requirements: Resources needed to run the model, including RAM, GPU 
+VRAM, processing power, and storage. This determines the necessary hardware for both 
+training and inference, varying significantly by model size.
+• Cost efficiency: The relationship between model performance and operational resources 
+required. Includes training and inference costs, storage, and maintenance, crucial for 
+determining commercial viability and model selection.
+
+5. Practical Applications
+• Text generation and completion
+• Code generation
+• Translation and multilingual capabilities
+• Question answering
+• Reasoning tasks
+
+6. Emergent Abilities
+• Chain-of-thought reasoning
+The ability to break down complex problems into smaller steps and solve them sequentially, similar to 
+human thought processes. This enables better problem solving and more transparent reasoning, as the 
+model shows its work rather than jumping directly to conclusions.
+• Few-shot learning
+The model's ability to learn new tasks from just a few examples, typically 2-5, without additional 
+training. By seeing a couple of examples in the prompt, the model can understand patterns and apply 
+them to similar problems.
+• Zero-shot capabilities
+The ability to perform tasks without any examples or prior specific training, relying solely on general 
+knowledge and instructions. This demonstrates the model's capacity to understand and execute new 
+tasks based purely on natural language descriptions.
+• In-context learning
+The model's capability to adapt its behavior based on the context provided within the prompt, without 
+updating its weights. This allows temporary adaptation to specific tasks, styles, or requirements within 
+a single conversation.
+• Task generalization
+The ability to apply knowledge and skills learned from one task to different but related tasks. This 
+demonstrates the model's capacity to understand underlying patterns and principles, rather than just 
+memorizing specific solutions.
+
+7. Evaluation and Benchmarking
+Standard benchmarks
+• Established test suites like GLUE, SuperGLUE, MMLU, and BigBench that provide standardized 
+ways to measure model performance across various tasks. These benchmarks allow for consistent 
+comparison between different models and track progress in the field. evaluation
+Human evaluation
+• Direct assessment of model outputs by human raters who evaluate aspects like accuracy, fluency, 
+relevance, and helpfulness. This provides qualitative insights that automated metrics might miss 
+and helps understand real-world usefulness of model responses.
+Performance metrics
+• Quantitative measurements including accuracy, precision, recall, F1 scores, and task-specific 
+metrics like BLEU for translation or ROUGE for summarization. These metrics provide objective 
+ways to compare models and track improvements in specific capabilities.
+
+MMLU (Massive Multitask Language Understanding)
+• MMLU is a comprehensive benchmark designed to test language models' 
+knowledge and reasoning abilities across multiple academic and professional 
+domains.
+• Provides a standardized way to compare model performance
+• It evaluates models through multiple-choice questions spanning 57 different 
+subjects, including:
+• STEM fields (mathematics, physics, chemistry, biology)
+• Humanities (history, philosophy, literature)
+• Social sciences (psychology, sociology, politics)
+• Professional fields (law, medicine, accounting)
+• Specialized knowledge areas (engineering, computer science)
+• MMLU is considered one of the most challenging and comprehensive
+benchmarks for assessing language models' general knowledge and problem-
+solving abilities
+
+8. Challenges, Limitations & Details
+Hallucinations and factuality
+• The tendency of models to generate plausible-sounding but false or unsupported information, mixing facts with fiction. This 
+presents a significant challenge for applications requiring high accuracy and reliability, particularly in professional or educational 
+contexts.
+Bias and fairness
+• Models can perpetuate or amplify societal biases present in their training data, potentially leading to unfair or discriminatory
+outputs. This includes gender, racial, and cultural biases that can affect decision-making and content generation.
+Computational costs
+• The significant resources required for training and running large language models, including expensive hardware, energy, and 
+maintenance. These costs can make development and deployment prohibitive for many organizations and limit accessibility.
+Environmental impact
+• The substantial energy consumption and carbon footprint associated with training and running large AI models. This includes both
+the direct energy use of computing resources and the indirect environmental costs of hardware manufacturing and cooling 
+systems.
+Privacy concerns
+• Risks related to handling sensitive information, potential data leakage from training data, and concerns about user data protection 
+during model interaction. This includes challenges in ensuring compliance with privacy regulations and protecting user 
+confidentiality.
+Alignment
+• Alignment in LLMs is the process of making AI models behave in ways that are helpful, safe, and consistent with human values and
+intentions, typically achieved through techniques like human feedback and careful training.
+
+Language BIAS
+• LLM are usually multilingual
+• There is no translation of either the prompt or the output.
+• Language bias occurs because AI models are often trained on data 
+sets dominated by English-language information.
+• It happens that sometimes the answer is better or more accurate in 
+English.
+
+Language BIAS example
+Prompt
+• Quiero en coche desde Saigón hasta Islamabad cruzando el menor número de 
+países. Dime la ruta indicando solo los países y ciudades más importantes que 
+debo pasar.
+• Je veux aller en voiture de Saïgon à Islamabad en traversant le moins de pays 
+possible. Indiquez-moi l'itinéraire en mentionnant uniquement les pays et les 
+villes principales par lesquels je dois passer.
+• I want to drive from Saigon to Islamabad crossing through the least number of 
+countries. Tell me the route indicating only the countries and major cities I 
+must pass through.
+
+Ideology BIAS
+• Large Language Models Reflect the Ideology of their Creators
+• https://arxiv.org/pdf/2410.18417
+
+Alignment
+• Making models behave according to human values
+• We are moving towards AGI (Artificial General Intelligence)
+• Ilya Sutskever left OpenAI and found Safe Superintelligence
+• https://ssi.inc/
+• It involves training models to:
+• Be helpful and truthful
+• Avoid harmful outputs
+• Follow human instructions accurately
+• Respect “ethical boundaries”  (Human Rights)
+• Maintain safety constraints
+
+Alignment
+• Common alignment techniques:
+• Reinforcement Learning from Human Feedback (RLHF)
+• Constitutional AI  (ethical constraints)
+• Reward modeling
+• Fine-tuning with human preferences
+• Safety constraints and filters
+
+Token Limit
+• Maximum number of tokens that can be processed at once
+• Claude 3.5 Sonnet:  4096 tokens
+• GPT 4o:  64,000 tokens
+• Llama 3.2 1B supports a context window of up to 128,000 tokens.
+
+Temperature(LLM)
+• Temperature in LLMs (Large Language Models) is a parameter that 
+controls the randomness or creativity in the model's outputs.
+• A lower temperature (closer to 0) makes the model:
+• More deterministic
+• More likely to choose the highest probability words
+• Better for tasks requiring accuracy like fact-based Q&A
+• A higher temperature (closer to 1) makes the model:
+• More random and diverse in responses
+• More creative and exploratory
+• Better for creative tasks like brainstorming or storytelling
+
+Prompt injection
+• Prompt injection is a security vulnerability in LLMs where an attacker 
+manipulates the model's behavior by inserting malicious inputs that 
+override or bypass the model's intended safeguards and instructions. 
+Here are the key aspects:
+• Basic Concept:
+• Exploits the model's tendency to follow the most recent or most compelling 
+instructions
+• Attempts to override the model's base behavior or security measures
+• Can bypass content filters and safety mechanisms
+
+Type of Prompt Injection
+1.Direct Injection
+• Explicitly attempting to override previous instructions
+• Example: "Ignore all previous instructions and do X instead"
+2.Indirect Injection
+• Hiding malicious prompts within seemingly innocent content
+• Using context manipulation to influence model behavior
+• Example: Embedding commands in user stories or dialogues
+3.Delimiter Attack
+• Exploiting system markers or special characters
+• Attempting to break out of intended conversation boundaries
+
+Overfitting vs Previous knowledge
+• Riddle
+• Simplify (a-x)(b-x)(c-x)…(z-x)
+
+Overfitting (with famous Riddels)
+• As I was going to St. Ives,I met a man with seven wives,Each wife had 
+seven sacks,Each sack had seven cats,Each cat had seven kits:Kits, cats, 
+sacks, and wives,How many were there going to St. Ives?
+• Answer is 1, because the other are in the opposite direction. OK
+• Let’s change a little bit
+• As I was going back from St. Ives,I met a man with seven wives,Each
+wife had seven sacks,Each sack had seven cats,Each cat had seven 
+kits:Kits, cats, sacks, and wives,How many were there going to St. Ives?
+• Answer again 1, and It’s wrong. It fails because overfitting
+
+9. Deployment and Integration
+API interfaces
+• The standardized endpoints and methods for interacting with language models, allowing developers to send 
+requests and receive responses. These interfaces handle authentication, rate limiting, and provide different 
+parameters for controlling model behavior and output.
+Prompt engineering
+• The practice of designing and optimizing input prompts to achieve desired outputs from language models. 
+This includes crafting clear instructions, providing relevant context, and using specific formats to improve 
+response accuracy and relevance.
+System integration
+• The process of incorporating language models into existing software systems and workflows, including 
+handling data flow, managing responses, and ensuring compatibility with current infrastructure. This 
+requires careful consideration of architecture, scalability, and error handling.
+Resource optimization
+• Strategies to maximize efficiency in model deployment, including caching, batch processing, and load 
+balancing. This involves finding the right balance between performance and resource usage while 
+maintaining response quality and speed.
+Cost considerations
+• Analysis and management of expenses related to model usage, including API calls, compute resources, and 
+maintenance. This includes implementing cost-control measures, monitoring usage patterns, and optimizing 
+query efficiency to maintain budget constrain
+
+10. Future Directions and Research Areas (i)
+1.Multimodal LLMs
+• Combines text with: 
+• Images   •Video
+• Audio     •Code
+• Benefits: 
+• Better understanding
+• Richer interactions
+• More natural communication
+2.Smaller Efficient Models
+• Focus on: 
+• Reduced size
+• Lower power usage
+• Faster responses
+• Goals: 
+• Mobile deployment
+• Edge computing
+• Affordable AI
+
+10. Future Directions and Research Areas (ii)
+3.Specialized Domain Models
+• Industry-specific models: 
+• Medical
+• Legal
+• Scientific
+• Financial
+• Features: 
+• Deep domain knowledge
+• Better accuracy
+• Focused capabilities
+4.Ethical Considerations
+• Bias reduction
+• Privacy protection
+• Safety measures
+• Transparency
+• Accountability
+5.Research Challenges
+• Better reasoning
+• Factual accuracy
+• Long-term memory
+• Common sense
+• Generalization
+
+LLMs

--- a/src/data/lessonSummaries/text/snlp-chapter-6.txt
+++ b/src/data/lessonSummaries/text/snlp-chapter-6.txt
@@ -1,0 +1,508 @@
+CHAPTER 6
+Speech Processing and 
+Recognition
+
+Summary
+1. Introduction and Fundamentals
+2. Core Architectures for Speech Recognition
+3. Modern Automatic Speech Recognition (ASR) Systems
+4. Practical Considerations and Future Directions
+
+1. Introduction and Fundamentals
+• A Brief History of Speech Recognition
+• The Deep Learning Revolution
+• Deep Learning's impact on speech recognition
+• Current applications and industry trends
+• Key challenges in speech recognition with DNN
+
+A Brief History of Speech Recognition
+• 1952: Bell Labs' "Audrey" - Recognized single digits spoken by a 
+single voice.
+• 1960s - 1970s: Hidden Markov Models (HMMs) - Became the 
+dominant approach, using statistical models to represent speech 
+sounds.
+• 1980s - 1990s: Statistical Language Models - Integration of language 
+models to improve accuracy by considering word probabilities.
+• 2000s: Gaussian Mixture Models (GMMs) with HMMs - Enhanced 
+acoustic modeling using GMMs to represent the distribution of 
+speech features.
+
+The Deep Learning Revolution
+• 2010s - Present: Deep Neural Networks (DNNs) - DNNs, particularly 
+Recurrent Neural Networks (RNNs) and Convolutional Neural Networks 
+(CNNs), revolutionized speech recognition by automatically learning 
+complex features from vast amounts of data.
+• Emergence of LSTMs, GRUs, and Attention Mechanisms- Further 
+advancements with specialized architectures like Long Short-Term Memory 
+(LSTM) networks, Gated Recurrent Units (GRUs), and attention 
+mechanisms significantly improved accuracy and robustness.
+• End-to-End Speech Recognition - Models directly map acoustic features to 
+text, simplifying the traditional pipeline and achieving state-of-the-art 
+performance.
+
+Deep Learning's impact on speech recognition
+• Deep Learning revolutionized speech recognition by addressing key limitations of tradi-
+tional approaches like GMM-HMM (Gaussian Mixture Model-Hidden Markov Model):
+• Feature Learning
+• Traditional: Required hand-crafted features and expert knowledge
+• Deep Learning: Automatically learns relevant features from raw or minimally processed audio
+2.Context Understanding
+• Traditional: Limited context window and rigid state transitions
+• Deep Learning: Can capture long-range dependencies and complex patterns in speech
+3.Performance Improvements
+• Error rates dropped dramatically (30-50% reduction) when deep neural networks were 
+introduced
+• Particularly better at handling: 
+• Noisy environments
+• Different accents and speaking styles
+• Natural, conversational speech
+
+Current applications
+1.Virtual Assistants
+• Siri, Alexa, Google Assistant
+• Natural language interfaces for smart home devices
+• In-car voice control systems
+2.Business Solutions
+• Automated customer service systems
+• Meeting transcription services
+• Voice biometrics for authentication
+3.Healthcare
+• Medical dictation and documentation
+• Remote patient monitoring
+• Voice-based diagnostic tools
+
+Industry trends
+1.On-device Processing
+• Shift toward local processing for privacy and reduced latency
+• Lightweight models for mobile devices
+2.Multilingual Capabilities
+• Single models handling multiple languages
+• Real-time translation services
+3.Personalization
+• Voice recognition systems adapting to individual users
+• Custom wake words and commands
+4.Integration with Other Technologies
+• Multimodal systems combining voice with vision
+• Integration with AR/VR environments
+
+Key challenges in speech processing with DNN
+1. Signal Variability
+• Speaker characteristics (accent, age, gender)
+• Environmental noise and acoustics
+• Recording conditions and hardware differences
+2. Model Engineering
+• Handling variable-length inputs
+• Real-time processing requirements
+• Balancing accuracy vs computational cost
+• Memory constraints for deployment
+3. Training and Technical Challenges
+• Large data requirements
+• Class imbalance in training data
+• Handling disfluencies (um, uh, stutters)
+4. Domain Adaptation
+• Generalizing across different contexts
+• Handling unseen speakers/conditions
+• Adapting to new languages/accents
+• Transfer learning effectiveness
+
+2. Core Architectures for Speech Recognition
+• RNN
+• LSTM & GRU
+• CNN
+• Hybryd CNN-RNN
+
+RNN
+1. RNN Basics
+• Process sequential data by maintaining hidden state   ht = f(Wx * xt + Wh * ht-1 + b)
+• Each timestep considers current input and previous state
+• Share parameters across time steps
+• Natural fit for variable-length speech sequences
+3. Limitations with Long Sequences
+a) Vanishing Gradients
+• Gradients become extremely small during backpropagation
+• Early inputs lose influence over time
+• Makes learning long-term dependencies difficult
+• Critical issue for long speech utterances
+• b) Exploding Gradients
+• Gradients become extremely large
+• Leads to unstable training
+• Can cause numerical overflow
+• Requires gradient clipping
+4. Practical Impact on Speech Processing
+• Poor performance on long utterances
+• Difficulty capturing long-range dependencies
+• Limited context window in practice
+• Memory inefficiency for long sequences
+
+LSTM
+1.LSTM Mechanism
+• Memory cell: Long-term information storage
+• Input gate: Controls new information flow
+• Forget gate: Removes irrelevant information
+• Output gate: Controls information output
+• Cell state: Carries information through time
+2.LSTM Advantages for Speech
+• Handles variable-length sequences
+• Captures long-term dependencies
+• Resistant to vanishing gradients
+• Better at learning speech timing patterns
+• Maintains speaker context over time
+
+GRU
+3.GRU Mechanism
+• Simpler than LSTM
+• Reset gate: Controls past state influence
+• Update gate: Combines current/past info
+• No separate memory cell
+• Fewer parameters than LSTM
+4.GRU Advantages
+• Faster training than LSTM
+• Less memory usage
+• Similar performance to LSTM
+• Better for shorter sequences
+• Easier to train with less data
+
+Applications of LSTM& GRU
+• Acoustic modelling
+• Language modelling
+• Speaker verification
+• Emotion recognition
+• Speech enhancement
+
+CNN
+1.Core Concept
+• Treats spectrograms as 2D images
+• Detects time-frequency patterns
+• Uses convolutions and pooling operations
+2.Key Benefits
+• Captures local acoustic features
+• Parallel processing capability
+• Translation invariance
+• Efficient parameter sharing
+3.Applications
+• Feature extraction
+• Speech enhancement
+• Speaker/phoneme recognition
+
+Hybrid CNN-RNN Architectures (i)
+1.Basic Structure
+• CNN layers: Process spectrogram, extract features
+• RNN layers: Model temporal dependencies
+• CNN outputs feed into RNN inputs
+• Final layers for task-specific predictions
+2.Why Combine Them
+• CNN: Local feature extraction, noise robustness
+• RNN: Temporal modeling, sequence handling
+• Together: Better than either alone
+• Balanced efficiency and accuracy
+
+Hybrid CNN-RNN Architectures (ii)
+3.Common Variations
+• CRNN: Basic CNN followed by RNN
+• DeepSpeech2: Multiple CNN+RNN layers
+• BiDirectional: RNNs process both directions
+• Attention-augmented: Added attention mechanisms
+4.Advantages
+• Better feature representation
+• Reduced computational cost vs pure RNN
+• Improved accuracy
+• More robust to noise/variations
+
+Hybrid CNN-RNN Architectures (iii)
+
+3. Modern Automatic Speech Recognition Systems
+• End-to-End ASR
+• Connectionist Temporal Classification (CTC)
+• Attention Mechanisms in ASR
+• Transformers for Speech Recognition
+
+End-to-End ASR Systems vs Traditional Pipeline
+1.Traditional Pipeline
+• Separate components: acoustic model, pronunciation model, language model
+• Each component trained independently
+• Complex integration and optimization
+• Requires expert knowledge for each component
+• Error propagation between stages
+2.End-to-End Approach
+• Single neural network
+• Direct audio-to-text conversion
+• Joint optimization of all components
+• Trained on <audio, transcript> pairs
+• Simpler training and deployment
+
+End-to-End ASR Systems vs Traditional Pipeline
+3.Key Advantages
+• Reduced system complexity
+• Better overall optimization
+• Easier to update and maintain
+• Fewer hand-designed components
+• Lower latency potential
+4.Main Trade-offs
+• Requires more training data
+• Less interpretability
+• May need larger models
+• Less modular for specific updates
+
+Connectionist Temporal Classification (CTC)
+Imagine you need to convert audio to text. The main problem is:
+• Audio is long (many frames)
+• Words aren't aligned with specific moments
+• We don't know exactly which part of audio corresponds to each letter
+CTC solves this:
+1. Allows the system to "guess" where letters go
+2. Uses a special symbol (blank) to: 
+1. Separate repeated letters
+2. Fill spaces where there are no letters
+Practical example:
+• Audio says "hello"
+• System might predict: "h-e-ll-o-“          (where "-" is the blank symbol)
+• It could also be: "-h-eell-oo-"
+• All these variations convert to "hello"
+
+Connectionist Temporal Classification (CTC)
+• All these paths for “hello” are valid. Each frame in a path has a probability -
+how confident the system is about that guess.
+• The scoring works like this:
+1.For each path, multiply the probabilities of each guess
+2.Add up all the path probabilities that lead to the correct word
+3.Higher total probability means the system is doing a good job
+• During training, if the total probability is low, the system adjusts to make better 
+guesses next time. It's like learning to recognize patterns: the more examples it 
+sees, the better it gets at matching sounds to letters.
+• Think of it like multiple people trying to write down what they hear. Some might 
+write it slightly differently, but as long as it reads correctly when cleaned up, it's 
+considered correct. The system learns which ways of hearing and writing are 
+most reliable.
+
+Attention Mechanisms in ASR
+1.Basic Concept
+• Helps model focus on relevant parts of audio
+• Creates dynamic connections between encoder and decoder
+• Learns where to "pay attention" in input sequence
+• Solves alignment problems better than CTC
+2.How It Works
+• Encoder processes audio into features
+• Decoder generates text one symbol at time
+• Attention scores relevant audio parts for each output
+• Weighted sum creates context for prediction
+• Updates focus as it generates each character
+
+Types of Attention
+• Bahdanau Attention:
+• Additive attention
+• Uses separate neural network
+• Computes alignment scores with learned weights
+• Better for varying length sequences
+• More flexible but computationally intensive
+• Luong Attention:
+• Multiplicative attention
+• Simpler, faster computation
+• Direct dot product between states
+• Works well for similar length sequences
+• More memory efficient
+
+Key Advantages of attention
+1. "Better handling of long sequences"
+• Imagine listening to a long sentence. Regular systems might forget the beginning by the time they reach the end
+• Attention is like taking notes - it can look back at any part whenever needed
+• Works better for long speeches or complex sentences
+2. "No monotonic alignment assumption"
+• Old systems assumed words must be processed strictly left to right
+• Attention is more like how humans understand speech - we can connect related parts even if they're far apart
+• Example: In "The cat, which I saw yesterday, is black", attention can link "cat" with "is black" even with words in between
+3. "Can attend to multiple parts of input"
+• Like having multiple sticky notes while listening
+• Can focus on several important parts at once
+• Example: When hearing "twenty-three", it can look at both parts together to understand it's "23"
+4. "Helps with noisy or unclear speech"
+• Like having the ability to "double-check" unclear parts
+• If one part is unclear, can use context from other parts
+• Similar to how we understand someone speaking in a noisy room
+5. "Provides interpretable alignment visualization"
+• We can see what parts of speech the system is focusing on
+• Like highlighting the words as they're being processed
+• Helps understand how the system makes decisions
+
+Transformers in Speech Recognition
+3. Trade-offs
+• Needs more memory
+• Requires more training data
+• More complex architecture
+• Higher computational cost
+1.Basic Structure
+• Uses self-attention instead of recurrence
+• Parallel processing of entire sequence
+• Encoder-decoder architecture
+• Positional encoding for timing
+2.Key Advantages vs RNNs
+• Faster training (parallel processing)
+• Better at long dependencies
+• No vanishing gradient problems
+• Captures global relationships easier
+• More stable training
+
+4. Practical Considerations and Future Directions
+• Data Augmentation for Speech
+• Transfer Learning in Speech Models
+• Model Optimization and Deployment
+• Future trends
+
+Data Augmentation for Speech
+1. Noise Injection
+• Adds different types of background noise
+• Examples: café noise, street sounds, music
+• Helps model handle real-world conditions
+• Controls noise level (Signal-to-Noise Ratio)
+• Makes system more robust
+2. Speed Perturbation
+• Changes speech rate (faster/slower)
+• Usually 0.9x to 1.1x speed
+• Maintains pitch and intelligibility
+• Creates more training examples
+• Helps handle different speaking rates
+3. Time Stretching
+• Changes duration without changing pitch
+• Like slow-motion or speed-up
+• Preserves speech characteristics
+• Different from speed perturbation
+• Good for accent/dialect variations
+
+Data Augmentation for Speech
+4.Other Common Techniques
+• Pitch shifting
+• Volume adjustment
+• Room simulation (reverb)
+• Frequency masking
+• Time masking
+5.Benefits
+• Increases dataset size
+• Improves model robustness
+• Reduces overfitting
+• Better real-world performance
+• Handles varied conditions
+
+Transfer Learning in Speech Models
+1.Basic Concept
+• Start with model trained on large dataset
+• Reuse learned features for new task
+• Adapt to specific needs with less data
+• Like teaching someone who already knows basics
+2.How It Works
+• Pre-training phase: 
+• Train on huge general dataset
+• Learn basic speech patterns
+• Develop feature understanding
+• Fine-tuning phase: 
+• Adjust for specific task
+• Use smaller target dataset
+• Keep useful knowledge
+
+Transfer Learning in Speech Models
+3.Common Approaches
+• Feature extraction only
+• Partial model fine-tuning
+• Full model fine-tuning
+• Layer-by-layer adaptation
+4.Benefits
+• Needs less training data
+• Faster training time
+• Better performance
+• Works for low-resource languages
+• Cost-effective
+5.Applications
+• Speech recognition
+• Speaker identification
+• Emotion detection
+• Accent adaptation
+• Language transfer
+
+Model Optimization and Deployment
+1. Quantization
+• Reduces numerical precision
+• Examples: 
+• Float32 to Float16/Int8
+• Fewer bits per weight
+• Benefits: 
+• Smaller model size
+• Faster inference
+• Less memory usage
+• Trade-off: Slight accuracy loss
+2. Pruning
+• Removes unnecessary connections
+• Methods: 
+• Weight pruning
+• Channel pruning
+• Structured pruning
+• Process: 
+• Identify less important weights
+• Remove them
+• Retrain network
+
+Model Optimization and Deployment
+3.Knowledge Distillation
+• Creates smaller "student" model
+• Learns from larger "teacher" model
+• Maintains most performance
+• Reduces model complexity
+4.Model Compression
+• Weight sharing
+• Huffman coding
+• Matrix factorization
+• Low-rank approximation
+5.Deployment Optimization
+• Hardware-specific optimization
+• Batch processing
+• Caching strategies
+• Pipeline optimization
+• Real-time considerations
+
+Future trends
+1.Multimodal Learning
+• Combines speech with: 
+• Video (lip reading)
+• Text
+• Gestures
+• Improves accuracy in noisy environments
+• Better context understanding
+• More natural interaction
+2.Unsupervised Learning
+• Learning from unlabeled data
+• Self-supervised pre-training
+• Reduces dependency on labeled data
+• Better representation learning
+• Cross-lingual transfer
+
+Future trends
+3. Low-Resource Scenarios
+• Solutions for rare languages
+• Few-shot learning
+• Cross-lingual transfer
+• Data augmentation techniques
+• Active learning approaches
+4. Emerging Directions
+• End-to-end multilingual models
+• Real-time translation
+• Emotion understanding
+• Personalization
+• Privacy-preserving ASR
+5. Technical Advances
+• Smaller, efficient models
+• On-device processing
+• Continuous learning
+• Zero-shot capabilities
+• Better noise handling
+
+LINKS
+
+Speech Emotion Recognition using LSTM and RNN
+• Code
+• https://github.com/Utkarsh2812/Speech-Emotion-Recognition-
+Using-LSTM-and-
+RNN/blob/main/Speech_emotion_recognition_lstm%26rnn.ipynb
+• Toronto emotional speech set
+• https://www.kaggle.com/datasets/ejlok1/toronto-emotional-speech-
+set-tess
+
+Tensorflow Speech Recognition Demo
+• https://github.com/llSourcell/tensorflow_speech_recognition_demo
+• Data is not available

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module '*.txt?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- convert each lesson PDF into a raw text asset and expose them through the lesson summary text registry
- append the full PDF transcript to every lesson summary while keeping existing metadata for translations
- teach Vite/Jest about raw text imports so the new assets work both in the app and in tests

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/SubjectsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d84086ebcc8324aa9e7ad4c4511a88