### PR TITLE
Fix InlineMarkdown typings and add KaTeX type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.12",
+        "@types/katex": "^0.16.7",
         "@types/node": "^20.11.24",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
@@ -2017,6 +2018,13 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "3.0.15",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.12",
+    "@types/katex": "^0.16.7",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/src/components/InlineMarkdown.tsx
+++ b/src/components/InlineMarkdown.tsx
@@ -101,8 +101,8 @@ const convertRowListMatrices = (text: string) =>
       return match;
     }
     const latexRows = rows
-      .map((row) => formatMatrixRow(row.slice(1, -1)))
-      .filter((row) => row.length > 0);
+      .map((row: string) => formatMatrixRow(row.slice(1, -1)))
+      .filter((row: string) => row.length > 0);
     if (latexRows.length === 0) {
       return match;
     }
@@ -114,14 +114,14 @@ const convertSemicolonMatrices = (text: string) =>
     const content = match.slice(1, -1);
     const rows = content
       .split(';')
-      .map((row) => row.trim())
-      .filter((row) => row.length > 0);
+      .map((row: string) => row.trim())
+      .filter((row: string) => row.length > 0);
     if (rows.length < 2) {
       return match;
     }
     const latexRows = rows
-      .map((row) => formatMatrixRow(row))
-      .filter((row) => row.length > 0);
+      .map((row: string) => formatMatrixRow(row))
+      .filter((row: string) => row.length > 0);
     if (latexRows.length === 0) {
       return match;
     }
@@ -133,8 +133,8 @@ const convertNumericVectors = (text: string) =>
     const content = bracket.slice(1, -1);
     const values = content
       .split(',')
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
+      .map((value: string) => value.trim())
+      .filter((value: string) => value.length > 0);
     if (values.length < 3) {
       return `${prefix}${bracket}`;
     }


### PR DESCRIPTION
## Summary
- add the @types/katex package so the build can resolve KaTeX typings
- annotate InlineMarkdown matrix helpers to avoid implicit any errors during compilation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0c5258188324905cdcdbbb84bea4