### PR TITLE
Fix diagram overflow and spacing

### DIFF
--- a/src/components/lessonFigures/dbdTema1.tsx
+++ b/src/components/lessonFigures/dbdTema1.tsx
@@ -282,7 +282,7 @@ export const dbdTema1Figures: Record<string, FigureRenderer> = {
           width: 160,
           height: 120,
           title: '1. Usuario',
-          lines: ['INSERT / UPDATE / DELETE'],
+          lines: ['INSERT', 'UPDATE', 'DELETE'],
           fill: '#ede9fe',
         })}
         {createLabeledBox({
@@ -291,7 +291,7 @@ export const dbdTema1Figures: Record<string, FigureRenderer> = {
           width: 160,
           height: 120,
           title: '2. Traducción',
-          lines: ['Esquemas externo/lógico/físico'],
+          lines: ['Esquemas externo', 'lógico/físico'],
         })}
         {createLabeledBox({
           x: 390,


### PR DESCRIPTION
## Summary
- auto-resize generated lesson diagrams so wide pipelines keep every node in view
- split long labels in the DBD update flow diagram to avoid text spilling outside boxes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db0479e188832488efb39509df7333