### PR TITLE
Fix lesson figures layout on subjects page

### DIFF
--- a/src/components/lessonFigures/dbdTema1.tsx
+++ b/src/components/lessonFigures/dbdTema1.tsx
@@ -72,6 +72,13 @@ const svgBase = (
   options: { width?: number; height?: number } = {}
 ) => {
   const { width = 720, height = 360 } = options;
+  const svgStyle: React.CSSProperties = {
+    display: 'block',
+    width: `${width}px`,
+    minWidth: `${width}px`,
+    height: `${height}px`,
+    minHeight: `${height}px`,
+  };
   return (
     <svg
       role="img"
@@ -79,6 +86,8 @@ const svgBase = (
       viewBox={viewBox}
       width={width}
       height={height}
+      preserveAspectRatio="xMidYMid meet"
+      style={svgStyle}
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>

--- a/src/components/lessonFigures/shared.tsx
+++ b/src/components/lessonFigures/shared.tsx
@@ -56,6 +56,14 @@ export const createDiagram = (
     nodes.map((node) => [node.id, { ...node, width: node.width ?? 170, height: node.height ?? 90 }])
   );
 
+  const svgStyle: React.CSSProperties = {
+    display: 'block',
+    width: `${width}px`,
+    minWidth: `${width}px`,
+    height: `${height}px`,
+    minHeight: `${height}px`,
+  };
+
   return (
     <svg
       role="img"
@@ -63,6 +71,8 @@ export const createDiagram = (
       viewBox={`0 0 ${width} ${height}`}
       width={width}
       height={height}
+      preserveAspectRatio="xMidYMid meet"
+      style={svgStyle}
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>

--- a/src/pages/SubjectsPage.module.css
+++ b/src/pages/SubjectsPage.module.css
@@ -361,18 +361,37 @@
   gap: 8px;
 }
 
-.contentFigure img {
-  width: 100%;
+.contentFigureMedia {
+  position: relative;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  border-radius: 12px;
+  padding-bottom: 4px;
+}
+
+.contentFigureMedia::-webkit-scrollbar {
+  height: 8px;
+}
+
+.contentFigureMedia::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.35);
+  border-radius: 999px;
+}
+
+.contentFigureMedia > svg,
+.contentFigureMedia > img {
+  display: block;
   border-radius: 10px;
   box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
 }
 
-.contentFigure svg {
+.contentFigureMedia > svg {
+  background: #ffffff;
+}
+
+.contentFigureMedia > img {
   width: 100%;
   height: auto;
-  border-radius: 10px;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
-  background: #ffffff;
 }
 
 .contentFigureCaption {

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -286,7 +286,7 @@ const SubjectsPage: React.FC = () => {
 
             return (
               <figure key={index} className={styles.contentFigure}>
-                {figureContent}
+                <div className={styles.contentFigureMedia}>{figureContent}</div>
                 {block.caption && <figcaption className={styles.contentFigureCaption}>{block.caption}</figcaption>}
               </figure>
             );


### PR DESCRIPTION
## Summary
- ensure inline lesson diagrams render at their intended width with preserved aspect ratio
- wrap lesson figures in a scrollable container so wide diagrams no longer collapse inside content blocks
- add horizontal scrollbar styling for the figure container so overflow is obvious when needed

## Testing
- Manual tests: Viewed lesson figures in the Subjects page

------
https://chatgpt.com/codex/tasks/task_e_68daf08744e483248b760d745052b1b5