### PR TITLE
Fix TypeScript build error in lesson diagram component

### DIFF
--- a/src/components/lessonFigures/shared.tsx
+++ b/src/components/lessonFigures/shared.tsx
@@ -205,7 +205,6 @@ export const createDiagram = (
               height={node.height - contentPadding * 2}
             >
               <div
-                xmlns="http://www.w3.org/1999/xhtml"
                 style={{
                   display: 'flex',
                   flexDirection: 'column',


### PR DESCRIPTION
## Summary
- remove the invalid `xmlns` attribute from the foreignObject div in the lesson diagram renderer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db0250c1ec8324853ce0a931388138