### PR TITLE
Fix subject content loading by using import.meta.glob directly

### DIFF
--- a/src/data/lessonContents/text/index.ts
+++ b/src/data/lessonContents/text/index.ts
@@ -1,12 +1,9 @@
 type GlobFunction = (pattern: string, options: { eager: true; as: 'raw' }) => Record<string, string>;
 
-const resolveGlob = (): GlobFunction | undefined => {
+const getImportMetaGlob = (): GlobFunction | undefined => {
   try {
-    // eslint-disable-next-line no-new-func
-    const result = new Function(
-      'return typeof import.meta !== "undefined" && import.meta.glob ? import.meta.glob : undefined;'
-    )();
-    return typeof result === 'function' ? (result as GlobFunction) : undefined;
+    const meta = import.meta as unknown as { glob?: GlobFunction };
+    return typeof meta.glob === 'function' ? meta.glob : undefined;
   } catch (error) {
     return undefined;
   }
@@ -43,7 +40,7 @@ const loadTextModulesWithFs = (): Record<string, string> => {
 };
 
 const textModules = (() => {
-  const glob = resolveGlob();
+  const glob = getImportMetaGlob();
   if (glob) {
     return glob('./**/*.txt', { eager: true, as: 'raw' }) as Record<string, string>;
   }


### PR DESCRIPTION
## Summary
- replace the dynamic import.meta lookup in lesson text loader with a safe direct access
- ensure lesson content text files load in the browser so subject pages render their content

## Testing
- npm test -- --runTestsByPath src/data/lessonContents/index.test.ts *(fails: file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68e301e42a5083248b95574fb12ac8b1