### PR TITLE
Fix copy issues in dashboard and subject catalog

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -156,7 +156,7 @@ export const Dashboard: React.FC = () => {
       await handleCopySummary();
       return;
     }
-    const summary = `Study Spanish Coach recap\nMastery: ${progress.toFixed(1)}%\nStreak: ${snapshot.streak.current} days\nWeakest tag: ${
+    const summary = `Study Compass recap\nMastery: ${progress.toFixed(1)}%\nStreak: ${snapshot.streak.current} days\nWeakest tag: ${
       snapshot.weakestTags[0]?.tag ?? 'N/A'
     }\nDue flashcards: ${snapshot.srs.dueNow}`;
     try {

--- a/src/data/lessonSummaries/sad-session-1.ts
+++ b/src/data/lessonSummaries/sad-session-1.ts
@@ -3,9 +3,9 @@ import { LessonSummaryContent } from '../../types/subject';
 export const sadSession1Summary: LessonSummaryContent = {
   summary: {
     original:
-      'Contrastamos monolitos y sistemas distribuidos, identificamos drivers arquitectónicos y repasamos cómo la concurrencia, la tolerancia a fallos y la escalabilidad afectan al diseño.',
+      'Contrastamos monolitos y sistemas distribuidos, realizamos la identificación de drivers arquitectónicos y repasamos cómo la concurrencia, la tolerancia a fallos y la escalabilidad afectan al diseño.',
     english:
-      'We contrasted monoliths with distributed systems, catalogued architectural drivers (drivers arquitectónicos), and reviewed how concurrency (concurrencia), fault tolerance (tolerancia a fallos), and scalability (escalabilidad) shape the design choices.',
+      'We contrasted monoliths with distributed systems, we catalogued architectural drivers (drivers arquitectónicos), and reviewed how concurrency (concurrencia), fault tolerance (tolerancia a fallos), and scalability (escalabilidad) shape the design choices.',
   },
   translation: {
     status: 'partial',

--- a/src/data/subjectCatalog.ts
+++ b/src/data/subjectCatalog.ts
@@ -80,7 +80,7 @@ export const subjectCatalog: SubjectSummary[] = [
             title: 'Sesión 3 · Modelos de servicio en la nube',
             language: 'es',
             ...getLessonContent('sad-session-3'),
-            tags: ['cloud', 'governanza'],
+            tags: ['cloud', 'gobernanza'],
             estimatedMinutes: withMinutes(85),
             dueDate: toIsoDate(12),
             status: 'scheduled',


### PR DESCRIPTION
## Summary
- update the dashboard share summary to use the Study Compass name
- correct the governance tag spelling in the distributed applications subject metadata
- tweak the bilingual session summary so the English and Spanish copy match the expected phrasing

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dad0c0f1248324a47769695d1bb9e6