### PR TITLE
Fix GGO original content fallback and add regression test

### DIFF
--- a/src/pages/SubjectsPage.tsx
+++ b/src/pages/SubjectsPage.tsx
@@ -509,7 +509,7 @@ const SubjectsPage: React.FC = () => {
     const fallbackOriginal = fallbackOriginalRaw && fallbackOriginalRaw.trim().length > 0
       ? fallbackOriginalRaw.trim()
       : undefined;
-    const original = fallbackOriginal ?? authoredOriginal;
+    const original = authoredOriginal ?? fallbackOriginal;
 
     const englishRaw = activeItem.content?.english?.trim();
     const englishFromItem = englishRaw && englishRaw.length > 0 ? englishRaw : undefined;
@@ -526,10 +526,10 @@ const SubjectsPage: React.FC = () => {
       ? 'resource'
       : null;
 
-    const originalSource: ContentSource | null = fallbackOriginal
-      ? 'resource'
-      : authoredOriginal
+    const originalSource: ContentSource | null = authoredOriginal
       ? 'authored'
+      : fallbackOriginal
+      ? 'resource'
       : null;
 
     const isOriginalDistinct = Boolean(

--- a/src/pages/__tests__/SubjectsPage.originalContent.test.tsx
+++ b/src/pages/__tests__/SubjectsPage.originalContent.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import SubjectsPage from '../SubjectsPage';
+import { ResourceLink } from '../../types/subject';
+
+jest.mock('../../components/SummaryQuiz', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+function makeResource(overrides: Partial<ResourceLink> & { label: string; href: string }): ResourceLink {
+  return {
+    label: overrides.label,
+    href: overrides.href,
+    filePath:
+      overrides.filePath ?? 'subjects/Ggo/T3. Alineación de negocio y SI_TI. Bedell/Methodology placeholder.pdf',
+    type: overrides.type ?? 'pdf',
+    extract: {
+      source:
+        overrides.extract?.source ??
+        overrides.filePath ??
+        'subjects/Ggo/T3. Alineación de negocio y SI_TI. Bedell/Methodology placeholder.pdf',
+      text: overrides.extract?.text ?? 'Fallback extract text',
+      ...(overrides.extract?.notes ? { notes: overrides.extract.notes } : {}),
+    },
+    ...(overrides.description ? { description: overrides.description } : {}),
+  };
+}
+
+jest.mock('../../data/subjectResources', () => ({
+  subjectResourceLibrary: {
+    ggo: [
+      makeResource({
+        label:
+          'T3. Alineación de negocio y SI TI. Bedell › Methodology for Business Value Analysis of Innovative IT in a Business Sector. The Case of the Material Supply Chain (PDF)',
+        href: '#t3-bedell',
+        filePath:
+          'subjects/Ggo/T3. Alineación de negocio y SI_TI. Bedell/Methodology for Business Value Analysis of Innovative IT in a Business Sector. The Case of the Material Supply Chain.pdf',
+      }),
+      makeResource({
+        label: 'T1. Intro Gobierno de TI › 23 Introducción a Gobierno de TI (PDF)',
+        href: '#t1-intro',
+        filePath: 'subjects/Ggo/T1. Intro Gobierno de TI/23 Introducción a Gobierno de TI.pdf',
+      }),
+    ],
+  },
+}));
+
+describe('SubjectsPage original content', () => {
+  it('prefers authored original text even when a fallback extract exists', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <SubjectsPage />
+      </MemoryRouter>
+    );
+
+    const subjectButton = await screen.findByRole('button', {
+      name: /gobierno de tecnologías de la información/i,
+    });
+    await user.click(subjectButton);
+
+    const detail = await screen.findByRole('article');
+    await within(detail).findByRole('heading', {
+      name: /tema 1 · introducción a gobierno de ti/i,
+    });
+
+    await user.click(within(detail).getByRole('tab', { name: /original/i }));
+
+    const originalRegion = within(detail).getByRole('region', { name: /original content/i });
+    expect(within(originalRegion).queryByText(/showing extracted text from/i)).not.toBeInTheDocument();
+    expect(
+      within(originalRegion).getByRole('heading', {
+        name: /topic 1 · introduction to it governance/i,
+      })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- prefer authored lesson content before using extracted fallbacks so Tema 1 shows the correct source
- add a regression test that selects the GGO subject and verifies the Original tab renders the authored text even when fallback extracts exist

## Testing
- npm test -- SubjectsPage.originalContent.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_69040fe5605c8324be26ebf6a86c4016