### PR TITLE
Fix TypeScript typing issues in notebook parsing and Subjects page

### DIFF
--- a/src/data/notebookRegistry.ts
+++ b/src/data/notebookRegistry.ts
@@ -101,8 +101,8 @@ const toNotebookCells = (raw: string): NotebookCell[] => {
             : [];
 
           const formattedOutputs = outputs
-            .map((value) => String(value).trimEnd())
-            .filter((value) => value.length > 0);
+            .map((value: unknown) => String(value).trimEnd())
+            .filter((value: string) => value.length > 0);
 
           return {
             id: baseId,
@@ -114,7 +114,7 @@ const toNotebookCells = (raw: string): NotebookCell[] => {
 
         return null;
       })
-      .filter((cell): cell is NotebookCell => cell !== null);
+      .filter((cell: NotebookCell | null): cell is NotebookCell => cell !== null);
   } catch (error) {
     console.warn('Failed to parse notebook', error);
     return [];

--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -9,6 +9,8 @@ import { LessonFigure } from '../components/lessonFigures';
 import InlineMarkdown from '../components/InlineMarkdown';
 import NotebookPreview from '../components/notebooks/NotebookPreview';
 
+type OrderedListStyle = 'decimal' | 'upper-roman' | 'lower-roman' | 'upper-alpha' | 'lower-alpha';
+
 const itemKindIcon: Record<CourseItem['kind'], string> = {
   lesson: '📘',
   reading: '📖',
@@ -285,8 +287,6 @@ const SubjectsPage: React.FC = () => {
     const placeholder = !english && activeItem.language !== 'en';
     return { original, english, showEnglish, placeholder };
   }, [activeItem]);
-
-  type OrderedListStyle = 'decimal' | 'upper-roman' | 'lower-roman' | 'upper-alpha' | 'lower-alpha';
 
   type ContentBlock =
     | { type: 'paragraph'; text: string }
@@ -602,14 +602,14 @@ const SubjectsPage: React.FC = () => {
             );
           }
 
-          return (
-            <div key={index} className={styles.contentListBlock}>
-              {block.heading && (
-                <p className={styles.contentListHeading}>
-                  <InlineMarkdown text={block.heading} />
-                </p>
-              )}
-              {block.type === 'callout' ? null : (
+          if (block.type === 'list') {
+            return (
+              <div key={index} className={styles.contentListBlock}>
+                {block.heading && (
+                  <p className={styles.contentListHeading}>
+                    <InlineMarkdown text={block.heading} />
+                  </p>
+                )}
                 <ul className={styles.contentList}>
                   {block.items.map((itemText, itemIndex) => (
                     <li key={itemIndex}>
@@ -617,9 +617,11 @@ const SubjectsPage: React.FC = () => {
                     </li>
                   ))}
                 </ul>
-              )}
-            </div>
-          );
+              </div>
+            );
+          }
+
+          return null;
         })}
       </div>
     );


### PR DESCRIPTION
## Summary
- annotate notebook output processing to avoid implicit any usage and keep filtered strings strongly typed
- hoist the ordered list style type alias and tighten list rendering conditions on the Subjects page to satisfy TypeScript narrowing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3e8180ac8324b80c57d8ed47134f