### PR TITLE
Load KaTeX dynamically for inline markdown

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom';
 
-jest.mock('katex', () => ({
-  __esModule: true,
-  default: {
-    renderToString: jest.fn(() => '<span class="katex-mock" />'),
-  },
-}));
+jest.mock('@/utils/loadKatex', () => {
+  const renderToString = jest.fn(() => '<span class="katex-mock" />');
+  return {
+    loadKatex: jest.fn(() => Promise.resolve({ renderToString })),
+  };
+});
 
 export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "dexie": "^3.2.4",
-        "katex": "^0.16.22",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.7",
@@ -23,7 +22,6 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.12",
-        "@types/katex": "^0.16.7",
         "@types/node": "^20.11.24",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
@@ -2019,13 +2017,6 @@
         "parse5": "^7.0.0"
       }
     },
-    "node_modules/@types/katex": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
-      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -2703,15 +2694,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/concat-map": {
@@ -4631,22 +4613,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/katex": {
-      "version": "0.16.22",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
-      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
       }
     },
     "node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "dexie": "^3.2.4",
-    "katex": "^0.16.22",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
@@ -27,7 +26,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.12",
-    "@types/katex": "^0.16.7",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/src/utils/loadKatex.ts
+++ b/src/utils/loadKatex.ts
@@ -1,0 +1,79 @@
+export interface KatexAPI {
+  renderToString: (expression: string, options?: { throwOnError?: boolean; displayMode?: boolean; strict?: boolean | 'ignore' }) => string;
+}
+
+declare global {
+  interface Window {
+    katex?: KatexAPI;
+  }
+}
+
+const SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js';
+const STYLE_URL = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css';
+
+let loadingPromise: Promise<KatexAPI | null> | null = null;
+
+const ensureStylesheet = () => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  if (document.querySelector('link[data-inline-markdown-katex="true"]')) {
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = STYLE_URL;
+  link.setAttribute('data-inline-markdown-katex', 'true');
+  document.head.appendChild(link);
+};
+
+const injectScript = () => {
+  if (typeof document === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  ensureStylesheet();
+
+  return new Promise<KatexAPI | null>((resolve) => {
+    const existing = window.katex;
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = SCRIPT_URL;
+    script.async = true;
+    script.onload = () => {
+      resolve(window.katex ?? null);
+    };
+    script.onerror = () => {
+      resolve(null);
+    };
+    document.head.appendChild(script);
+  });
+};
+
+export const loadKatex = (): Promise<KatexAPI | null> => {
+  if (typeof window === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  if (window.katex) {
+    ensureStylesheet();
+    return Promise.resolve(window.katex);
+  }
+
+  if (!loadingPromise) {
+    loadingPromise = injectScript().then((result) => {
+      if (!result) {
+        loadingPromise = null;
+      }
+      return result;
+    });
+  }
+
+  return loadingPromise;
+};


### PR DESCRIPTION
## Summary
- load the KaTeX script and stylesheet on demand so inline math keeps working even when the package is not installed locally
- render math tokens through a React component that waits for the loader and falls back gracefully while loading or on errors
- remove the direct katex dependencies and update the Jest setup to mock the new loader in tests

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc0d68fde8832485528b85b91661ee