### PR TITLE
Exclude test files from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,12 @@
     }
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/__tests__",
+    "src/**/__tests__"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude TypeScript test files and directories from the build configuration so runtime-only builds do not need test dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8438a1f908324ab11f47915b566c6