### PR TITLE
Add regression tests for subject diagrams

### DIFF
--- a/src/components/lessonFigures/__tests__/lessonFigures.test.tsx
+++ b/src/components/lessonFigures/__tests__/lessonFigures.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { lessonFigureRegistry } from '..';
+import { lessonSummaryText } from '../../../data/lessonContents/text';
+
+describe('lesson figures', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('has a renderer for every figure referenced in lesson content', () => {
+    const figureRegex = /!\[[^\]]*\]\(figure:([^\)\s]+)\)/g;
+    const referenced = new Set<string>();
+
+    for (const text of Object.values(lessonSummaryText)) {
+      for (const match of text.matchAll(figureRegex)) {
+        const figureId = match[1]?.trim();
+        if (figureId) {
+          referenced.add(figureId);
+        }
+      }
+    }
+
+    const missing = Array.from(referenced).filter((id) => !lessonFigureRegistry[id]);
+
+    expect(missing).toEqual([]);
+  });
+
+  it.each(Object.entries(lessonFigureRegistry))('renders figure %s without errors', (figureId, renderer) => {
+    const altText = `Test diagram for ${figureId}`;
+    expect(() => {
+      render(<>{renderer(altText)}</>);
+    }).not.toThrow();
+
+    const figure = screen.getByRole('img', { name: altText });
+    expect(figure).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest test that scans lesson content for referenced diagrams and ensures each has a registered renderer
- render every subject diagram to verify they mount without runtime errors

## Testing
- npm test -- --runTestsByPath src/components/lessonFigures/__tests__/lessonFigures.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc1498bf888324b0beac08028814b8