### PR TITLE
Fix resource link typing in subject catalog

### DIFF
--- a/src/data/subjectCatalog.ts
+++ b/src/data/subjectCatalog.ts
@@ -1,4 +1,4 @@
-import { CourseItem, SubjectMetrics, SubjectSummary } from '../types/subject';
+import { CourseItem, ResourceLink, SubjectMetrics, SubjectSummary } from '../types/subject';
 import { getLessonContent } from './lessonContents';
 import { subjectResourceLibrary } from './subjectResources';
 
@@ -8,7 +8,7 @@ const toIsoDate = (offsetDays: number) => new Date(now + offsetDays * DAY_IN_MS)
 
 const withMinutes = (minutes: number) => minutes;
 
-const pickResourceLink = (subjectId: string, label: string) => {
+const pickResourceLink = (subjectId: string, label: string): ResourceLink => {
   const pool = subjectResourceLibrary[subjectId] ?? [];
   const match = pool.find((resource) => resource.label === label);
 


### PR DESCRIPTION
## Summary
- import the `ResourceLink` type into the subject catalog and annotate the `pickResourceLink` helper to return it
- ensure resource link spreads retain the correct discriminated union type during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd72677790832481a6ef0a68836171